### PR TITLE
getfeatureinfo ampersand bug 533

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
@@ -206,7 +206,7 @@ public class OwsHttpClientImpl implements OwsHttpClient {
         // TODO: this method does not work. url.getQuery is the query part not the base url
         String s = url.toString();
         if ( url.getQuery() != null ) {
-            if ( !s.endsWith( "&" ) && !s.endsWith( "?" ) ) {
+            if ( !s.endsWith( "&" ) && ( !s.endsWith( "?" ) && s.length() == 1 ) ) {
                 s += "&";
             }
         } else {


### PR DESCRIPTION
 http://tracker.deegree.org/deegree-services/ticket/533

GFI requests against remote WMS are constructed with an additional "&" at the beginning of a GET query when "?" is included within the URL in the Capabilities:
host/path?&request
instead of
host/path?request
is the result.
This leads into problems with some security components.
