### PR TITLE
Deactivated on-demand parsing of crs definitions

### DIFF
--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/CoordinateSystemParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/CoordinateSystemParser.java
@@ -144,13 +144,13 @@ public class CoordinateSystemParser extends DefinitionParser {
                 if ( result != null ) {
                     getStore().addIdToCache( result, false );
                 }
-                while ( result != null && !result.hasId( tmpCRSId, false, true ) ) {
+                while ( result != null ) {
                     result = parseCoordinateSystem( configReader );
                     if ( result != null ) {
                         getStore().addIdToCache( result, false );
                     }
                 }
-
+                return getStore().getCachedIdentifiable( CRS.class, tmpCRSId );
             } catch ( XMLStreamException e ) {
                 throw new CRSConfigurationException( e );
             }
@@ -385,7 +385,8 @@ public class CoordinateSystemParser extends DefinitionParser {
         try {
             usedCRS = getRequiredText( reader, new QName( CRS_NS, "UsedCRS" ), true );
         } catch ( XMLParsingException e ) {
-            throw new CRSConfigurationException( Messages.getMessage( "CRS_CONFIG_PARSE_ERROR", "usedCRS",
+            throw new CRSConfigurationException( Messages.getMessage( "CRS_CONFIG_PARSE_ERROR",
+                                                                      "usedCRS",
                                                                       ( ( reader == null ) ? "null"
                                                                                           : reader.getLocalName() ),
                                                                       e.getMessage() ), e );
@@ -407,8 +408,8 @@ public class CoordinateSystemParser extends DefinitionParser {
                                                                       e.getLocalizedMessage() ), e );
         }
 
-        double defaultHeight = XMLStreamUtils.getElementTextAsDouble( reader, new QName( CRS_NS, "DefaultHeight" ),
-                                                                         0, true );
+        double defaultHeight = XMLStreamUtils.getElementTextAsDouble( reader, new QName( CRS_NS, "DefaultHeight" ), 0,
+                                                                      true );
         // adding to cache will be done in AbstractCRSProvider.
         return new CompoundCRS( heightAxis, usedCoordinateSystem, defaultHeight, id );
     }

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/DatumParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/DatumParser.java
@@ -38,6 +38,7 @@
 
 package org.deegree.cs.persistence.deegree.d3.parsers;
 
+import static org.deegree.commons.xml.stax.XMLStreamUtils.moveReaderToFirstMatch;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.nextElement;
 import static org.deegree.cs.persistence.deegree.d3.DeegreeCRSStore.CRS_NS;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -121,7 +122,7 @@ public class DatumParser extends DefinitionParser {
      */
     protected GeodeticDatum parseDatum( XMLStreamReader reader )
                             throws XMLStreamException {
-        if ( reader == null || !super.moveReaderToNextIdentifiable( reader, DATUM_ELEM ) ) {
+        if ( reader == null || !moveReaderToFirstMatch( reader, DATUM_ELEM ) ) {
             LOG.debug( "Could not get datum, no more definitions left." );
             return null;
         }
@@ -138,8 +139,8 @@ public class DatumParser extends DefinitionParser {
         IEllipsoid ellipsoid = new EllipsoidRef( store.getResolver( RESOURCETYPE.ELLIPSOID ), '#' + ellipsID, null );
 
         // get the primemeridian if any.
-        String pMeridianID = XMLStreamUtils.getText( getConfigReader(), new QName( CRS_NS, "UsedPrimeMeridian" ),
-                                                        null, true );
+        String pMeridianID = XMLStreamUtils.getText( getConfigReader(), new QName( CRS_NS, "UsedPrimeMeridian" ), null,
+                                                     true );
         IPrimeMeridian pMeridian = null;
         if ( pMeridianID != null && pMeridianID.trim().length() > 0 ) {
             pMeridian = new PrimeMeridianRef( store.getResolver( RESOURCETYPE.PM ), '#' + pMeridianID, null );

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/DefinitionParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/DefinitionParser.java
@@ -39,7 +39,6 @@
 package org.deegree.cs.persistence.deegree.d3.parsers;
 
 import static org.deegree.commons.xml.stax.XMLStreamUtils.getSimpleUnboundedAsStrings;
-import static org.deegree.commons.xml.stax.XMLStreamUtils.moveReaderToFirstMatch;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.nextElement;
 import static org.deegree.cs.persistence.deegree.d3.DeegreeCRSStore.CRS_NS;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -271,20 +270,6 @@ public abstract class DefinitionParser {
      */
     public DeegreeCRSStore getStore() {
         return store;
-    }
-
-    /**
-     * Forwards the stream
-     * 
-     * @param reader
-     *            to forward
-     * @param elementName
-     * @return true if the stream is pointing to an element with the given qname.
-     * @throws XMLStreamException
-     */
-    public boolean moveReaderToNextIdentifiable( XMLStreamReader reader, QName elementName )
-                            throws XMLStreamException {
-        return moveReaderToFirstMatch( reader, elementName );
     }
 
     /**

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/EllipsoidParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/EllipsoidParser.java
@@ -40,6 +40,7 @@ package org.deegree.cs.persistence.deegree.d3.parsers;
 
 import static org.deegree.commons.xml.stax.XMLStreamUtils.getElementTextAsDouble;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.getRequiredElementTextAsDouble;
+import static org.deegree.commons.xml.stax.XMLStreamUtils.moveReaderToFirstMatch;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.nextElement;
 import static org.deegree.cs.persistence.deegree.d3.DeegreeCRSStore.CRS_NS;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -121,7 +122,7 @@ public class EllipsoidParser extends DefinitionParser {
      */
     protected Ellipsoid parseEllipsoid( XMLStreamReader reader )
                             throws XMLStreamException {
-        if ( reader == null || !super.moveReaderToNextIdentifiable( reader, ELLIPS_ELEM ) ) {
+        if ( reader == null || !moveReaderToFirstMatch( reader, ELLIPS_ELEM ) ) {
             LOG.debug( "Could not get ellipsoid no more definitions found." );
             return null;
         }

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/PrimemeridianParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/PrimemeridianParser.java
@@ -38,6 +38,7 @@
 
 package org.deegree.cs.persistence.deegree.d3.parsers;
 
+import static org.deegree.commons.xml.stax.XMLStreamUtils.moveReaderToFirstMatch;
 import static org.deegree.cs.persistence.deegree.d3.DeegreeCRSStore.CRS_NS;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -115,7 +116,7 @@ public class PrimemeridianParser extends DefinitionParser {
      */
     protected PrimeMeridian parsePrimeMeridian( XMLStreamReader reader )
                             throws XMLStreamException {
-        if ( reader == null || !super.moveReaderToNextIdentifiable( reader, PM_ELEMENT ) ) {
+        if ( reader == null || !moveReaderToFirstMatch( reader, PM_ELEMENT ) ) {
             LOG.debug( "Could not get prime meridian no more definitions found." );
             return null;
         }


### PR DESCRIPTION
Backport from 3.4.

The on-demand parsing of CRS-definitions still leads to error (e.g. different objects returned for same CRS code) and has no measurable benefit. 
