### PR TITLE
 fix umn get feature info parser

### DIFF
--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/parsing/FeatureInfoParser.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/parsing/FeatureInfoParser.java
@@ -192,9 +192,9 @@ public class FeatureInfoParser {
 
         String ftName = reader.getLocalName();
         String singleFeatureTagName = ftName.split( "_" )[0] + "_feature";
-        if ( StringUtils.count(ftName, "_") > 1 ) {
+        if ( StringUtils.count( ftName, "_" ) > 1 ) {
             int splitIndex = ftName.lastIndexOf( "_" );
-            singleFeatureTagName = ftName.substring(0, splitIndex) + "_feature";               
+            singleFeatureTagName = ftName.substring( 0, splitIndex ) + "_feature";
         }
 
         while ( reader.isStartElement() && reader.getLocalName().equals( ftName ) ) {


### PR DESCRIPTION
corresponding ticket http://tracker.deegree.org/deegree-services/ticket/351
bugfix to parse umn mapserver getfeatureinfo requests containing layer with more than one "_" character
