### PR TITLE
missing OWSMetadataProvider dependencies added

### DIFF
--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CswMetadata.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CswMetadata.java
@@ -32,7 +32,10 @@ import org.deegree.metadata.persistence.MetadataStoreManager;
 import org.deegree.metadata.persistence.MetadataStoreProvider;
 import org.deegree.services.OWS;
 import org.deegree.services.jaxb.csw.DeegreeCSW;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
 import org.deegree.workspace.ResourceMetadata;
@@ -68,6 +71,14 @@ public class CswMetadata extends AbstractResourceMetadata<OWS> {
             } else {
                 for ( ResourceMetadata<?> md : workspace.getResourceManager( MetadataStoreManager.class ).getResourceMetadata() ) {
                     softDependencies.add( md.getIdentifier() );
+                }
+            }
+            
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> mdId = md.getIdentifier();
+                if ( mdId.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( mdId );
                 }
             }
 

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/WcsMetadata.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/WcsMetadata.java
@@ -32,9 +32,13 @@ import org.deegree.coverage.Coverage;
 import org.deegree.coverage.persistence.CoverageProvider;
 import org.deegree.services.OWS;
 import org.deegree.services.jaxb.wcs.DeegreeWCS;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
+import org.deegree.workspace.ResourceMetadata;
 import org.deegree.workspace.Workspace;
 import org.deegree.workspace.standard.AbstractResourceMetadata;
 import org.deegree.workspace.standard.AbstractResourceProvider;
@@ -62,6 +66,14 @@ public class WcsMetadata extends AbstractResourceMetadata<OWS> {
             for ( org.deegree.services.jaxb.wcs.ServiceConfiguration.Coverage cov : cfg.getServiceConfiguration().getCoverage() ) {
                 String id = cov.getCoverageStoreId();
                 dependencies.add( new DefaultResourceIdentifier<Coverage>( CoverageProvider.class, id ) );
+            }
+            
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> mdId = md.getIdentifier();
+                if ( mdId.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( mdId );
+                }
             }
 
             return new WcsBuilder( this, workspace, cfg );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WfsMetadata.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WfsMetadata.java
@@ -38,7 +38,10 @@ import org.deegree.services.OWS;
 import org.deegree.services.OWSProvider;
 import org.deegree.services.OwsManager;
 import org.deegree.services.jaxb.wfs.DeegreeWFS;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
 import org.deegree.workspace.ResourceMetadata;
@@ -88,6 +91,14 @@ public class WfsMetadata extends AbstractResourceMetadata<OWS> {
                     if ( name.equalsIgnoreCase( "CSW" ) ) {
                         softDependencies.add( md.getIdentifier() );
                     }
+                }
+            }
+
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> id = md.getIdentifier();
+                if ( id.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( id );
                 }
             }
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WmsMetadata.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WmsMetadata.java
@@ -35,9 +35,12 @@ import org.deegree.services.OWS;
 import org.deegree.services.OWSProvider;
 import org.deegree.services.OwsManager;
 import org.deegree.services.jaxb.wms.DeegreeWMS;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.theme.Theme;
 import org.deegree.theme.persistence.ThemeProvider;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
 import org.deegree.workspace.ResourceMetadata;
@@ -85,6 +88,14 @@ public class WmsMetadata extends AbstractResourceMetadata<OWS> {
                     if ( name.equalsIgnoreCase( "CSW" ) ) {
                         softDependencies.add( md.getIdentifier() );
                     }
+                }
+            }
+            
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> mdId = md.getIdentifier();
+                if ( mdId.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( mdId );
                 }
             }
 

--- a/deegree-services/deegree-services-wmts/src/main/java/org/deegree/services/wmts/WmtsMetadata.java
+++ b/deegree-services/deegree-services-wmts/src/main/java/org/deegree/services/wmts/WmtsMetadata.java
@@ -33,10 +33,13 @@ import org.deegree.commons.xml.jaxb.JAXBUtils;
 import org.deegree.services.OWS;
 import org.deegree.services.OWSProvider;
 import org.deegree.services.OwsManager;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.services.wmts.jaxb.DeegreeWMTS;
 import org.deegree.theme.Theme;
 import org.deegree.theme.persistence.ThemeProvider;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
 import org.deegree.workspace.ResourceMetadata;
@@ -77,6 +80,14 @@ public class WmtsMetadata extends AbstractResourceMetadata<OWS> {
                     if ( name.equalsIgnoreCase( "CSW" ) ) {
                         softDependencies.add( md.getIdentifier() );
                     }
+                }
+            }
+            
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> mdId = md.getIdentifier();
+                if ( mdId.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( mdId );
                 }
             }
 

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/WpsMetadata.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/WpsMetadata.java
@@ -32,8 +32,11 @@ import java.util.Collection;
 import org.deegree.commons.xml.jaxb.JAXBUtils;
 import org.deegree.services.OWS;
 import org.deegree.services.jaxb.wps.DeegreeWPS;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.services.wps.provider.ProcessProvider;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
 import org.deegree.workspace.ResourceMetadata;
@@ -66,6 +69,14 @@ public class WpsMetadata extends AbstractResourceMetadata<OWS> {
             Collection<ResourceMetadata<ProcessProvider>> mds = mgr.getResourceMetadata();
             for ( ResourceMetadata<ProcessProvider> md : mds ) {
                 softDependencies.add( md.getIdentifier() );
+            }
+            
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> mdId = md.getIdentifier();
+                if ( mdId.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( mdId );
+                }
             }
 
             return new WpsBuilder( this, workspace, cfg );

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/controller/WpvsMetadata.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/controller/WpvsMetadata.java
@@ -36,7 +36,10 @@ import org.deegree.rendering.r3d.persistence.RenderableStore;
 import org.deegree.rendering.r3d.persistence.RenderableStoreManager;
 import org.deegree.services.OWS;
 import org.deegree.services.jaxb.wpvs.DeegreeWPVS;
+import org.deegree.services.metadata.OWSMetadataProvider;
+import org.deegree.services.metadata.OWSMetadataProviderManager;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceIdentifier;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceLocation;
 import org.deegree.workspace.ResourceMetadata;
@@ -75,6 +78,14 @@ public class WpvsMetadata extends AbstractResourceMetadata<OWS> {
             Collection<ResourceMetadata<RenderableStore>> mds2 = rmgr.getResourceMetadata();
             for ( ResourceMetadata<RenderableStore> md : mds2 ) {
                 softDependencies.add( md.getIdentifier() );
+            }
+            
+            OWSMetadataProviderManager mmgr = workspace.getResourceManager( OWSMetadataProviderManager.class );
+            for ( ResourceMetadata<OWSMetadataProvider> md : mmgr.getResourceMetadata() ) {
+                ResourceIdentifier<OWSMetadataProvider> mdId = md.getIdentifier();
+                if ( mdId.getId().equals( getIdentifier().getId() + "_metadata" ) ) {
+                    softDependencies.add( mdId );
+                }
             }
 
             return new WpvsBuilder( this, workspace, cfg );


### PR DESCRIPTION
I observed that services sometimes didn't 'notice' their configured metadata. This pull requests provides a fix.
