### PR TITLE
Missing support for "xml:" namespace added

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/CommonNamespaces.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/CommonNamespaces.java
@@ -190,6 +190,11 @@ public class CommonNamespaces {
     public static final String XMLNS_PREFIX = "xmlns";
 
     /**
+     * The XMLNSNS prefix is always assigned to: "xml"
+     */
+    public static final String XMLNSNS_PREFIX = "xml";
+
+    /**
      * The XS prefix is currently assigned to: "xs"
      */
     public static final String XS_PREFIX = "xs";

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/NamespaceBindings.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/NamespaceBindings.java
@@ -69,8 +69,8 @@ public class NamespaceBindings implements org.jaxen.NamespaceContext, javax.xml.
      * Creates a new instance of {@link NamespaceContext} with no bindings.
      */
     public NamespaceBindings() {
-        // nothing to do
-        // prefixToNs.put( CommonNamespaces.XMLNS_PREFIX, CommonNamespaces.XMLNS );
+    	prefixToNs.put( CommonNamespaces.XMLNSNS_PREFIX, CommonNamespaces.XMLNSNS );
+    	nsToPrefix.put( CommonNamespaces.XMLNSNS, CommonNamespaces.XMLNSNS_PREFIX );
     }
 
     /**
@@ -80,6 +80,8 @@ public class NamespaceBindings implements org.jaxen.NamespaceContext, javax.xml.
      *            bindings to copy, must not be <code>null</code>
      */
     public NamespaceBindings( NamespaceBindings nsContext ) {
+    	this();
+    	
         prefixToNs.putAll( nsContext.prefixToNs );
         nsToPrefix.putAll( nsContext.nsToPrefix );
     }
@@ -92,6 +94,8 @@ public class NamespaceBindings implements org.jaxen.NamespaceContext, javax.xml.
      *            bindings to copy, must not be <code>null</code>
      */
     public NamespaceBindings( javax.xml.namespace.NamespaceContext nsContext, Collection<String> prefixes ) {
+    	this();
+    	
         for ( String prefix : prefixes ) {
             String ns = nsContext.getNamespaceURI( prefix );
             prefixToNs.put( prefix, ns );


### PR DESCRIPTION
Based on a patch I wrote in May 2012. It worked satisfactory back then. Requires additional testing before merging into 3.4 though.

Received confirmation (on the mailing list) that this patch results in the expected behavior.
