### PR TITLE
prevent unnecessary clipping

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
@@ -178,7 +178,9 @@ public class Java2DRenderer implements Renderer {
             LOG.warn( "Trying to render point with line styling." );
             return;
         }
-        geom = rendererContext.clipper.clipGeometry( geom );
+        if ( styling.stroke != null && styling.stroke.stroke != null ) {
+            geom = rendererContext.clipper.clipGeometry( geom );
+        }
         if ( geom instanceof Curve ) {
             Double line = rendererContext.geomHelper.fromCurve( (Curve) geom, false );
             rendererContext.strokeRenderer.applyStroke( styling.stroke, styling.uom, line, styling.perpendicularOffset,
@@ -207,7 +209,9 @@ public class Java2DRenderer implements Renderer {
         if ( geom instanceof Curve ) {
             LOG.warn( "Trying to render line with polygon styling." );
         }
-        geom = rendererContext.clipper.clipGeometry( geom );
+        if ( styling.stroke != null && styling.stroke.stroke != null ) {
+            geom = rendererContext.clipper.clipGeometry( geom );
+        }
         if ( geom instanceof Envelope ) {
             geom = envelopeToPolygon( (Envelope) geom );
         }


### PR DESCRIPTION
While profiling a deegree wms I discovered that clipping accounts for 60% of the execution time. Feeding non-clipped geometries to Java2D seems faster most of the time. The only situation where clipping seems necessary (performance wise) is when ShapeStroke or TextStroke is being used.
