### PR TITLE
reversed order of level directories again in file system tile store

### DIFF
--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/src/main/java/org/deegree/tile/persistence/filesystem/layout/TileCacheDiskLayout.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/src/main/java/org/deegree/tile/persistence/filesystem/layout/TileCacheDiskLayout.java
@@ -121,8 +121,7 @@ public class TileCacheDiskLayout implements DiskLayout {
 
     private String getLevelDirectory( TileDataLevel tileMatrix ) {
         DecimalFormat formatter = new DecimalFormat( "00" );
-        int num = set.getTileDataLevels().size();
-        int tileMatrixIndex = num - 1 - set.getTileDataLevels().indexOf( tileMatrix );
+        int tileMatrixIndex = set.getTileDataLevels().indexOf( tileMatrix );
         return formatter.format( tileMatrixIndex );
     }
 


### PR DESCRIPTION
The new order is 00 == first level of tile matrix set again as in the original code.
