### PR TITLE
Missing User-Agent header results in NullPointerException

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController111.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController111.java
@@ -101,7 +101,7 @@ public class WMSController111 extends WMSControllerBase {
         response.setContentType( "application/vnd.ogc.wms_xml" );
         String userAgent = OGCFrontController.getContext().getUserAgent();
 
-        if ( userAgent.toLowerCase().contains( "mozilla" ) ) {
+        if ( userAgent != null && userAgent.toLowerCase().contains( "mozilla" ) ) {
             response.setContentType( "application/xml" );
         }
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController130.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController130.java
@@ -94,7 +94,7 @@ public class WMSController130 extends WMSControllerBase {
         response.setContentType( "text/xml" );
         String userAgent = OGCFrontController.getContext().getUserAgent();
 
-        if ( userAgent.toLowerCase().contains( "mozilla" ) ) {
+        if ( userAgent != null && userAgent.toLowerCase().contains( "mozilla" ) ) {
             response.setContentType( "application/xml" );
         }
 


### PR DESCRIPTION
This pull requests contains a patch to avoid a NullPointerException when the User-Agent header is missing.
