### PR TITLE
FilteringXMLStreamWriter: Fix missing XML namespace bindings in output

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/FilteringXMLStreamWriter.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/FilteringXMLStreamWriter.java
@@ -343,19 +343,25 @@ public class FilteringXMLStreamWriter implements XMLStreamWriter {
     @Override
     public void setPrefix( String prefix, String uri )
                             throws XMLStreamException {
-        writer.setPrefix( prefix, uri );
+        if ( isWriting ) {
+            writer.setPrefix( prefix, uri );
+        }
     }
 
     @Override
     public void setDefaultNamespace( String uri )
                             throws XMLStreamException {
-        writer.setDefaultNamespace( uri );
+        if ( isWriting ) {
+            writer.setDefaultNamespace( uri );
+        }
     }
 
     @Override
     public void setNamespaceContext( NamespaceContext context )
                             throws XMLStreamException {
-        writer.setNamespaceContext( context );
+        if ( isWriting ) {
+            writer.setNamespaceContext( context );
+        }
     }
 
     @Override

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/xml/stax/FilteringXMLStreamWriterTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/xml/stax/FilteringXMLStreamWriterTest.java
@@ -36,16 +36,20 @@
 package org.deegree.commons.xml.stax;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.commons.io.IOUtils;
 import org.deegree.commons.xml.NamespaceBindings;
+import org.deegree.commons.xml.XMLAdapter;
 import org.deegree.commons.xml.XPath;
 import org.junit.Assert;
 import org.junit.Test;
@@ -165,4 +169,18 @@ public class FilteringXMLStreamWriterTest {
         Assert.assertEquals( 0, actual.length );
     }
 
+    @Test
+    public void testFilteringXPathSetPrefixBug()
+                            throws Exception {
+        final XMLAdapter input = new XMLAdapter( FilteringXMLStreamWriterTest.class.getResourceAsStream( "filtering_xpath_set_prefix.xml" ) );
+        final List<String> list = new ArrayList<String>();
+        list.add( "/app:a/nix:d" );
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        final XMLStreamWriter writer = getWriter( list, bos );
+        input.getRootElement().serialize( writer );
+        writer.close();
+        byte[] actual = bos.toByteArray();
+        byte[] expected = IOUtils.toByteArray( FilteringXMLStreamWriterTest.class.getResourceAsStream( "filtering_xpath_set_prefix_expected.xml" ) );
+        Assert.assertArrayEquals( expected, actual );
+    }
 }

--- a/deegree-core/deegree-core-commons/src/test/resources/org/deegree/commons/xml/stax/filtering_xpath_set_prefix.xml
+++ b/deegree-core/deegree-core-commons/src/test/resources/org/deegree/commons/xml/stax/filtering_xpath_set_prefix.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<app:a xmlns:app="http://www.deegree.org/app">
+  <nix:c xmlns:nix="http://www.deegree.org/nix" />
+  <nix:d xmlns:nix="http://www.deegree.org/nix" />
+</app:a>

--- a/deegree-core/deegree-core-commons/src/test/resources/org/deegree/commons/xml/stax/filtering_xpath_set_prefix_expected.xml
+++ b/deegree-core/deegree-core-commons/src/test/resources/org/deegree/commons/xml/stax/filtering_xpath_set_prefix_expected.xml
@@ -1,0 +1,6 @@
+<app:a xmlns:app="http://www.deegree.org/app">
+  
+  
+  <nix:d xmlns:nix="http://www.deegree.org/nix"/>
+
+</app:a>


### PR DESCRIPTION
In some cases, this bug caused missing XML namespace bindings in CSW-GetRecords responses.

3.4 version: #315.
