### PR TITLE
SQLFeatureStore: Insert in relational mode does not use regenerated FID values in href mapping

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
@@ -382,12 +382,11 @@ public class InsertRowManager {
                         }
                         children.add( currentRow );
 
-                        // href handling is done above
-                        // SQLIdentifier hrefCol = null;
-                        // if ( ( (FeatureMapping) mapping ).getHrefMapping() != null ) {
-                        // hrefCol = new SQLIdentifier( ( (FeatureMapping) mapping ).getHrefMapping().toString() );
-                        // }
-                        // ref.addHrefingRow( currentRow, hrefCol );
+                        SQLIdentifier hrefCol = null;
+                        if ( ( (FeatureMapping) mapping ).getHrefMapping() != null ) {
+                            hrefCol = new SQLIdentifier( ( (FeatureMapping) mapping ).getHrefMapping().toString() );
+                        }
+                        ref.addHrefingRow( currentRow, hrefCol );
 
                         if ( !delayedRows.contains( subFeatureRow ) ) {
                             // sub feature already inserted, propagate key values right away


### PR DESCRIPTION
Uncommented lines that are responsible for the href mapping columns to use newly generated ids instead of the old ones. These have been erroneously commted out in commit 73fa12c550e9b783694ac765763ebbc3ae70a2b4.
