### PR TITLE
Support service metadata files in subdirectories

### DIFF
--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/AbstractOWS.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/AbstractOWS.java
@@ -131,17 +131,9 @@ public abstract class AbstractOWS implements OWS {
 
     protected ImplementationMetadata<?> serviceInfo;
 
-    private String configId;
-
     protected AbstractOWS( URL configURL, ImplementationMetadata<?> serviceInfo ) {
         this.configURL = configURL;
         this.serviceInfo = serviceInfo;
-        try {
-            File f = new File( configURL.toURI() );
-            this.configId = f.getName().substring( 0, f.getName().length() - 4 );
-        } catch ( URISyntaxException e ) {
-            // then no configId will be available
-        }
     }
 
     private static List<SerializerProvider> exceptionSerializers = new ArrayList<SerializerProvider>();
@@ -180,8 +172,24 @@ public abstract class AbstractOWS implements OWS {
         return serviceInfo;
     }
 
-    public String getId() {
-        return configId;
+    /**
+     * Returns the resource id of this {@link AbstractOWS}.
+     * 
+     * @return resource id, never <code>null</code>
+     * @throws ResourceInitException
+     *             if the id can not be derived from the config URL
+     */
+    protected String getId()
+                            throws ResourceInitException {
+        try {
+            final File wsDir = new File( workspace.getLocation(), "services" );
+            final File configFile = new File( configURL.toURI() );
+            final String relative = wsDir.toURI().relativize( configFile.toURI() ).getPath();
+            return relative.substring( 0, relative.lastIndexOf( '.' ) );
+        } catch ( URISyntaxException e ) {
+            final String msg = "Unable to determine service id from config URL: " + e.getMessage();
+            throw new ResourceInitException( msg );
+        }
     }
 
     /**


### PR DESCRIPTION
Consider a deegree INSPIRE workspace with several WMS and WFS instances:
- workspaces/inspire/services/inspire/ad/wfs.xml
- workspaces/inspire/services/inspire/ad/wfs_metadata.xml
- workspaces/inspire/services/inspire/ad/wms.xml
- workspaces/inspire/services/inspire/ad/wms_metadata.xml
- workspaces/inspire/services/inspire/cp/wfs.xml
- workspaces/inspire/services/inspire/cp/wfs_metadata.xml
- workspaces/inspire/services/inspire/cp/wms.xml
- workspaces/inspire/services/inspire/cp/wms_metadata.xml

In the use-cas, it is important to have separate services for each inspire theme. For WMS, the GetCapabilities request returns a document with the data from the correct wms_metadata.xml. The problem is that for WFS it does not seem to use the wfs_metadata.xml from the corresponding directory. The WFS GetCapabilities document contains some default values for metadata.

Currently, when a wfs_metadata.xml is put in the directory workspaces/inspire/services/, that file is picked up by both AD and CP WFS capabilities. This patch fixes that behavior.

Note that a patch for 3.4 is not required, as this already works as expected. This is an effect of the workspace reimplementation.
