### PR TITLE
Improvement for busy loop in ThreadFeatureInputStream.hasNext()

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/stream/ThreadedFeatureInputStream.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/stream/ThreadedFeatureInputStream.java
@@ -152,20 +152,20 @@ public class ThreadedFeatureInputStream implements FeatureInputStream {
                             f = iter.next();
                         }
                         synchronized ( this ) {
-                        if ( !featureQueue.offer( f ) ) {
-                            // wait until we get notified that queue needs to be filled up again
+                            if ( !featureQueue.offer( f ) ) {
+                                // wait until we get notified that queue needs to be filled up again
 
-                            // LOG.debug( "Producer thread going to sleep: fill=" + featureQueue.size() );
-                            sleeping = true;
-                            wait();
-                            sleeping = false;
-                            // LOG.debug( "Producer thread waking up: fill=" + featureQueue.size() );
-                        } else {
-                            f = null;
-                            // Wake reading thread
-                            notify();
+                                // LOG.debug( "Producer thread going to sleep: fill=" + featureQueue.size() );
+                                sleeping = true;
+                                wait();
+                                sleeping = false;
+                                // LOG.debug( "Producer thread waking up: fill=" + featureQueue.size() );
+                            } else {
+                                f = null;
+                                // Wake reading thread
+                                notify();
+                            }
                         }
-                    }
                     }
                 } catch ( InterruptedException e ) {
                     LOG.debug( "Got interrupted." );
@@ -173,6 +173,12 @@ public class ThreadedFeatureInputStream implements FeatureInputStream {
             } finally {
                 finished = true;
                 rs.close();
+                
+                // Consumer may still be waiting for more input
+                synchronized ( this ) {
+                    notify();
+                }
+                
                 LOG.debug( "Producer thread exiting" );
             }
         }


### PR DESCRIPTION
Hi,

I made a change to org.deegree.feature.stream.ThreadedFeatureInputStream which add a wait(1000) to the while loop in QueueFiller.hasNext()

The reason is that the loop used a lot of of CPU when the features are drawn quicker than they are loaded from the database. This seems to fix this problem. To make sure the code does not deadlock i have set the wait timeout to 1 second.

This is my first github based contribution so i hope i have not made any stupid mistakes :)

Best regards,
Jeroen
