### PR TITLE
OWSMetadataProvider usage in WMSController

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -648,13 +648,14 @@ public class WMSController extends AbstractOWS {
     }
 
     public List<OMElement> getExtendedCapabilities( String version ) {
-        List<OMElement> list;
+        Map<String, List<OMElement>> extendedCaps;
         if ( metadataProvider != null ) {
-            list = metadataProvider.getExtendedCapabilities().get( version );
+            extendedCaps = metadataProvider.getExtendedCapabilities();
         } else {
-            list = extendedCaps.get( version );
+            extendedCaps = this.extendedCaps;
         }
 
+        List<OMElement> list = extendedCaps.get( version );
         if ( list == null ) {
             list = extendedCaps.get( "default" );
         }


### PR DESCRIPTION
The OWSMetadataProvider is being consulted when performing a GetCapabilities request on the WMS. Currently it is not using the result in the output of the pending request but it is storing it for later use (i.e. the next GetCapabilities requests) instead. This causes the information in the capabilities to be obsolete (and missing for the first request).
