### PR TITLE
Fix null pointer when evaluating long xpaths

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/TypedObjectNodeXPathEvaluator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/TypedObjectNodeXPathEvaluator.java
@@ -101,7 +101,7 @@ public class TypedObjectNodeXPathEvaluator implements XPathEvaluator<TypedObject
 
         // simple property with just a simple element step?
         QName simplePropName = propName.getAsQName();
-        if ( bindings != null
+        if ( bindings != null && simplePropName != null
              && ( simplePropName.getNamespaceURI() == null || simplePropName.getNamespaceURI().isEmpty() ) ) {
             QName altName = bindings.get( simplePropName.getLocalPart() );
             if ( altName != null ) {


### PR DESCRIPTION
Fix potential null pointer when evaluating long xpaths pointing to gml objects. This also fixes the problem of INSPIRE addresses not being painted with recent versions.
