### PR TITLE
fixed assembly plugin build warnings about long file names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>2.2</version>
+          <configuration>
+            <tarLongFileMode>gnu</tarLongFileMode>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Just a simple plugin configuration change.
