### PR TITLE
maven-compiler-plugin configuration: enable fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.0</version>
+          <configuration>
+          	<fork>true</fork>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Enable the 'fork' configuration option for maven-compiler-plugin in order to resolve out of memory issues.
