### PR TITLE
Added EPSG:4647 (ETRS89 / UTM zone 32N (zE-N)

### DIFF
--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
@@ -68288,5 +68288,27 @@
                 </crs:Axis>
                 <crs:UsedGeographicCRS>epsg:4761</crs:UsedGeographicCRS>
                 <crs:UsedProjection>epsg:19851</crs:UsedProjection>
-        </crs:ProjectedCRS>                       
+        </crs:ProjectedCRS>
+        <crs:ProjectedCRS>
+                <crs:Id>epsg:4647</crs:Id>
+                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#4647</crs:Id>
+                <crs:Id>urn:ogc:def:crs:epsg::4647</crs:Id>
+                <crs:Id>urn:opengis:def:crs:epsg::4647</crs:Id>
+                <crs:Name>ETRS89 / UTM zone 32N (zE-N)</crs:Name>
+                <crs:Version>2012-11-26</crs:Version>
+                <crs:AreaOfUse>6,47.27,12,55.46</crs:AreaOfUse>
+                <crs:AreaOfUse>Germany - onshore and offshore between 6°E and 12°E, including Mecklenburg-Vorpommern west of 12°E and Schleswig-Holstein.</crs:AreaOfUse>
+                <crs:Axis>
+                        <crs:Name>x</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>east</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:Axis>
+                        <crs:Name>y</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:UsedGeographicCRS>epsg:4258</crs:UsedGeographicCRS>
+                <crs:UsedProjection>epsg:4648</crs:UsedProjection>
+        </crs:ProjectedCRS>
 </crs:CRSDefinitions>

--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
@@ -10789,5 +10789,14 @@
     <crs:ScaleFactor>0.9999</crs:ScaleFactor>
     <crs:FalseEasting>500000.0</crs:FalseEasting>
     <crs:FalseNorthing>0.0</crs:FalseNorthing>
-  </crs:TransverseMercator>  
+  </crs:TransverseMercator>
+  <crs:TransverseMercator>
+    <crs:Id>epsg:4648</crs:Id>
+    <crs:Name>UTM zone 32N with prefix</crs:Name>
+    <crs:LatitudeOfNaturalOrigin>0.0</crs:LatitudeOfNaturalOrigin>
+    <crs:LongitudeOfNaturalOrigin>9.0</crs:LongitudeOfNaturalOrigin>
+    <crs:ScaleFactor>0.9996</crs:ScaleFactor>
+    <crs:FalseEasting>32500000.0</crs:FalseEasting>
+    <crs:FalseNorthing>0.0</crs:FalseNorthing>
+  </crs:TransverseMercator>
 </crs:ProjectionDefinitions>

--- a/deegree-core/deegree-core-cs/src/test/java/org/deegree/cs/transformations/TransformationAccuracyTest.java
+++ b/deegree-core/deegree-core-cs/src/test/java/org/deegree/cs/transformations/TransformationAccuracyTest.java
@@ -36,6 +36,8 @@
 
 package org.deegree.cs.transformations;
 
+import static java.lang.Double.NaN;
+
 import java.util.Collections;
 
 import javax.vecmath.Point3d;
@@ -572,5 +574,25 @@ public class TransformationAccuracyTest extends TransformationAccuracy implement
         Assert.assertEquals( sourcePoint.y, targetPoint.x, 0 );
         Assert.assertEquals( sourcePoint.x, targetPoint.y, 0 );
         Assert.assertEquals( sourcePoint.z, targetPoint.z, 0 );
+    }
+
+    @Test
+    public void testEpsg4647ToEpsg4326()
+                            throws IllegalArgumentException, TransformationException {
+        ICRS sourceCRS = CRSManager.getCRSRef( "epsg:4647" );
+        ICRS targetCRS = CRSManager.getCRSRef( "epsg:4326" );
+        Point3d sourcePoint = new Point3d( 32574177.309926, 6020313.020522, NaN );
+        Point3d targetPoint = new Point3d( 10.140556, 54.325278, NaN );
+        doForwardAndInverse( sourceCRS, targetCRS, sourcePoint, targetPoint, EPSILON_D, EPSILON_M );
+    }
+
+    @Test
+    public void testEpsg4647ToEpsg25832()
+                            throws IllegalArgumentException, TransformationException {
+        ICRS sourceCRS = CRSManager.getCRSRef( "epsg:4647" );
+        ICRS targetCRS = CRSManager.getCRSRef( "epsg:25832" );
+        Point3d sourcePoint = new Point3d( 32574177.309926, 6020313.020522, NaN );
+        Point3d targetPoint = new Point3d( 574177.309926, 6020313.020522, NaN );
+        doForwardAndInverse( sourceCRS, targetCRS, sourcePoint, targetPoint, EPSILON_D, EPSILON_M );
     }
 }


### PR DESCRIPTION
Adds support for EPSG:4647.

http://www.epsg-registry.org/export.htm?gml=urn:ogc:def:crs:EPSG::4647
