### PR TITLE
Bumped versions 3.2-pre14-SNAPSHOT

### DIFF
--- a/deegree-tests/deegree-compliance-tests/pom.xml
+++ b/deegree-tests/deegree-compliance-tests/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-csw-bkg/pom.xml
+++ b/deegree-tests/deegree-csw-bkg/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre11-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wms-remoteows-tests/pom.xml
+++ b/deegree-tests/deegree-wms-remoteows-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wms-similarity-tests/pom.xml
+++ b/deegree-tests/deegree-wms-similarity-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wms-tiling-tests/pom.xml
+++ b/deegree-tests/deegree-wms-tiling-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wmts-tests/pom.xml
+++ b/deegree-tests/deegree-wmts-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-workspace-tests/pom.xml
+++ b/deegree-tests/deegree-workspace-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/pom.xml
+++ b/deegree-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.2-pre13-SNAPSHOT</version>
+    <version>3.2-pre14-SNAPSHOT</version>
   </parent>
 
   <repositories>


### PR DESCRIPTION
Test modules did not release properly and therefore had their versions not updated.
