### PR TITLE
SQLFeatureStore: trying to remove attribute from feature results in NullPointerException

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
@@ -837,21 +837,25 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
                 if ( mapping.getJoinedTable() != null && !mapping.getJoinedTable().isEmpty() ) {
                     continue;
                 }
-                ParticleConverter<TypedObjectNode> converter = (ParticleConverter<TypedObjectNode>) fs.getConverter( mapping );
-                if ( mapping instanceof PrimitiveMapping ) {
-                    MappingExpression me = ( (PrimitiveMapping) mapping ).getMapping();
-                    if ( !( me instanceof DBField ) ) {
-                        continue;
+                
+                Object value = replacementProp.getValue();
+                if ( value != null ) {                
+                    ParticleConverter<TypedObjectNode> converter = (ParticleConverter<TypedObjectNode>) fs.getConverter( mapping );
+                    if ( mapping instanceof PrimitiveMapping ) {
+                        MappingExpression me = ( (PrimitiveMapping) mapping ).getMapping();
+                        if ( !( me instanceof DBField ) ) {
+                            continue;
+                        }
+                        converter.setParticle( stmt, (PrimitiveValue) value, i++ );
+                    } else if ( mapping instanceof GeometryMapping ) {
+                        MappingExpression me = ( (GeometryMapping) mapping ).getMapping();
+                        if ( !( me instanceof DBField ) ) {
+                            continue;
+                        }
+                        converter.setParticle( stmt, (Geometry) value, i++ );
                     }
-                    PrimitiveValue value = (PrimitiveValue) replacementProp.getValue();
-                    converter.setParticle( stmt, value, i++ );
-                } else if ( mapping instanceof GeometryMapping ) {
-                    MappingExpression me = ( (GeometryMapping) mapping ).getMapping();
-                    if ( !( me instanceof DBField ) ) {
-                        continue;
-                    }
-                    Geometry value = (Geometry) replacementProp.getValue();
-                    converter.setParticle( stmt, value, i++ );
+                } else {
+                    stmt.setObject( i++, null );
                 }
             }
         }


### PR DESCRIPTION
It is possible to remove a feature attribute by performing an update transaction that doesn't include a value for that attribute:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<wfs:Transaction service="WFS" version="1.1.0"
    xmlns:app="http://www.deegree.org/app"
    xmlns:ogc="http://www.opengis.net/ogc"
    xmlns:wfs="http://www.opengis.net/wfs">
    <wfs:Update typeName="app:test">
        <wfs:Property>
            <wfs:Name>app:additionalInfo</wfs:Name>
        </wfs:Property>
        <ogc:Filter>
            <ogc:FeatureId fid="APP_TEST_1"/>
        </ogc:Filter>
    </wfs:Update>
</wfs:Transaction>
```

Within the SQLFeatureStore, this currently results in a NullPointerException. The patch proposed in this pull requests correctly implements this case.
