### PR TITLE
set epsilon for collinearity test to sane value

### DIFF
--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/CurveLinearizer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/CurveLinearizer.java
@@ -96,7 +96,7 @@ public class CurveLinearizer {
 
     private static Logger LOG = LoggerFactory.getLogger( CurveLinearizer.class );
 
-    private static final double EPSILON = 1E-12;
+    private static final double EPSILON = 1E-6;
 
     private final GeometryFactory geomFac;
 


### PR DESCRIPTION
This solves linearization issues with degenerate arcs.
