### PR TITLE
Fix for #527 - 3.3: Queryable not configurable

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -229,6 +229,8 @@ public class ConfigUtils {
         }
         if ( cfg.getFeatureInfo() != null && cfg.getFeatureInfo().isEnabled() ) {
             rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+        } else if ( cfg.getFeatureInfo() != null && !cfg.getFeatureInfo().isEnabled() ) {
+            rad = 0;
         } else if ( cfg.getFeatureInfoRadius() != null ) {
             rad = cfg.getFeatureInfoRadius();
         }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -449,11 +449,15 @@ public class MapService {
             OperatorFilter f = filterItr == null ? null : filterItr.next();
             int layerRadius = 0;
             for ( org.deegree.layer.Layer l : Themes.getAllLayers( themeMap.get( lr.getName() ) ) ) {
-                if ( l.getMetadata().getMapOptions() != null
-                     && l.getMetadata().getMapOptions().getFeatureInfoRadius() != 1 ) {
-                    layerRadius = l.getMetadata().getMapOptions().getFeatureInfoRadius();
+                if ( l.getMetadata().getMapOptions().getFeatureInfoRadius() == 0 ) {
+                    return null;
                 } else {
-                    layerRadius = defaultLayerOptions.getFeatureInfoRadius();
+                    if ( l.getMetadata().getMapOptions() != null
+                         && l.getMetadata().getMapOptions().getFeatureInfoRadius() != 1 ) {
+                        layerRadius = l.getMetadata().getMapOptions().getFeatureInfoRadius();
+                    } else {
+                        layerRadius = defaultLayerOptions.getFeatureInfoRadius();
+                    }
                 }
             }
             LayerQuery query = new LayerQuery( gfi.getEnvelope(), gfi.getWidth(), gfi.getHeight(), gfi.getX(),


### PR DESCRIPTION
http://tracker.deegree.org/deegree-services/ticket/527

It's possible to set a layer as queryable or not queryable setting the attribute "enabled" on the "l:FeatureInfo" element. This configuration was not working properly.