### PR TITLE
MemoryFeatureStore: Update references after insertion of features

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
@@ -51,7 +51,7 @@ public class Reference<T extends Object> implements Object {
 
     private final ReferenceResolver resolver;
 
-    private final String uri;
+    private String uri;
 
     private final String baseURL;
 
@@ -85,6 +85,16 @@ public class Reference<T extends Object> implements Object {
      */
     public String getURI() {
         return uri;
+    }
+
+    /**
+     * Sets the URI of the object.
+     * 
+     * @param uri
+     *            URI of the object, must not be <code>null</code>
+     */
+    public void setURI( String uri ) {
+        this.uri = uri;
     }
 
     /**

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
@@ -340,7 +340,35 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
         } catch ( IllegalArgumentException e ) {
             throw new FeatureStoreException( e.getMessage() );
         }
+        fixReferences( fc );
         return features;
+    }
+
+    private void fixReferences( final FeatureCollection fc ) {
+        GMLObjectVisitor visitor = new GMLObjectVisitor() {
+            @Override
+            public boolean visitGeometry( Geometry geom ) {
+                return true;
+            }
+
+            @Override
+            public boolean visitFeature( Feature feature ) {
+                return true;
+            }
+
+            @Override
+            public boolean visitReference( Reference<?> ref ) {
+                fixReference( ref );
+                return true;
+            }
+        };
+        new GMLObjectWalker( visitor ).traverse( fc );
+    }
+
+    private void fixReference( Reference<?> ref ) {
+        if ( ref.isResolved() ) {
+            ref.setURI( "#" + ref.getId() );
+        }
     }
 
     private String getFeatureId( Feature feature, IDGenMode mode ) {
@@ -417,7 +445,7 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
                 }
             }
         }
-        feature.setEnvelope( feature.calcEnvelope() );        
+        feature.setEnvelope( feature.calcEnvelope() );
         return feature;
     }
 


### PR DESCRIPTION
This is necessary, as gml-ids may have been changed.
