### PR TITLE
Tk#411 - 3.3: Use of explicit uom within SE Styles

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
@@ -181,6 +181,9 @@ public class Java2DRenderer implements Renderer {
         geom = rendererContext.clipper.clipGeometry( geom );
         if ( geom instanceof Curve ) {
             Double line = rendererContext.geomHelper.fromCurve( (Curve) geom, false );
+            rendererContext.strokeRenderer.uomStrokeWidth = styling.uomStroke;
+            rendererContext.strokeRenderer.uomPerpendicularOffset = styling.uomPerpendicular;
+            rendererContext.strokeRenderer.uomGap = styling.uomGp;
             rendererContext.strokeRenderer.applyStroke( styling.stroke, styling.uom, line, styling.perpendicularOffset,
                                                         styling.perpendicularOffsetType );
         } else if ( geom instanceof Surface ) {

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DStrokeRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DStrokeRenderer.java
@@ -83,6 +83,12 @@ class Java2DStrokeRenderer {
 
     private Java2DFillRenderer fillRenderer;
 
+    UOM uomStrokeWidth;
+
+    UOM uomPerpendicularOffset;
+
+    UOM uomGap;
+
     Java2DStrokeRenderer( Graphics2D graphics, UomCalculator uomCalculator, Java2DFillRenderer fillRenderer ) {
         this.graphics = graphics;
         this.uomCalculator = uomCalculator;
@@ -116,10 +122,10 @@ class Java2DStrokeRenderer {
             Shape shape = getShapeFromSvg( stroke.stroke.imageURL,
                                            uomCalculator.considerUOM( stroke.stroke.size, uom ), stroke.stroke.rotation );
             graphics.setStroke( new ShapeStroke( shape, uomCalculator.considerUOM( stroke.strokeGap
-                                                                                   + stroke.stroke.size, uom ),
+                                                                                   + stroke.stroke.size, uomGap ),
                                                  stroke.positionPercentage, stroke.strokeInitialGap ) );
         } else if ( stroke.stroke.mark != null ) {
-            double poff = uomCalculator.considerUOM( perpendicularOffset, uom );
+            double poff = uomCalculator.considerUOM( perpendicularOffset, uomPerpendicularOffset );
             Shape transed = object;
             if ( !isZero( poff ) ) {
                 transed = new OffsetStroke( poff, null, type ).createStrokedShape( transed );
@@ -130,7 +136,7 @@ class Java2DStrokeRenderer {
             if ( sz <= 0 ) {
                 sz = 6;
             }
-            ShapeStroke s = new ShapeStroke( shape, uomCalculator.considerUOM( stroke.strokeGap + sz, uom ),
+            ShapeStroke s = new ShapeStroke( shape, uomCalculator.considerUOM( stroke.strokeGap + sz, uomGap ),
                                              stroke.positionPercentage, stroke.strokeInitialGap );
             transed = s.createStrokedShape( transed );
             if ( stroke.stroke.mark.fill != null ) {
@@ -161,9 +167,10 @@ class Java2DStrokeRenderer {
             }
         }
 
-        BasicStroke bs = new BasicStroke( (float) uomCalculator.considerUOM( stroke.width, uom ), linecap, linejoin,
-                                          miterLimit, dasharray, dashoffset );
-        double poff = uomCalculator.considerUOM( perpendicularOffset, uom );
+        BasicStroke bs = new BasicStroke( (float) uomCalculator.considerUOM( stroke.width, uomStrokeWidth ), linecap,
+                                          linejoin, miterLimit, dasharray, dashoffset );
+
+        double poff = uomCalculator.considerUOM( perpendicularOffset, uomPerpendicularOffset );
         if ( !isZero( poff ) ) {
             graphics.setStroke( new OffsetStroke( poff, bs, type ) );
         } else {

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/LabelRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/LabelRenderer.java
@@ -84,8 +84,8 @@ class LabelRenderer {
     void render( TextStyling styling, Font font, String text, Point p ) {
         Point2D.Double pt = (Point2D.Double) renderer.worldToScreen.transform( new Point2D.Double( p.get0(), p.get1() ),
                                                                                null );
-        double x = pt.x + context.uomCalculator.considerUOM( styling.displacementX, styling.uom );
-        double y = pt.y - context.uomCalculator.considerUOM( styling.displacementY, styling.uom );
+        double x = pt.x + context.uomCalculator.considerUOM( styling.displacementX, styling.uomDisplacementX );
+        double y = pt.y - context.uomCalculator.considerUOM( styling.displacementY, styling.uomDisplacementY );
         renderer.graphics.setFont( font );
         AffineTransform transform = renderer.graphics.getTransform();
         renderer.graphics.rotate( toRadians( styling.rotation ), x, y );
@@ -123,12 +123,13 @@ class LabelRenderer {
     void render( TextStyling styling, Font font, String text, Curve c ) {
         context.fillRenderer.applyFill( styling.fill, styling.uom );
         java.awt.Stroke stroke = new TextStroke( text, font, styling.linePlacement );
+        double poff = context.uomCalculator.considerUOM( styling.linePlacement.perpendicularOffset,
+                                                         styling.uomPerpendicularOffsetText );
         if ( isZero( ( (TextStroke) stroke ).getLineHeight() ) ) {
             return;
         }
         if ( !isZero( styling.linePlacement.perpendicularOffset ) ) {
-            stroke = new OffsetStroke( styling.linePlacement.perpendicularOffset, stroke,
-                                       styling.linePlacement.perpendicularOffsetType );
+            stroke = new OffsetStroke( poff, stroke, styling.linePlacement.perpendicularOffsetType );
         }
 
         renderer.graphics.setStroke( stroke );

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/PolygonRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/PolygonRenderer.java
@@ -103,6 +103,9 @@ class PolygonRenderer {
                 fillRenderer.applyFill( styling.fill, styling.uom );
                 graphics.fill( polygon );
                 for ( Double d : lines ) {
+                    strokeRenderer.uomStrokeWidth = styling.uomStroke;
+                    strokeRenderer.uomPerpendicularOffset = styling.uomPerpendicular;
+                    strokeRenderer.uomGap = styling.uomGp;
                     strokeRenderer.applyStroke( styling.stroke, styling.uom, d, styling.perpendicularOffset,
                                                 styling.perpendicularOffsetType );
                 }
@@ -134,6 +137,9 @@ class PolygonRenderer {
                     if ( curve.getCoordinateSystem() == null ) {
                         curve.setCoordinateSystem( surface.getCoordinateSystem() );
                     }
+                    strokeRenderer.uomStrokeWidth = styling.uomStroke;
+                    strokeRenderer.uomPerpendicularOffset = styling.uomPerpendicular;
+                    strokeRenderer.uomGap = styling.uomGp;
                     renderer.render( styling, curve );
                 }
             } else {

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/parser/StrokeSymbologyParser.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/parser/StrokeSymbologyParser.java
@@ -81,6 +81,10 @@ class StrokeSymbologyParser {
 
     private SymbologyParserContext context;
 
+    private boolean pixelStrokeToken;
+    
+    private boolean pixelGapToken;
+
     StrokeSymbologyParser( SymbologyParserContext context ) {
         this.context = context;
     }
@@ -140,7 +144,14 @@ class StrokeSymbologyParser {
             contn = context.parser.updateOrContinue( in, "Parameter", base, new Updater<Stroke>() {
                 @Override
                 public void update( Stroke obj, String val ) {
-                    obj.width = Double.parseDouble( val );
+                    if ( val.endsWith( "px" ) ) {
+                        String valpx = val.substring( 0, val.length() - 2 );
+                        pixelStrokeToken = true;
+                        obj.width = Double.parseDouble( valpx );
+                    } else {
+                        pixelStrokeToken = false;
+                        obj.width = Double.parseDouble( val );
+                    }
                 }
             }, contn ).second;
         } else if ( name.equals( "stroke-linejoin" ) ) {
@@ -251,7 +262,14 @@ class StrokeSymbologyParser {
                 contn = context.parser.updateOrContinue( in, "Gap", base, new Updater<Stroke>() {
                     @Override
                     public void update( Stroke obj, String val ) {
-                        obj.strokeGap = Double.parseDouble( val );
+                        if ( val.endsWith( "px" ) ) {
+                            String valpx = val.substring( 0, val.length() - 2 );
+                            pixelGapToken = true;
+                            obj.strokeGap = Double.parseDouble( valpx );
+                        } else {
+                            pixelGapToken = false;
+                            obj.strokeGap = Double.parseDouble( val );
+                        }
                     }
                 }, contn ).second;
                 in.require( END_ELEMENT, null, "Gap" );
@@ -274,4 +292,11 @@ class StrokeSymbologyParser {
         return contn;
     }
 
+    public boolean getPixelStrokeToken() {
+        return pixelStrokeToken;
+    }
+    
+    public boolean getPixelGapToken() {
+        return pixelGapToken;
+    }
 }

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/parser/SymbologyParser.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/parser/SymbologyParser.java
@@ -139,6 +139,14 @@ public class SymbologyParser {
 
     private SymbologyParserContext context = new SymbologyParserContext( this );
 
+    private boolean pixelPerpendicularToken;
+
+    private boolean pixelTextPerpendicularToken;
+
+    private boolean pixelTextDisplacementXToken;
+
+    private boolean pixelTextDisplacementYToken;
+
     /**
      * Constructs one which does not collect source snippets.
      */
@@ -481,6 +489,9 @@ public class SymbologyParser {
         Common common = new Common( in.getLocation() );
         LineStyling baseOrEvaluated = new LineStyling();
         baseOrEvaluated.uom = uom;
+        baseOrEvaluated.uomStroke = uom;
+        baseOrEvaluated.uomPerpendicular = uom;
+        baseOrEvaluated.uomGp = uom;
         Continuation<LineStyling> contn = null;
 
         while ( !( in.isEndElement() && in.getLocalName().equals( "LineSymbolizer" ) ) ) {
@@ -489,6 +500,17 @@ public class SymbologyParser {
             parseCommon( common, in );
 
             if ( in.getLocalName().equals( "Stroke" ) ) {
+                if ( context.strokeParser.getPixelStrokeToken() == true ) {
+                    baseOrEvaluated.uomStroke = Pixel;
+                } else {
+                    baseOrEvaluated.uomStroke = uom;
+                }
+                if ( context.strokeParser.getPixelGapToken() == true ) {
+                    baseOrEvaluated.uomGp = Pixel;
+                } else {
+                    baseOrEvaluated.uomGp = uom;
+                }
+
                 final Pair<Stroke, Continuation<Stroke>> pair = context.strokeParser.parseStroke( in );
 
                 if ( pair != null ) {
@@ -504,11 +526,23 @@ public class SymbologyParser {
                     }
                 }
             } else if ( in.getLocalName().equals( "PerpendicularOffset" ) ) {
+                if ( this.getPixelPerpendicularToken() == true ) {
+                    baseOrEvaluated.uomPerpendicular = Pixel;
+                } else {
+                    baseOrEvaluated.uomPerpendicular = uom;
+                }
                 baseOrEvaluated.perpendicularOffsetType = getPerpendicularOffsetType( in );
                 contn = updateOrContinue( in, "PerpendicularOffset", baseOrEvaluated, new Updater<LineStyling>() {
                     @Override
                     public void update( LineStyling obj, String val ) {
-                        obj.perpendicularOffset = Double.parseDouble( val );
+                        if ( val.endsWith( "px" ) ) {
+                            String valpx = val.substring( 0, val.length() - 2 );
+                            pixelPerpendicularToken = true;
+                            obj.perpendicularOffset = Double.parseDouble( valpx );
+                        } else {
+                            pixelPerpendicularToken = false;
+                            obj.perpendicularOffset = Double.parseDouble( val );
+                        }
                     }
                 }, contn ).second;
             } else if ( in.isStartElement() ) {
@@ -541,6 +575,9 @@ public class SymbologyParser {
         Common common = new Common( in.getLocation() );
         PolygonStyling baseOrEvaluated = new PolygonStyling();
         baseOrEvaluated.uom = uom;
+        baseOrEvaluated.uomStroke = uom;
+        baseOrEvaluated.uomPerpendicular = uom;
+        baseOrEvaluated.uomGp = uom;
         Continuation<PolygonStyling> contn = null;
 
         while ( !( in.isEndElement() && in.getLocalName().equals( "PolygonSymbolizer" ) ) ) {
@@ -549,6 +586,17 @@ public class SymbologyParser {
             parseCommon( common, in );
 
             if ( in.getLocalName().equals( "Stroke" ) ) {
+                if ( context.strokeParser.getPixelStrokeToken() == true ) {
+                    baseOrEvaluated.uomStroke = Pixel;
+                } else {
+                    baseOrEvaluated.uomStroke = uom;
+                }
+                if ( context.strokeParser.getPixelGapToken() == true ) {
+                    baseOrEvaluated.uomGp = Pixel;
+                } else {
+                    baseOrEvaluated.uomGp = uom;
+                }
+
                 final Pair<Stroke, Continuation<Stroke>> pair = context.strokeParser.parseStroke( in );
 
                 if ( pair != null ) {
@@ -579,11 +627,23 @@ public class SymbologyParser {
                     }
                 }
             } else if ( in.getLocalName().equals( "PerpendicularOffset" ) ) {
+                if ( this.getPixelPerpendicularToken() == true ) {
+                    baseOrEvaluated.uomPerpendicular = Pixel;
+                } else {
+                    baseOrEvaluated.uomPerpendicular = uom;
+                }
                 baseOrEvaluated.perpendicularOffsetType = getPerpendicularOffsetType( in );
                 contn = updateOrContinue( in, "PerpendicularOffset", baseOrEvaluated, new Updater<PolygonStyling>() {
                     @Override
                     public void update( PolygonStyling obj, String val ) {
-                        obj.perpendicularOffset = Double.parseDouble( val );
+                        if ( val.endsWith( "px" ) ) {
+                            String valpx = val.substring( 0, val.length() - 2 );
+                            pixelPerpendicularToken = true;
+                            obj.perpendicularOffset = Double.parseDouble( valpx );
+                        } else {
+                            pixelPerpendicularToken = false;
+                            obj.perpendicularOffset = Double.parseDouble( val );
+                        }
                     }
                 }, contn ).second;
             } else if ( in.getLocalName().equals( "Displacement" ) ) {
@@ -739,10 +799,28 @@ public class SymbologyParser {
         Continuation<StringBuffer> label = null;
         String xmlText = null;
 
+        if ( this.getPixelTextPerpendicularToken() == true ) {
+            baseOrEvaluated.uomPerpendicularOffsetText = Pixel;
+        } else {
+            baseOrEvaluated.uomPerpendicularOffsetText = uom;
+        }
+
         while ( !( in.isEndElement() && in.getLocalName().equals( "TextSymbolizer" ) ) ) {
             in.nextTag();
 
             parseCommon( common, in );
+
+            if ( this.getPixelTextDisplacementXToken() == true ) {
+                baseOrEvaluated.uomDisplacementX = Pixel;
+            } else {
+                baseOrEvaluated.uomDisplacementX = uom;
+            }
+
+            if ( this.getPixelTextDisplacementYToken() == true ) {
+                baseOrEvaluated.uomDisplacementY = Pixel;
+            } else {
+                baseOrEvaluated.uomDisplacementY = uom;
+            }
 
             if ( in.getLocalName().equals( "Label" ) ) {
                 Pair<String, Continuation<StringBuffer>> res = updateOrContinue( in, "Label", new StringBuffer(),
@@ -797,7 +875,15 @@ public class SymbologyParser {
                                                                   new Updater<TextStyling>() {
                                                                       @Override
                                                                       public void update( TextStyling obj, String val ) {
-                                                                          obj.displacementX = Double.parseDouble( val );
+                                                                          if ( val.endsWith( "px" ) ) {
+                                                                              String valpx = val.substring( 0,
+                                                                                                            val.length() - 2 );
+                                                                              pixelTextDisplacementXToken = true;
+                                                                              obj.displacementX = Double.parseDouble( valpx );
+                                                                          } else {
+                                                                              pixelTextDisplacementXToken = false;
+                                                                              obj.displacementX = Double.parseDouble( val );
+                                                                          }
                                                                       }
                                                                   }, contn ).second;
                                     } else if ( in.getLocalName().equals( "DisplacementY" ) ) {
@@ -805,7 +891,15 @@ public class SymbologyParser {
                                                                   new Updater<TextStyling>() {
                                                                       @Override
                                                                       public void update( TextStyling obj, String val ) {
-                                                                          obj.displacementY = Double.parseDouble( val );
+                                                                          if ( val.endsWith( "px" ) ) {
+                                                                              String valpx = val.substring( 0,
+                                                                                                            val.length() - 2 );
+                                                                              pixelTextDisplacementYToken = true;
+                                                                              obj.displacementY = Double.parseDouble( valpx );
+                                                                          } else {
+                                                                              pixelTextDisplacementYToken = false;
+                                                                              obj.displacementY = Double.parseDouble( val );
+                                                                          }
                                                                       }
                                                                   }, contn ).second;
                                     } else if ( in.isStartElement() ) {
@@ -1046,8 +1140,14 @@ public class SymbologyParser {
                 contn = updateOrContinue( in, "PerpendicularOffset", baseOrEvaluated, new Updater<LinePlacement>() {
                     @Override
                     public void update( LinePlacement obj, String val ) {
-                        obj.perpendicularOffset = Double.parseDouble( val );
-
+                        if ( val.endsWith( "px" ) ) {
+                            String valpx = val.substring( 0, val.length() - 2 );
+                            pixelTextPerpendicularToken = true;
+                            obj.perpendicularOffset = Double.parseDouble( valpx );
+                        } else {
+                            pixelTextPerpendicularToken = false;
+                            obj.perpendicularOffset = Double.parseDouble( val );
+                        }
                     }
                 }, contn ).second;
             }
@@ -1067,7 +1167,6 @@ public class SymbologyParser {
                     @Override
                     public void update( LinePlacement obj, String val ) {
                         obj.gap = Double.parseDouble( val );
-
                     }
                 }, contn ).second;
             }
@@ -1344,4 +1443,19 @@ public class SymbologyParser {
 
     }
 
+    public boolean getPixelPerpendicularToken() {
+        return pixelPerpendicularToken;
+    }
+
+    public boolean getPixelTextPerpendicularToken() {
+        return pixelTextPerpendicularToken;
+    }
+
+    public boolean getPixelTextDisplacementXToken() {
+        return pixelTextDisplacementXToken;
+    }
+
+    public boolean getPixelTextDisplacementYToken() {
+        return pixelTextDisplacementYToken;
+    }
 }

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/LineStyling.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/LineStyling.java
@@ -58,6 +58,12 @@ public class LineStyling implements Styling<LineStyling> {
      */
     public UOM uom = Pixel;
 
+    public UOM uomStroke = Pixel;
+
+    public UOM uomPerpendicular = Pixel;
+
+    public UOM uomGp = Pixel;
+
     /**
      * Default is standard gray.
      */
@@ -83,6 +89,9 @@ public class LineStyling implements Styling<LineStyling> {
         copy.perpendicularOffset = perpendicularOffset;
         copy.perpendicularOffsetType = perpendicularOffsetType.copy();
         copy.uom = uom;
+        copy.uomStroke = uomStroke;
+        copy.uomPerpendicular = uomPerpendicular;
+        copy.uomGp = uomGp;
         return copy;
     }
 

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/PolygonStyling.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/PolygonStyling.java
@@ -59,6 +59,12 @@ public class PolygonStyling implements Styling<PolygonStyling> {
      */
     public UOM uom = Pixel;
 
+    public UOM uomStroke = Pixel;
+
+    public UOM uomPerpendicular = Pixel;
+
+    public UOM uomGp = Pixel;
+
     /**
      * Default is null.
      */
@@ -97,6 +103,9 @@ public class PolygonStyling implements Styling<PolygonStyling> {
         copy.perpendicularOffset = perpendicularOffset;
         copy.perpendicularOffsetType = perpendicularOffsetType.copy();
         copy.uom = uom;
+        copy.uomStroke = uomStroke;
+        copy.uomPerpendicular = uomPerpendicular;
+        copy.uomGp = uomGp;
         return copy;
     }
 

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/TextStyling.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/TextStyling.java
@@ -61,6 +61,12 @@ public class TextStyling implements Styling<TextStyling> {
      */
     public UOM uom = Pixel;
 
+    public UOM uomPerpendicularOffsetText = Pixel;
+
+    public UOM uomDisplacementX = Pixel;
+
+    public UOM uomDisplacementY = Pixel;
+
     /**
      * Default is a font with default settings.
      */
@@ -127,6 +133,9 @@ public class TextStyling implements Styling<TextStyling> {
         copy.linePlacement = linePlacement == null ? null : linePlacement.copy();
         copy.halo = halo == null ? null : halo.copy();
         copy.uom = uom;
+        copy.uomPerpendicularOffsetText = uomPerpendicularOffsetText;
+        copy.uomDisplacementX = uomDisplacementX;
+        copy.uomDisplacementY = uomDisplacementY;
         return copy;
     }
 


### PR DESCRIPTION
http://tracker.deegree.org/deegree-services/ticket/411

This feature is part of the OGC Symbology Encoding standard.
With this enhancement is possible to overwrite the unit of measure (attribute "uom") for symbolizers setting the value for "stroke-width" or for the other options using "px" after the number. Ex.:

``` xml
<se:PolygonSymbolizer uom="mm">
    <se:Stroke>
        <se:SvgParameter name="stroke-width">3px</se:SvgParameter>
    </se:Stroke>
</se:PolygonSymbolizer>
```

I implemented this feature for the next symbolizers and options:

PolygonSymbolizer: Stroke-width - PerpendicularOffset - Gap;

LineSymbolizer: Stroke-width - PerpendicularOffset - Gap;

TextSymbolizer: LinePlacement: PerpendicularOffset - PointPlacement: Displacement
