### PR TITLE
FeatureInfoRadius for single layer - 3.3

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/LayerQuery.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/LayerQuery.java
@@ -204,15 +204,4 @@ public class LayerQuery {
                                                  envelope.getMax().get1() - ( y - r2 ) * dh },
                                    envelope.getCoordinateSystem() );
     }
-
-    // public Envelope calcClickBox( int radius ) {
-    // TODO again: re-implement this properly
-    // TODO implement all this per layer also if more than one layer is requested
-    // if ( layers.size() == 1 && service.getDefaultFeatureInfoRadius().get( layers.getFirst() ) != null ) {
-    // radius = service.getDefaultFeatureInfoRadius().get( layers.getFirst() );
-    // }
-    // radius = parameters.get( "RADIUS" ) == null ? radius : parseInt( parameters.get( "RADIUS" ) );
-    // return calcClickBox( radius );
-    // }
-
 }


### PR DESCRIPTION
http://tracker.deegree.org/deegree-services/ticket/606

When a GetFeatureInfo request queries more than one layer, the layer wide radius will be applied for those layers for which the radius is set.

For the layers for which the radius is not set, the service wide radius will be applied. If the service wide radius is not set, a default value (1) will be applied.
