### PR TITLE
Inserted missing read timeout parameter

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/main/java/org/deegree/protocol/csw/client/CSWClient.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/main/java/org/deegree/protocol/csw/client/CSWClient.java
@@ -141,7 +141,7 @@ public class CSWClient extends AbstractOWSClient<CSWCapabilitiesAdapter> {
      */
     public CSWClient( URL capaUrl, int connectionTimeout, int readTimeout ) throws OWSExceptionReport,
                             XMLStreamException, IOException {
-        super( capaUrl, new OwsHttpClientImpl( connectionTimeout, 0, null, null ) );
+        super( capaUrl, new OwsHttpClientImpl( connectionTimeout, readTimeout, null, null ) );
     }
 
     @Override


### PR DESCRIPTION
This bug fixes a hard coded constructor argument concerning the read timeout for CSWClient.
