### PR TITLE
OWS Exception Report parsing fix

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/exception/OWSExceptionReader.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/exception/OWSExceptionReader.java
@@ -147,7 +147,9 @@ public class OWSExceptionReader {
      */
     public static OWSExceptionReport parseExceptionReport( XMLStreamReader reader )
                             throws NoSuchElementException, XMLStreamException {
-
+        while ( reader.getEventType() != XMLStreamReader.START_ELEMENT ) {
+            reader.next();
+        }
         // <attribute name="version" use="required">
         String version = reader.getAttributeValue( null, "version" );
 


### PR DESCRIPTION
Made parsing of OWS exception reports more robust when XML stream is eg. on START_DOCUMENT.
