### PR TITLE
adding missing Content-Type header for WMTS GetTile response

### DIFF
--- a/deegree-services/deegree-services-wmts/src/main/java/org/deegree/services/wmts/controller/TileHandler.java
+++ b/deegree-services/deegree-services-wmts/src/main/java/org/deegree/services/wmts/controller/TileHandler.java
@@ -113,6 +113,7 @@ class TileHandler {
         if ( !tds.getNativeImageFormat().equals( format ) ) {
             throw new OWSException( "Unknown format: " + format, INVALID_PARAMETER_VALUE );
         }
+        response.setContentType( format );
 
         TileDataLevel level = tds.getTileDataLevel( op.getTileMatrix() );
         if ( level == null ) {


### PR DESCRIPTION
before (http is the [httpie](https://github.com/jakubroztocil/httpie/) tool)

``` bash
$ http "http://localhost:8080/deegree-webservices/services/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=basemap&STYLE=default&TILEMATRIXSET=inspirecrs84quad&TILEMATRIX=272989.3867327723&TILEROW=221&TILECOL=1101&FORMAT=image%2Fpng"
HTTP/1.1 200 OK
Cache-Control: no-cache, no-store
Date: Fri, 06 Jun 2014 10:01:34 GMT
Server: Apache-Coyote/1.1
Transfer-Encoding: chunked
deegree-version: 3.3.9

[…]
```

and after

``` bash
$ http "http://localhost:8080/deegree-webservices/services/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=basemap&STYLE=default&TILEMATRIXSET=inspirecrs84quad&TILEMATRIX=272989.3867327723&TILEROW=221&TILECOL=1101&FORMAT=image%2Fpng" 
HTTP/1.1 200 OK
Cache-Control: no-cache, no-store
Content-Type: image/png
Date: Fri, 06 Jun 2014 10:04:28 GMT
Server: Apache-Coyote/1.1
Transfer-Encoding: chunked
deegree-version: 3.3.9

[…]
```

Clients like QGIS (tested with version 2.2.0) refuse to show tiles without Content-Type in the http header.
