### PR TITLE
Query without order by returns unspecified order

### DIFF
--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/QueryHelper.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/QueryHelper.java
@@ -106,9 +106,13 @@ class QueryHelper extends SqlHelper {
             }
 
             getPSBody( builder, idSelect );
+            idSelect.append( " ORDER BY " );
             if ( builder.getOrderBy() != null ) {
-                idSelect.append( " ORDER BY " );
                 idSelect.append( builder.getOrderBy().getSQL() );
+            }
+            else
+            {
+                idSelect.append( idColumn );
             }
 
             if ( query != null && query.getStartPosition() != 1 && dialect instanceof PostGISDialect ) {


### PR DESCRIPTION
While working with the Deegree metadata store in our database we discovered, when we are using

harvesting that we got back duplicate records via getRecords.
This happened because paginiation is used, requesting 20 records each time.

This resulted in the next queries to the database:
SELECT recordfull FROM idxtb_main A INNER JOIN (SELECT DISTINCT X1.id FROM idxtb_main X1 LIMIT 20) B ON A.id=B.id
SELECT recordfull FROM idxtb_main A INNER JOIN (SELECT DISTINCT X1.id FROM idxtb_main X1 ORDER BY id OFFSET 20 LIMIT 20) B ON A.id=B.id

Because postgres returns result in a unspecified order, and because there is no order by (Which specifies order),
records are returned twice (Or more).

This change adds a ORDER BY to the inner join.

Before this change, of 96 of the 132 unique records in my database were returned by deegree
After this change, all 132 records are returned.
