### PR TITLE
RenderHelper.getWorldToScreenTransform bugfix

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/RenderHelper.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/RenderHelper.java
@@ -232,44 +232,30 @@ public class RenderHelper {
 
     public static Pair<Envelope, DoublePair> getWorldToScreenTransform( AffineTransform worldToScreen, Envelope bbox,
                                                                         int width, int height ) {
-        boolean xy = true;
-        double scalex = width / bbox.getSpan0();
-        double scaley = height / bbox.getSpan1();
-        try {
-            if ( bbox.getCoordinateSystem() != null && !bbox.getCoordinateSystem().getAlias().equals( "CRS:1" )
-                 && !bbox.getCoordinateSystem().getUnits()[0].equals( METRE ) ) {
-                xy = bbox.getCoordinateSystem().getAxis()[0].getOrientation() == Axis.AO_EAST;
-            }
-        } catch ( ReferenceResolvingException e ) {
-            LOG.warn( "Could not determine CRS of bbox, assuming it's in meter..." );
-            LOG.debug( "Stack trace:", e );
-        } catch ( Throwable e ) {
-            LOG.warn( "Could not transform bbox, assuming it's in meter..." );
-            LOG.debug( "Stack trace:", e );
-        }
-
-        if ( !xy ) {
-            CRSRef swapped = CRSManager.getCRSRef( bbox.getCoordinateSystem().getAlias(), true );
-            GeometryTransformer t = new GeometryTransformer( swapped );
-            try {
-                bbox = t.transform( bbox );
-            } catch ( Throwable e ) {
-                LOG.warn( "Could not swap bbox axis order, image will probably be flipped/broken." );
-                LOG.debug( "Stack trace:", e );
-            }
-        }
-
-        if ( xy ) {
-            // we have to flip horizontally, so invert y scale and add the screen height
-            worldToScreen.translate( -bbox.getMin().get0() * scalex, bbox.getMin().get1() * scaley + height );
-            worldToScreen.scale( scalex, -scaley );
+        
+        // we have to flip horizontally, so invert y-axis and move y-axis with screen height
+        worldToScreen.scale( 1, -1 );
+        worldToScreen.translate( 0, -height );
+        
+        // calculate scalex, scaley and swap axis if necessary
+        final double scalex, scaley;
+        if ( bbox.getCoordinateSystem() != null && !bbox.getCoordinateSystem().getAlias().equals( "CRS:1" )
+                && !bbox.getCoordinateSystem().getUnits()[0].equals( METRE ) 
+                && bbox.getCoordinateSystem().getAxis()[0].getOrientation() != Axis.AO_EAST ) {
+            
+    		worldToScreen.scale( -1, 1 );
+    		worldToScreen.rotate( Math.PI / 2 );
+    		
+    		scalex = height / bbox.getSpan0();
+            scaley = width / bbox.getSpan1();
         } else {
-            // recalculate scale with correct bbox
-            scalex = width / bbox.getSpan0();
+        	scalex = width / bbox.getSpan0();
             scaley = height / bbox.getSpan1();
-            worldToScreen.translate( -bbox.getMin().get0() * scalex, bbox.getMin().get1() * scaley + height );
-            worldToScreen.scale( scalex, -scaley );
         }
+        
+        worldToScreen.scale( scalex, scaley );
+        worldToScreen.translate( -bbox.getMin().get0(), -bbox.getMin().get1() );
+        
         return new Pair<Envelope, DoublePair>( bbox, new DoublePair( scalex, scaley ) );
     }
 

--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/RenderHelperTest.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/RenderHelperTest.java
@@ -1,0 +1,108 @@
+//$$HeadURL$$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2012 by:
+ - IDgis bv -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+ 
+ IDgis bv
+ Boomkamp 16, 7461 AX Rijssen
+ The Netherlands
+ http://www.idgis.nl/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+----------------------------------------------------------------------------*/
+
+package org.deegree.rendering.r2d;
+
+import java.awt.geom.AffineTransform;
+
+import org.deegree.cs.persistence.CRSManager;
+import org.deegree.geometry.Envelope;
+import org.deegree.geometry.GeometryFactory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <code>RenderHelperTest</code>
+ * 
+ * @author <a href="mailto:reijer.copier@idgis.nl">Reijer Copier</a>
+ * @author last edited by: $Author$
+ * 
+ * @version $Revision$, $Date$
+ */
+public class RenderHelperTest {
+
+    private GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Test
+    public void testWGS84ShortIdTransform()
+                            throws Exception {
+
+        final double[] min = new double[] { 4.835947, 52.442229 };
+        final double[] max = new double[] { 4.871100, 52.453817 };
+
+        final AffineTransform worldToScreen = new AffineTransform();
+        final Envelope bbox = geometryFactory.createEnvelope( min, max, CRSManager.lookup( "EPSG:4326" ) );
+        RenderHelper.getWorldToScreenTransform( worldToScreen, bbox, 42, 47 );
+
+        final double[] transformedPoint = new double[2];
+
+        worldToScreen.transform( min, 0, transformedPoint, 0, 1 );
+        assertEquals( 0, transformedPoint[0], 0.1 );
+        assertEquals( 47, transformedPoint[1], 0.1 );
+
+        worldToScreen.transform( max, 0, transformedPoint, 0, 1 );
+        assertEquals( 42, transformedPoint[0], 0.1 );
+        assertEquals( 0, transformedPoint[1], 0.1 );
+    }
+
+    @Test
+    public void testWGS84LongIdTransform()
+                            throws Exception {
+
+        final double[] min = new double[] { 52.442229, 4.835947 };
+        final double[] max = new double[] { 52.453817, 4.871100 };
+
+        final AffineTransform worldToScreen = new AffineTransform();
+        final Envelope bbox = geometryFactory.createEnvelope( min, max,
+                                                              CRSManager.lookup( "urn:ogc:def:crs:EPSG::4326" ) );
+        RenderHelper.getWorldToScreenTransform( worldToScreen, bbox, 42, 47 );
+
+        final double[] transformedPoint = new double[2];
+
+        worldToScreen.transform( min, 0, transformedPoint, 0, 1 );
+        assertEquals( 0, transformedPoint[0], 0.1 );
+        assertEquals( 47, transformedPoint[1], 0.1 );
+
+        worldToScreen.transform( max, 0, transformedPoint, 0, 1 );
+        assertEquals( 42, transformedPoint[0], 0.1 );
+        assertEquals( 0, transformedPoint[1], 0.1 );
+    }
+}


### PR DESCRIPTION
Starting from deegree 3.2-pre12 GetMap requests with a 'long' crs id (ie urn:ogc:def:crs:EPSG::4326 instead of just EPSG:4326) always results in a blank image. While poking around in the code I discovered that RenderHelper.getWorldToScreenTransform creates an incorrect transformation matrix for those cases.

This method hasn't been changed between pre11 and pre12 but for some reason this bug was not causing problems in pre11 and earlier.

This pull request contains a fixed version of RenderHelper.getWorldToScreenTransform and a unit test to demonstrate the problem.
