### PR TITLE
3.3 master ogcschemaloc fix

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
@@ -108,6 +108,8 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
     private static final Logger LOG = LoggerFactory.getLogger( GmlDescribeFeatureTypeHandler.class );
 
     private static final String APPSCHEMAS = "appschemas";
+    
+    private static final String OGC_SCHEMA_HOST = "http://schemas.opengis.net";
 
     // URL of workspace appschema directory
     private String wsAppSchemaBaseURL;
@@ -132,6 +134,8 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
         URL baseUrl = DescribeFeatureType.class.getResource( "/META-INF/SCHEMAS_OPENGIS_NET" );
         if ( baseUrl != null ) {
             this.ogcSchemaJarBaseURL = baseUrl.toString();
+            LOG.debug( "GmlDescribeFeatureTypeHandler OGC Schema Jar Base URL: '" + this.ogcSchemaJarBaseURL + "'" );
+            
         }
     }
 
@@ -231,13 +235,37 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
                     return options.getAppSchemaBaseURL() + "/" + relativePath;
                 }
                 if ( uri.startsWith( ogcSchemaJarBaseURL ) ) {
-                    return "http://schemas.opengis.net" + uri.substring( ogcSchemaJarBaseURL.length() );
+                    return translateOGCSchemaLocation( uri );
                 }
                 return uri;
             }
         } );
     }
 
+    /**
+     * Helper method to translate the internal URI given into a remote OGC Schema location. 
+     * This method ensures there's a starting "/" in the path.
+     * @param uri The URI String to translate
+     * @return The "remote" OGC Schema location.
+     */
+    private String translateOGCSchemaLocation(String uri){
+        
+        StringBuilder ogcSchemaLocation = new StringBuilder(OGC_SCHEMA_HOST);
+        String ogcSchemaPath = uri.substring( ogcSchemaJarBaseURL.length() );
+        if(!ogcSchemaPath.startsWith( "/" ))
+        {
+            ogcSchemaLocation.append("/");
+            LOG.debug( "OGC Schema path from internal Jar did not include starting '/'. Path: '" + ogcSchemaPath + "'. Prefixed with '/' to complete URL...." );
+        }
+        ogcSchemaLocation.append( ogcSchemaPath );
+
+        LOG.debug( "Translated OGC Schema Jar URL to schemaLocation: '" + ogcSchemaLocation + "'" );
+        
+        return ogcSchemaLocation.toString();
+        // Old behaviour
+        // return "http://schemas.opengis.net" + uri.substring( ogcSchemaJarBaseURL.length() );
+    }
+    
     private void writeWFSSchema( XMLStreamWriter writer, Version version, GMLVersion gmlVersion )
                             throws XMLStreamException {
 


### PR DESCRIPTION
As requested, an additional pull request on 3.3-master for the schema location fix:
"This fix ensures that the starting '/' is not missing in the schemalocation path when translating internal OGC schema location into external OGC schema location.
When running deegree 3.3.8 on EAP 6.2 (JBoss 7.x), as a compressed WAR, we experiences problems with the translated OGC Schema location. The starting '/' in the path was missing, causing the generated schema to not validate. 
E.g. The schemalocation for "extdBaseTypes.xsd" was printed as "http://schemas.opengis.netgml/3.3/extdBaseTypes.xsd" in the DescribeFeature response.

The code in master is the same for this translation as in tag 3.3.8, hence the pull request on master."
