### PR TITLE
Fix remotewms-tilestore to use overridden/passed parameters for GFI

### DIFF
--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/src/main/java/org/deegree/tile/persistence/remotewms/RemoteWMSTile.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/src/main/java/org/deegree/tile/persistence/remotewms/RemoteWMSTile.java
@@ -176,7 +176,7 @@ class RemoteWMSTile implements Tile {
             Map<String, String> overriddenParameters = new HashMap<String, String>();
             RequestUtils.replaceParameters( overriddenParameters, RequestUtils.getCurrentThreadRequestParameters().get(),
                                      defaultGetFeatureInfo, hardGetFeatureInfo );
-            fc = client.doGetFeatureInfo( request, null );
+            fc = client.doGetFeatureInfo( request, overriddenParameters );
         } catch ( SocketTimeoutException e ) {
             String msg = "Error performing GetFeatureInfo request, read timed out (timeout configured is "
                          + client.getReadTimeout() + " seconds).";


### PR DESCRIPTION
Added missing parameter to actually use overridden parameters for GetFeatureInfo.
