### PR TITLE
Fixed ugly null pointer when starting up with broken workspace root

### DIFF
--- a/deegree-client/deegree-jsf-console/src/main/java/org/deegree/console/ConfigManager.java
+++ b/deegree-client/deegree-jsf-console/src/main/java/org/deegree/console/ConfigManager.java
@@ -159,9 +159,12 @@ public class ConfigManager implements Serializable {
     public List<ResourceManagerMetadata2> getConnectionManagers() {
         return getResourceManagers( "connection" );
     }
-    
+
     public List<ResourceManagerMetadata2> getResourceManagers( String category ) {
         List<ResourceManagerMetadata2> rmMetadata = new ArrayList<ResourceManagerMetadata2>();
+        if ( getServiceWorkspace() == null ) {
+            return rmMetadata;
+        }
         for ( ResourceManager mgr : getServiceWorkspace().getResourceManagers() ) {
             ResourceManagerMetadata2 md = ResourceManagerMetadata2.getMetadata( mgr );
             if ( md != null && category.equals( md.getCategory() ) ) {


### PR DESCRIPTION
Used to happen when starting up with a non-existing workspace root which cannot be created. See http://tracker.deegree.org/deegree-services/ticket/292
