### PR TITLE
fix for #531  urn:ogc:def:storedQuery:OGC-WFS::GetFeatureById  to  urn:o...

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/WFSConstants.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/WFSConstants.java
@@ -85,7 +85,7 @@ public class WFSConstants {
 
     public static final String GML32_SCHEMA_URL = "http://schemas.opengis.net/gml/3.2.1/gml.xsd";
 
-    public static final String URN_OGC_QUERY_PREFIX = "urn:ogc:def:storedQuery:OGC-WFS::";
+    public static final String URN_OGC_QUERY_PREFIX = "urn:ogc:def:query:OGC-WFS::";
 
     public static final String QUERY_ID_GET_FEATURE_BY_ID = URN_OGC_QUERY_PREFIX + "GetFeatureById";
 }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/StoredQueryHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/StoredQueryHandler.java
@@ -84,9 +84,9 @@ public class StoredQueryHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger( StoredQueryHandler.class );
 
-    public static final String GET_FEATURE_BY_ID = "urn:ogc:def:storedQuery:OGC-WFS::GetFeatureById";
+    public static final String GET_FEATURE_BY_ID = "urn:ogc:def:query:OGC-WFS::GetFeatureById";
 
-    public static final String GET_FEATURE_BY_TYPE = "urn:ogc:def:storedQuery:OGC-WFS::GetFeatureByType";
+    public static final String GET_FEATURE_BY_TYPE = "urn:ogc:def:query:OGC-WFS::GetFeatureByType";
 
     private final Map<String, StoredQueryDefinition> idToQuery = Collections.synchronizedMap( new TreeMap<String, StoredQueryDefinition>() );
 

--- a/deegree-services/deegree-services-wfs/src/main/resources/org/deegree/services/wfs/query/idquery.xml
+++ b/deegree-services/deegree-services-wfs/src/main/resources/org/deegree/services/wfs/query/idquery.xml
@@ -1,4 +1,4 @@
-<wfs:StoredQueryDefinition id="urn:ogc:def:storedQuery:OGC-WFS::GetFeatureById" xmlns:wfs="http://www.opengis.net/wfs/2.0"
+<wfs:StoredQueryDefinition id="urn:ogc:def:query:OGC-WFS::GetFeatureById" xmlns:wfs="http://www.opengis.net/wfs/2.0"
   xmlns:fes="http://www.opengis.net/fes/2.0">
   <wfs:Title>GetFeatureById</wfs:Title>
   <wfs:Abstract>Returns the single feature whose value is equal to the specified value of the ID argument</wfs:Abstract>

--- a/deegree-services/deegree-services-wfs/src/main/resources/org/deegree/services/wfs/query/typequery.xml
+++ b/deegree-services/deegree-services-wfs/src/main/resources/org/deegree/services/wfs/query/typequery.xml
@@ -1,4 +1,4 @@
-<wfs:StoredQueryDefinition id="urn:ogc:def:storedQuery:OGC-WFS::GetFeatureByType" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<wfs:StoredQueryDefinition id="urn:ogc:def:query:OGC-WFS::GetFeatureByType" xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2">
   <wfs:Title>GetFeatureByType</wfs:Title>  
   <wfs:Abstract>Returns a collection of features by type. If returnFeatureTypes='gml:AbstractFeatureType', the query

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/xml/wfs_storedquerydefinition.xml
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/xml/wfs_storedquerydefinition.xml
@@ -1,4 +1,4 @@
-<StoredQueryDefinition id="urn:x-inspire:storedQuery:GetAddressesForStreet"
+<StoredQueryDefinition id="urn:x-inspire:query:GetAddressesForStreet"
   xmlns="http://www.opengis.net/wfs/2.0"
   xmlns:ad="urn:x-inspire:specification:gmlas:Addresses:3.0"
   xmlns:gn="urn:x-inspire:specification:gmlas:GeographicalNames:3.0">

--- a/deegree-workspaces/deegree-workspace-inspire/src/main/workspace/manager/requests/wfs/Address/GetFeature/xml/StoredQuery_200.xml
+++ b/deegree-workspaces/deegree-workspace-inspire/src/main/workspace/manager/requests/wfs/Address/GetFeature/xml/StoredQuery_200.xml
@@ -2,7 +2,7 @@
 <GetFeature version="2.0.0" service="WFS" xmlns="http://www.opengis.net/wfs/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/wfs/2.0
 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
-  <StoredQuery id="urn:ogc:def:storedQuery:OGC-WFS::GetFeatureById">
+  <StoredQuery id="urn:ogc:def:query:OGC-WFS::GetFeatureById">
     <Parameter name="ID">NL.KAD.BAG.0532200000000026</Parameter>
   </StoredQuery>
 </GetFeature>


### PR DESCRIPTION
Following URN Code is used for StoredQuery identifiers:

urn:ogc:def:storedQuery:OGC-WFS::GetFeatureById

Following one is expected by compliance tests and a confirmed CR:

urn:ogc:def:query:OGC-WFS::GetFeatureById
