### PR TITLE
maven site fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
       <plugin>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-maven-plugin</artifactId>
+        <version>1.18</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
This bumps the deegree maven plugin version to use the new module status list plugin to be included in the site.
