### PR TITLE
Fix well formed XML

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/renderstyles.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/renderstyles.rst
@@ -419,7 +419,7 @@ ________________
           </ogc:Filter>
           <PointSymbolizer>
             <Graphic>
-              <Mark
+              <Mark>
                 <WellKnownName>square</WellKnownName>
                 <Fill>
                   <SvgParameter name="fill">#FF0000</SvgParameter>


### PR DESCRIPTION
I fixed an incorrect example. The well-formed XML example PointSymbolizer is processed correctly in the deegree configuration.
