### PR TITLE
Add bbox to root layer when multiple themes are configured

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
@@ -42,6 +42,7 @@ import static org.deegree.commons.xml.CommonNamespaces.XLNNS;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.deegree.commons.xml.XMLAdapter.writeElement;
 import static org.deegree.layer.dims.Dimension.formatDimensionValueList;
+import static org.deegree.services.wms.controller.capabilities.WmsCapabilities130SpatialMetadataWriter.writeSrsAndEnvelope;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.List;
@@ -58,12 +59,15 @@ import org.deegree.commons.ows.metadata.ServiceIdentification;
 import org.deegree.commons.ows.metadata.ServiceProvider;
 import org.deegree.commons.utils.Pair;
 import org.deegree.commons.xml.stax.XMLStreamUtils;
+import org.deegree.geometry.metadata.SpatialMetadata;
 import org.deegree.layer.dims.Dimension;
+import org.deegree.layer.metadata.LayerMetadata;
 import org.deegree.services.metadata.OWSMetadataProvider;
 import org.deegree.services.wms.MapService;
 import org.deegree.services.wms.controller.WMSController;
 import org.deegree.style.se.unevaluated.Style;
 import org.deegree.theme.Theme;
+import org.deegree.theme.Themes;
 import org.slf4j.Logger;
 
 /**
@@ -188,9 +192,24 @@ public class Capabilities130XMLAdapter {
         } else {
             // synthetic root layer needed
             writer.writeStartElement( WMSNS, "Layer" );
-            // TODO
-            writer.writeAttribute( "queryable", "1" );
             writeElement( writer, WMSNS, "Title", "Root" );
+
+            // TODO think about a push approach instead of a pull approach
+            LayerMetadata lmd = null;
+            for ( Theme t : themes ) {
+                for ( org.deegree.layer.Layer l : Themes.getAllLayers( t ) ) {
+                    if ( lmd == null ) {
+                        lmd = l.getMetadata();
+                    } else {
+                        lmd.merge( l.getMetadata() );
+                    }
+                }
+            }
+            if ( lmd != null ) {
+                SpatialMetadata smd = lmd.getSpatialMetadata();
+                writeSrsAndEnvelope( writer, smd.getCoordinateSystems(), smd.getEnvelope() );
+            }
+
             for ( Theme t : themes ) {
                 themeWriter.writeTheme( writer, t );
             }


### PR DESCRIPTION
Adds synthetic root layer bounding box when multiple themes are configured.

This fixes the issue with the 'see layers' page not zooming to the actual data eg. in the INSPIRE workspace.
