### PR TITLE
Support for additional keywords lists and vocabulary attribute.

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities111ThemeWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities111ThemeWriter.java
@@ -146,14 +146,16 @@ class WmsCapabilities111ThemeWriter {
 
     private void writeKeywords( XMLStreamWriter writer, LayerMetadata md, LayerMetadata lmd )
                             throws XMLStreamException {
-        List<Pair<List<LanguageString>, CodeType>> kws = md.getDescription().getKeywords();
-        if ( lmd != null && ( kws == null || kws.isEmpty() || kws.get( 0 ).first.isEmpty() ) ) {
-            kws = lmd.getDescription().getKeywords();
+        List<Pair<List<LanguageString>, CodeType>> kwsl = md.getDescription().getKeywords();
+        if ( lmd != null && ( kwsl == null || kwsl.isEmpty() || kwsl.get( 0 ).first.isEmpty() ) ) {
+            kwsl = lmd.getDescription().getKeywords();
         }
-        if ( kws != null && !kws.isEmpty() && !kws.get( 0 ).first.isEmpty() ) {
+        if ( kwsl != null && !kwsl.isEmpty() && !kwsl.get( 0 ).first.isEmpty() ) {
             writer.writeStartElement( "KeywordList" );
-            for ( LanguageString ls : kws.get( 0 ).first ) {
-                writeElement( writer, "Keyword", ls.getString() );
+            for ( Pair<List<LanguageString>, CodeType> kws : kwsl ) {
+                for ( LanguageString ls : kws.first ) {
+                    writeElement( writer, "Keyword", ls.getString() );
+                }
             }
             writer.writeEndElement();
         }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities130ThemeWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities130ThemeWriter.java
@@ -153,14 +153,21 @@ class WmsCapabilities130ThemeWriter {
 
     private static void writeKeywords( XMLStreamWriter writer, LayerMetadata md, LayerMetadata lmd )
                             throws XMLStreamException {
-        List<Pair<List<LanguageString>, CodeType>> kws = md.getDescription().getKeywords();
-        if ( lmd != null && ( kws == null || kws.isEmpty() || kws.get( 0 ).first.isEmpty() ) ) {
-            kws = lmd.getDescription().getKeywords();
+        List<Pair<List<LanguageString>, CodeType>> kwsl = md.getDescription().getKeywords();
+        if ( lmd != null && ( kwsl == null || kwsl.isEmpty() || kwsl.get( 0 ).first.isEmpty() ) ) {
+            kwsl = lmd.getDescription().getKeywords();
         }
-        if ( kws != null && !kws.isEmpty() && !kws.get( 0 ).first.isEmpty() ) {
+        if ( kwsl != null && !kwsl.isEmpty() && !kwsl.get( 0 ).first.isEmpty() ) {
             writer.writeStartElement( WMSNS, "KeywordList" );
-            for ( LanguageString ls : kws.get( 0 ).first ) {
-                writeElement( writer, WMSNS, "Keyword", ls.getString() );
+
+            for ( Pair<List<LanguageString>, CodeType> kws : kwsl ) {
+                String vocabulary = null;
+                if ( kws.second != null ) {
+                    vocabulary = kws.second.getCodeSpace();
+                }
+                for ( LanguageString ls : kws.first ) {
+                    writeElement( writer, WMSNS, "Keyword", ls.getString(), null, null, "vocabulary", vocabulary );
+                }
             }
             writer.writeEndElement();
         }


### PR DESCRIPTION
After converting an old style wms configuration to a new theme based configuration, I discovered that the vocabulary attribute was missing in the WMS Capabilities. Also missing where additional keywords lists.

This patch adds support for both missing features to the theme writer classes.

Fragment of original configuration:

``` xml
      <RequestableLayer queryable="true">
        <!-- irrelevant stuff omitted -->
        <Keywords>
          <Keyword>behoud</Keyword>
          <Keyword>milieu</Keyword>
          <Keyword>landbouw</Keyword>
          <Keyword>natuurbescherming</Keyword>
          <Type codeSpace="GEMET - Concepts, version 2.4"/>
        </Keywords>
        <Keywords>
          <Keyword>Beschermde gebieden</Keyword>
          <Type codeSpace="GEMET - INSPIRE themes, version 1.0"/>
        </Keywords>
        <!-- irrelevant stuff omitted -->
      </RequestableLayer>
```

Corresponding fragment of new configuration:

``` xml
      <Themes>
           <!-- irrelevant stuff omitted -->
           <Theme>
              <!-- irrelevant stuff omitted -->
              <Theme>
                  <!-- irrelevant stuff omitted -->
                  <d:Keywords>
                      <d:Keyword>behoud</d:Keyword>
                      <d:Keyword>milieu</d:Keyword>
                      <d:Keyword>landbouw</d:Keyword>
                      <d:Keyword>natuurbescherming</d:Keyword>
                      <d:Type codeSpace="GEMET - Concepts, version 2.4"/>
                  </d:Keywords>
                  <d:Keywords>
                      <d:Keyword>Beschermde gebieden</d:Keyword>
                      <d:Type codeSpace="GEMET - INSPIRE themes, version 1.0"/>
                  </d:Keywords>
                  <!-- irrelevant stuff omitted -->
              </Theme>
          </Theme>
      </Themes>
```

Expected capabilities output:

``` xml
      <Layer queryable="1">        
        <!-- irrelevant stuff omitted -->
        <KeywordList>
          <Keyword vocabulary="GEMET - Concepts, version 2.4">behoud</Keyword>
          <Keyword vocabulary="GEMET - Concepts, version 2.4">milieu</Keyword>
          <Keyword vocabulary="GEMET - Concepts, version 2.4">landbouw</Keyword>
          <Keyword vocabulary="GEMET - Concepts, version 2.4">natuurbescherming</Keyword>
          <Keyword vocabulary="GEMET - INSPIRE themes, version 1.0">Beschermde gebieden</Keyword>
        </KeywordList>
        <!-- irrelevant stuff omitted -->
      </Layer>
```

But was instead:

``` xml
      <Layer queryable="1">        
        <!-- irrelevant stuff omitted -->
        <KeywordList>
          <Keyword>behoud</Keyword>
          <Keyword>milieu</Keyword>
          <Keyword>landbouw</Keyword>
          <Keyword>natuurbescherming</Keyword>
          <!-- keyword missing! -->
        </KeywordList>
        <!-- irrelevant stuff omitted -->
      </Layer>
```
