### PR TITLE
Fixed style handling in case of multiple grouped layers

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/AbstractLayer.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/AbstractLayer.java
@@ -39,19 +39,21 @@ package org.deegree.layer;
 import org.deegree.commons.annotations.LoggingNotes;
 import org.deegree.commons.utils.CollectionUtils.Mapper;
 import org.deegree.layer.metadata.LayerMetadata;
+import org.deegree.style.StyleRef;
+import org.deegree.style.se.unevaluated.Style;
 
 /**
  * <code>Layer</code>
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
 @LoggingNotes(warn = "logs information about dimension handling")
 public abstract class AbstractLayer implements Layer {
 
-    private LayerMetadata metadata;
+    private final LayerMetadata metadata;
 
     public static final Mapper<String, Layer> LAYER_NAME = new Mapper<String, Layer>() {
         @Override
@@ -69,6 +71,10 @@ public abstract class AbstractLayer implements Layer {
 
     protected AbstractLayer( LayerMetadata md ) {
         this.metadata = md;
+    }
+
+    protected Style resolveStyleRef( StyleRef ref ) {
+        return metadata.getStyles().get( ref.getName() );
     }
 
     @Override

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
@@ -56,10 +56,10 @@ import org.deegree.style.se.unevaluated.Style;
 import org.slf4j.Logger;
 
 /**
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author: stranger $
- * 
+ *
  * @version $Revision: $, $Date: $
  */
 public class CoverageLayer extends AbstractLayer {
@@ -70,7 +70,7 @@ public class CoverageLayer extends AbstractLayer {
 
     private final MultiResolutionRaster multiraster;
 
-    private CoverageDimensionHandler dimensionHandler;
+    private final CoverageDimensionHandler dimensionHandler;
 
     public CoverageLayer( LayerMetadata md, AbstractRaster raster, MultiResolutionRaster multiraster ) {
         super( md );
@@ -84,14 +84,8 @@ public class CoverageLayer extends AbstractLayer {
                             throws OWSException {
         try {
             Envelope bbox = query.getEnvelope();
-
             RangeSet filter = dimensionHandler.getDimensionFilter( query.getDimensions(), headers );
-
-            StyleRef ref = query.getStyle();
-            if ( !ref.isResolved() ) {
-                ref.resolve( getMetadata().getStyles().get( ref.getName() ) );
-            }
-            Style style = ref.getStyle();
+            Style style = resolveStyleRef( query.getStyle() );
             // handle SLD/SE scale settings
             style = style == null ? null : style.filter( query.getScale() );
 

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
@@ -69,25 +69,25 @@ import org.deegree.style.utils.Styles;
 import org.slf4j.Logger;
 
 /**
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author: stranger $
- * 
+ *
  * @version $Revision: $, $Date: $
  */
 public class FeatureLayer extends AbstractLayer {
 
     private static final Logger LOG = getLogger( FeatureLayer.class );
 
-    private FeatureStore featureStore;
+    private final FeatureStore featureStore;
 
-    private OperatorFilter filter;
+    private final OperatorFilter filter;
 
     private final QName featureType;
 
     SortProperty[] sortBy, sortByFeatureInfo;
 
-    private DimensionFilterBuilder dimFilterBuilder;
+    private final DimensionFilterBuilder dimFilterBuilder;
 
     public FeatureLayer( LayerMetadata md, FeatureStore featureStore, QName featureType, OperatorFilter filter,
                          List<SortProperty> sortBy, List<SortProperty> sortByFeatureInfo ) {
@@ -107,14 +107,9 @@ public class FeatureLayer extends AbstractLayer {
     @Override
     public FeatureLayerData mapQuery( final LayerQuery query, List<String> headers )
                             throws OWSException {
-        StyleRef ref = query.getStyle();
-        if ( !ref.isResolved() ) {
-            ref.resolve( getMetadata().getStyles().get( ref.getName() ) );
-        }
-        Style style = ref.getStyle();
-
+        Style style = resolveStyleRef( query.getStyle() );
         if ( style == null ) {
-            throw new OWSException( "The style " + ref.getName() + " is not defined for layer "
+            throw new OWSException( "The style " + query.getStyle().getName() + " is not defined for layer "
                                     + getMetadata().getName() + ".", "StyleNotDefined", "styles" );
         }
         style = style.filter( query.getScale() );

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -99,10 +99,10 @@ import org.slf4j.Logger;
 
 /**
  * <code>MapService</code>
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
 @LoggingNotes(error = "logs errors when querying feature stores/evaluating filter encoding expressions", trace = "logs stack traces", warn = "logs problems when loading layers, also invalid values for vendor specific parameters such as ANTIALIAS, QUALITY etc.", debug = "logs if layers are skipped because of scale constraints, and info about feature store queries")
@@ -111,14 +111,14 @@ public class MapService {
     private static final Logger LOG = getLogger( MapService.class );
 
     /**
-     * 
+     *
      */
     public HashMap<String, Layer> layers;
 
     private Layer root;
 
     /**
-     * 
+     *
      */
     public StyleRegistry registry;
 
@@ -126,7 +126,7 @@ public class MapService {
 
     MapOptions defaultLayerOptions;
 
-    private LinkedList<LayerUpdater> dynamics = new LinkedList<LayerUpdater>();
+    private final LinkedList<LayerUpdater> dynamics = new LinkedList<LayerUpdater>();
 
     /**
      * The current update sequence.
@@ -141,9 +141,9 @@ public class MapService {
 
     HashMap<String, Theme> themeMap;
 
-    private GetLegendHandler getLegendHandler;
+    private final GetLegendHandler getLegendHandler;
 
-    private OldStyleMapService oldStyleMapService;
+    private final OldStyleMapService oldStyleMapService;
 
     /**
      * @param conf
@@ -346,7 +346,9 @@ public class MapService {
                      || l.getMetadata().getScaleDenominators().second < scale ) {
                     continue;
                 }
-                list.add( l.mapQuery( query, headers ) );
+                if ( l.getMetadata().getStyles().containsKey( query.getStyle().getName() ) ) {
+                    list.add( l.mapQuery( query, headers ) );
+                }
             }
         }
         Iterator<MapOptions> optIter = mapOptions.iterator();
@@ -419,7 +421,7 @@ public class MapService {
         List<OperatorFilter> filters = gfi.getFilters();
         Iterator<OperatorFilter> filterItr = filters == null ? null : filters.iterator();
         while ( layerItr.hasNext() ) {
-            LayerRef lr = layerItr.next();
+            layerItr.next();
             StyleRef sr = styleItr.next();
             OperatorFilter f = filterItr == null ? null : filterItr.next();
 


### PR DESCRIPTION
For themes that group multiple layers like this:

``` xml
      <Theme>
          <Identifier>Provincies</Identifier>
          <d:Title>Provincies-grens</d:Title>          
          <Layer>OR.Provincies-1</Layer>
          <Layer>OR.Provincies-2</Layer>
      </Theme>
```

it sometimes appeared as if only the first layer was rendered. However, actually the style from the first layer was also applied to the second.
