### PR TITLE
Made evaluation of intersects operator more flexible

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/spatial/Intersects.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/spatial/Intersects.java
@@ -41,6 +41,7 @@ import org.deegree.feature.Feature;
 import org.deegree.filter.Expression;
 import org.deegree.filter.FilterEvaluationException;
 import org.deegree.filter.XPathEvaluator;
+import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,11 +87,22 @@ public class Intersects extends SpatialOperator {
         } else if ( obj instanceof Feature ) {
             // handle the case where the property name is empty
             Feature f = (Feature) obj;
+            boolean foundGeom = false;
             for ( Property prop : f.getProperties() ) {
                 if ( prop.getValue() instanceof Geometry ) {
+                    foundGeom = true;
                     Geometry geom = (Geometry) prop.getValue();
                     Geometry transformedGeom = getCompatibleGeometry( geometry, geom );
                     if ( transformedGeom.intersects( geometry ) ) {
+                        return true;
+                    }
+                }
+            }
+            if ( !foundGeom ) {
+                Envelope env = f.getEnvelope();
+                if ( env != null ) {
+                    Geometry g = getCompatibleGeometry( geometry, env );
+                    if ( g.intersects( geometry ) ) {
                         return true;
                     }
                 }


### PR DESCRIPTION
In case of no geometry properties (eg. INSPIRE address features) the envelope of the feature is also considered for evaluation before evaluating to false.
