### PR TITLE
deegree-featurestore-sql: Provide prefix for derived xsi:nil attributes

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
@@ -37,6 +37,8 @@ package org.deegree.feature.persistence.sql.rules;
 
 import static java.lang.Boolean.TRUE;
 import static org.deegree.commons.utils.JDBCUtils.close;
+import static org.deegree.commons.xml.CommonNamespaces.XSINS;
+import static org.deegree.commons.xml.CommonNamespaces.XSI_PREFIX;
 import static org.jaxen.saxpath.Axis.CHILD;
 
 import java.sql.Connection;
@@ -523,7 +525,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
                             }
                         }
                     }
-                    nilAttrs.put( new QName( CommonNamespaces.XSINS, "nil" ), new PrimitiveValue( Boolean.TRUE ) );
+                    nilAttrs.put( new QName( XSINS, "nil", XSI_PREFIX ), new PrimitiveValue( TRUE ) );
                     particle = new GenericXMLElement( elName, cm.getElementDecl(), nilAttrs, null );
                 }
             } else {


### PR DESCRIPTION
Ensures that the GMLWriter always knows the correct prefix when writing xsi:nil attributes that have been generated to materialize a NULL value on feature reconstruction.
