### PR TITLE
Align default WFS buffering setting with documentation (default: off)

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -207,7 +207,7 @@ public class WebFeatureService extends AbstractOWS {
 
     private IDGenMode idGenMode;
 
-    private boolean disableBuffering;
+    private boolean disableBuffering = true;
 
     private ICRS defaultQueryCRS = CRSUtils.EPSG_4326;
 


### PR DESCRIPTION
If the EnableBuffering element is omitted from the WFS configuration, buffering should be off, not on (as it can be very expensive).
