### PR TITLE
Only load files ending with '.jar' as workspace module

### DIFF
--- a/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/standard/DefaultWorkspace.java
+++ b/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/standard/DefaultWorkspace.java
@@ -242,13 +242,15 @@ public class DefaultWorkspace implements Workspace {
                     if ( fs[i].isFile() ) {
                         try {
                             URL url = fs[i].toURI().toURL();
-                            urls.add( url );
-                            ModuleInfo moduleInfo = ModuleInfo.extractModuleInfo( url );
-                            if ( moduleInfo != null ) {
-                                LOG.info( " - " + moduleInfo );
-                                wsModules.add( moduleInfo );
-                            } else {
-                                LOG.info( " - " + fs[i] + " (non-deegree)" );
+                            if ( url.getFile().endsWith( ".jar" ) ) {
+                                urls.add( url );
+                                ModuleInfo moduleInfo = ModuleInfo.extractModuleInfo( url );
+                                if ( moduleInfo != null ) {
+                                    LOG.info( " - " + moduleInfo );
+                                    wsModules.add( moduleInfo );
+                                } else {
+                                    LOG.info( " - " + fs[i] + " (non-deegree)" );
+                                }
                             }
                         } catch ( Exception e ) {
                             LOG.warn( "Module {} could not be loaded: {}", fs[i].getName(), e.getLocalizedMessage() );


### PR DESCRIPTION
It is imho not a good idea to load files which do not end with '.jar' as people expect to be able to disable jar files by appending a suffix to the name.
