### PR TITLE
Swapped targetObject/sourceObject fix

### DIFF
--- a/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/ebrim/Association.java
+++ b/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/ebrim/Association.java
@@ -62,14 +62,14 @@ public class Association extends RegistryObject {
      * @return the sourceObject
      */
     public String getSourceObject() {
-        return adapter.getRequiredNodeAsString( adapter.getRootElement(), new XPath( "@targetObject", ns ) );
+        return adapter.getRequiredNodeAsString( adapter.getRootElement(), new XPath( "@sourceObject", ns ) );
     }
 
     /**
      * @return the targetObject
      */
     public String getTargetObject() {
-        return adapter.getRequiredNodeAsString( adapter.getRootElement(), new XPath( "@sourceObject", ns ) );
+        return adapter.getRequiredNodeAsString( adapter.getRootElement(), new XPath( "@targetObject", ns ) );
     }
 
     /**

--- a/deegree-core/deegree-core-metadata/src/test/java/org/deegree/metadata/ebrim/AssociationTest.java
+++ b/deegree-core/deegree-core-metadata/src/test/java/org/deegree/metadata/ebrim/AssociationTest.java
@@ -1,0 +1,94 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2013 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.metadata.ebrim;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Checks the parsing of the association object
+ * 
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ * @author last edited by: $Author: lyn $
+ * 
+ * @version $Revision: $, $Date: $
+ */
+public class AssociationTest {
+
+    private static Association association;
+
+    @BeforeClass
+    public static void initAssociation()
+                            throws XMLStreamException, FactoryConfigurationError {
+        XMLStreamReader associationAsXml = readAssociationFromXml();
+        association = new Association( associationAsXml );
+    }
+
+    @Test
+    public void testGetTargetObjectShouldBeParsedFromXml() {
+        String actualTargetObject = association.getTargetObject();
+        assertEquals( "urn:ogc:def:EOP:RE00:MSI_IMG_3A:5397721:eoap", actualTargetObject );
+    }
+
+    @Test
+    public void testGetSourceObjectShouldBeParsedFromXml() {
+        String actualSourceObject = association.getSourceObject();
+        assertEquals( "urn:ogc:def:EOP:RE00:MSI_IMG_3A:5397721:eo", actualSourceObject );
+    }
+
+    @Test
+    public void testGetAssociationTypeShouldBeParsedFromXml() {
+        String actualAssociationType = association.getAssociationType();
+        assertEquals( "urn:x-ogc:specification:csw-ebrim:AssociationType:EO:AcquiredBy", actualAssociationType );
+    }
+
+    private static XMLStreamReader readAssociationFromXml()
+                            throws XMLStreamException, FactoryConfigurationError {
+        InputStream associationAsStream = AssociationTest.class.getResourceAsStream( "association.xml" );
+        XMLStreamReader associationAsXml = XMLInputFactory.newInstance().createXMLStreamReader( associationAsStream );
+        return associationAsXml;
+    }
+
+}

--- a/deegree-core/deegree-core-metadata/src/test/resources/org/deegree/metadata/ebrim/association.xml
+++ b/deegree-core/deegree-core-metadata/src/test/resources/org/deegree/metadata/ebrim/association.xml
@@ -1,0 +1,4 @@
+<rim:Association xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+	xmlns="http://www.isotc211.org/2005/gmd" associationType="urn:x-ogc:specification:csw-ebrim:AssociationType:EO:AcquiredBy"
+	sourceObject="urn:ogc:def:EOP:RE00:MSI_IMG_3A:5397721:eo" targetObject="urn:ogc:def:EOP:RE00:MSI_IMG_3A:5397721:eoap"
+	id="AcquiredBy_5397721" />


### PR DESCRIPTION
This fix includes a bug fix in the parser of ebrim association elements. The attributes targetObject and sourceObject was swapped. due to swapped XPath expressions.
