### PR TITLE
OGC GeoPackage implementation - 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 
 *.iml
 .idea
+.metadata

--- a/deegree-client/deegree-jsf-console/pom.xml
+++ b/deegree-client/deegree-jsf-console/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-jsf-console</artifactId>
   <packaging>jar</packaging>
@@ -12,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -109,10 +110,15 @@
       <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-sql</artifactId>
       <version>${project.version}</version>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.deegree</groupId>
       <artifactId>deegree-sqldialect-postgis</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-tilestore-gpkg</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/deegree-client/deegree-jsf-console/src/main/java/org/deegree/console/jdbc/JdbcBean.java
+++ b/deegree-client/deegree-jsf-console/src/main/java/org/deegree/console/jdbc/JdbcBean.java
@@ -91,6 +91,10 @@ public class JdbcBean {
             dbConn = "jdbc:postgresql://" + dbHost + ":" + dbPort + "/" + dbName;
             return;
         }
+        if ( dbType.equals( "geopackage" ) ) {
+            dbConn = "jdbc:sqlite:" + dbName;
+            return;
+        }
     }
 
     public void setDbPort( String dbPort ) {
@@ -143,6 +147,10 @@ public class JdbcBean {
                 dbPort = "5432";
             }
             dbConn = "jdbc:postgresql://" + dbHost + ":" + dbPort + "/" + dbName;
+            return;
+        }
+        if ( dbType.equals( "geopackage" ) ) {
+            dbConn = "jdbc:sqlite:" + dbName;
             return;
         }
     }

--- a/deegree-client/deegree-jsf-console/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.gpkg.GpkgTileStoreProvider
+++ b/deegree-client/deegree-jsf-console/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.gpkg.GpkgTileStoreProvider
@@ -1,0 +1,2 @@
+name=GpkgTileStore
+example1_location=/META-INF/schemas/datasource/tile/gpkg/3.2.0/example.xml

--- a/deegree-client/deegree-jsf-console/src/main/webapp/console/jdbc/edit.xhtml
+++ b/deegree-client/deegree-jsf-console/src/main/webapp/console/jdbc/edit.xhtml
@@ -1,71 +1,96 @@
-<ui:composition template="/layout.xhtml" xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:c="http://java.sun.com/jsp/jstl/core" xmlns:fn="http://java.sun.com/jsp/jstl/functions" xmlns:dg="http://deegree.org/jsf" xmlns:dgc="http://java.sun.com/jsf/composite/deegree">
+<ui:composition template="/layout.xhtml" xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core"
+  xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:c="http://java.sun.com/jsp/jstl/core" xmlns:fn="http://java.sun.com/jsp/jstl/functions"
+  xmlns:dg="http://deegree.org/jsf" xmlns:dgc="http://java.sun.com/jsf/composite/deegree">
   <ui:define name="center">
     <h:panelGroup rendered="#{!logBean.loggedIn}">
       <ui:include src="/console/jsf/accessForbidden.xhtml" />
     </h:panelGroup>
     <h:panelGroup rendered="#{logBean.loggedIn}">
-      <fieldset class="fieldset"><legend> <h:outputText styleClass="titel" value="jdbc" /> </legend> <h:form>
-        <table style="font-size: small" border="0">
-          <tr>
-            <td />
-          </tr>
-          <h:commandButton styleClass="buttonEdit" value="Use XML editor" action="#{jdbcBean.editAsXml}"></h:commandButton>
-          <tr>
-            <td />
-          </tr>
-          <tr>
-            <td><h:outputText value="DB type: " /></td>
-            <td><h:selectOneMenu styleClass="liste" value="#{jdbcBean.dbType}">
-              <f:selectItem itemValue="mssql" itemLabel="MSSQL" />
-              <f:selectItem itemValue="oracle" itemLabel="Oracle" />
-              <f:selectItem itemValue="postgis" itemLabel="PostGIS" />
-              <f:ajax render="dbConn dbPort" />
-            </h:selectOneMenu></td>
-          </tr>
-          <tr>
-            <td><h:outputText value="Host: " /></td>
-            <td><h:inputText id="dbHost" size="25" required="true" requiredMessage="#{labels.jdbc_edit_host_req}" value="#{jdbcBean.dbHost}">
-              <f:ajax render="dbConn" />
-            </h:inputText> <h:outputText value=" Port: " /> <h:inputText id="dbPort" size="5" required="true" requiredMessage="#{labels.jdbc_edit_port_req}" value="#{jdbcBean.dbPort}">
-              <f:validateLongRange minimum="0" maximum="65535" />
-              <f:ajax render="dbConn" />
-            </h:inputText></td>
-          </tr>
-          <tr>
-            <td><h:outputText value="DB name: " /></td>
-            <td><h:inputText id="dbName" size="25" required="true" requiredMessage="#{labels.jdbc_edit_dbname_req}" value="#{jdbcBean.dbName}">
-              <f:ajax render="dbConn" />
-            </h:inputText></td>
-          </tr>
-          <tr>
-            <td><h:outputText value="Username: " /></td>
-            <td><h:inputText id="dbUser" size="25" required="true" requiredMessage="#{labels.jdbc_edit_user_req}" value="#{jdbcBean.dbUser}">
-              <f:ajax render="dbConn" />
-            </h:inputText></td>
-          </tr>
-          <tr>
-            <td><h:outputText value="Password: " /></td>
-            <td><h:inputText id="dbPwd" size="10" value="#{jdbcBean.dbPwd}">
-              <f:ajax render="dbConn" />
-            </h:inputText></td>
-          </tr>
-          <tr>
-            <td><h:outputText value="jdbc URL: " /></td>
-            <td><h:inputText id="dbConn" size="50" required="true" requiredMessage="#{labels.jdbc_edit_conn_req}" redisplay="false" value="#{jdbcBean.dbConn}" /></td>
-          </tr>
-          <tr>
-            <td><br />
-            <h:commandButton styleClass="buttonInfo" value="#{labels.jdbc_test}" action="#{jdbcBean.testConnection}" alt="#{config.id}">
-            </h:commandButton></td>
-          </tr>
-        </table>
-        <br />
-        <div><h:commandButton styleClass="buttonCreateNew" value="Create" action="#{jdbcBean.save}">
-          <f:setPropertyActionListener target="#{actionParams.param1}" value="#{config.id}" />
-        </h:commandButton> <h:outputLink styleClass="buttonCancel" value="../../#{configManager.currentResourceManager.startView}.jsf" action="#{jdbcBean.cancel}">
-          <h:outputText value="Cancel" />
-        </h:outputLink></div>
-      </h:form></fieldset>
+      <fieldset class="fieldset">
+        <legend>
+          <h:outputText styleClass="titel" value="jdbc" />
+        </legend>
+        <h:form>
+          <table style="font-size: small" border="0">
+            <tr>
+              <td />
+            </tr>
+            <h:commandButton styleClass="buttonEdit" value="Use XML editor" action="#{jdbcBean.editAsXml}"></h:commandButton>
+            <tr>
+              <td />
+            </tr>
+            <tr>
+              <td><h:outputText value="DB type: " /></td>
+              <td><h:selectOneMenu styleClass="liste" value="#{jdbcBean.dbType}">
+                  <f:selectItem itemValue="mssql" itemLabel="MSSQL" />
+                  <f:selectItem itemValue="oracle" itemLabel="Oracle" />
+                  <f:selectItem itemValue="postgis" itemLabel="PostGIS" />
+                  <f:selectItem itemValue="geopackage" itemLabel="GeoPackage" />
+                  <f:ajax render="fields dbConn dbPort" />
+                </h:selectOneMenu></td>
+            </tr>
+          </table>
+          <h:panelGroup id="fields">
+            <table>
+              <tr>
+                <td><h:outputText value="Host: "
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}" /></td>
+                <td><h:inputText id="dbHost" size="25" required="false" requiredMessage="#{labels.jdbc_edit_host_req}" value="#{jdbcBean.dbHost}"
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}">
+                    <f:ajax render="dbConn" />
+                  </h:inputText> <h:outputText value=" Port: " rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}" />
+                  <h:inputText id="dbPort" size="5" required="false" requiredMessage="#{labels.jdbc_edit_port_req}" value="#{jdbcBean.dbPort}"
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}">
+                    <f:validateLongRange minimum="0" maximum="65535" />
+                    <f:ajax render="dbConn" />
+                  </h:inputText></td>
+              </tr>
+              <tr>
+                <td><h:outputText value="DB name: "
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}" /> <h:outputText
+                    value="Path to file: " rendered="#{jdbcBean.dbType == 'geopackage'}" /></td>
+                <td><h:inputText id="dbName" size="25" required="true" requiredMessage="#{labels.jdbc_edit_dbname_req}" value="#{jdbcBean.dbName}">
+                    <f:ajax render="dbConn" />
+                  </h:inputText></td>
+              </tr>
+              <tr>
+                <td><h:outputText value="Username: "
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}" /></td>
+                <td><h:inputText id="dbUser" size="25" required="true" requiredMessage="#{labels.jdbc_edit_user_req}" value="#{jdbcBean.dbUser}"
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}">
+                    <f:ajax render="dbConn" />
+                  </h:inputText></td>
+              </tr>
+              <tr>
+                <td><h:outputText value="Password: "
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}" /></td>
+                <td><h:inputText id="dbPwd" size="10" value="#{jdbcBean.dbPwd}"
+                    rendered="#{jdbcBean.dbType == 'mssql' or jdbcBean.dbType == 'oracle' or jdbcBean.dbType == 'postgis'}">
+                    <f:ajax render="dbConn" />
+                  </h:inputText></td>
+              </tr>
+              <tr>
+                <td><h:outputText value="jdbc URL: " /></td>
+                <td><h:inputText id="dbConn" size="50" required="true" requiredMessage="#{labels.jdbc_edit_conn_req}" redisplay="false"
+                    value="#{jdbcBean.dbConn}" /></td>
+              </tr>
+              <tr>
+                <td><br /> <h:commandButton styleClass="buttonInfo" value="#{labels.jdbc_test}" action="#{jdbcBean.testConnection}" alt="#{config.id}">
+                  </h:commandButton></td>
+              </tr>
+            </table>
+          </h:panelGroup>
+          <br />
+          <div>
+            <h:commandButton styleClass="buttonCreateNew" value="Create" action="#{jdbcBean.save}">
+              <f:setPropertyActionListener target="#{actionParams.param1}" value="#{config.id}" />
+            </h:commandButton>
+            <h:outputLink styleClass="buttonCancel" value="../../#{configManager.currentResourceManager.startView}.jsf" action="#{jdbcBean.cancel}">
+              <h:outputText value="Cancel" />
+            </h:outputLink>
+          </div>
+        </h:form>
+      </fieldset>
     </h:panelGroup>
   </ui:define>
 </ui:composition>

--- a/deegree-client/deegree-jsf-core/pom.xml
+++ b/deegree-client/deegree-jsf-core/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-client/deegree-wps-webclient/pom.xml
+++ b/deegree-client/deegree-wps-webclient/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-client/deegree-wpsprinter-webclient/pom.xml
+++ b/deegree-client/deegree-wpsprinter-webclient/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-client/pom.xml
+++ b/deegree-client/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-3d/pom.xml
+++ b/deegree-core/deegree-core-3d/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-annotations/pom.xml
+++ b/deegree-core/deegree-core-annotations/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-base/pom.xml
+++ b/deegree-core/deegree-core-base/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-core-commons</artifactId>
   <name>deegree-core-commons</name>
@@ -12,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -110,6 +111,10 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/ConnectionManager.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/ConnectionManager.java
@@ -44,6 +44,7 @@ import static org.deegree.commons.jdbc.ConnectionManager.Type.H2;
 import static org.deegree.commons.jdbc.ConnectionManager.Type.MSSQL;
 import static org.deegree.commons.jdbc.ConnectionManager.Type.Oracle;
 import static org.deegree.commons.jdbc.ConnectionManager.Type.PostgreSQL;
+import static org.deegree.commons.jdbc.ConnectionManager.Type.GeoPackage;
 
 import java.io.File;
 import java.net.URL;
@@ -76,14 +77,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Manages the {@link ConnectionPools} of a {@link DeegreeWorkspace}.
+ * Manages the {@link ConnectionPool} of a {@link DeegreeWorkspace}.
  * <p>
  * TODO complete separation of JDBC parameter definition ({@link JDBCParams}) and connection pooling
  * </p>
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author: schneider $
- * 
  * @version $Revision: $, $Date: $
  */
 public class ConnectionManager extends AbstractBasicResourceManager implements ResourceProvider {
@@ -97,12 +97,12 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
     private static Map<String, ConnectionPool> idToPools = new HashMap<String, ConnectionPool>();
 
     public static enum Type {
-        PostgreSQL, MSSQL, Oracle, H2
+        PostgreSQL, MSSQL, Oracle, H2, GeoPackage
     }
 
     /**
      * Initializes the {@link ConnectionManager} by loading all JDBC pool configurations from the given directory.
-     * 
+     *
      * @param jdbcDir
      */
     @SuppressWarnings("unchecked")
@@ -154,7 +154,7 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
     /**
      * @param id
      * @return the type of the connection, null if the connection is unknown or the connection type could not be
-     *         determined
+     * determined
      */
     public Type getType( String id ) {
         return idToType.get( id );
@@ -162,9 +162,8 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
 
     /**
      * Returns a connection from the connection pool with the given id.
-     * 
-     * @param id
-     *            id of the connection pool
+     *
+     * @param id id of the connection pool
      * @return connection from the corresponding connection pool, null, if not available
      */
     public Connection get( String id ) {
@@ -184,12 +183,10 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
 
     /**
      * Returns a connection from the connection pool with the given id.
-     * 
-     * @param id
-     *            id of the connection pool
+     *
+     * @param id id of the connection pool
      * @return connection from the corresponding connection pool
-     * @throws SQLException
-     *             if the connection pool is unknown or a SQLException occurs creating the connection
+     * @throws SQLException if the connection pool is unknown or a SQLException occurs creating the connection
      */
     public static Connection getConnection( String id )
                             throws SQLException {
@@ -203,11 +200,9 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
 
     /**
      * Invalidates a broken {@link Connection} to avoid its re-use.
-     * 
-     * @param id
-     *            connection pool id, must not be <code>null</code>
-     * @param conn
-     *            connection, must not be <code>null</code>
+     *
+     * @param id   connection pool id, must not be <code>null</code>
+     * @param conn connection, must not be <code>null</code>
      * @throws Exception
      */
     public static void invalidate( String id, Connection conn )
@@ -220,11 +215,10 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
 
     /**
      * Adds the connection pool defined in the given file.
-     * 
+     *
      * @param connId
      * @param params
-     * @param workspace
-     *            can be <code>null</code>
+     * @param workspace can be <code>null</code>
      * @throws JAXBException
      */
     public void addPool( String connId, JDBCParams params, DeegreeWorkspace workspace ) {
@@ -265,11 +259,14 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
         if ( url.startsWith( "jdbc:sqlserver:" ) ) {
             idToType.put( connId, MSSQL );
         }
+        if ( url.startsWith( "jdbc:sqlite:" ) ) {
+            idToType.put( connId, GeoPackage );
+        }
     }
 
     /**
      * Adds a connection pool as specified in the parameters.
-     * 
+     *
      * @param connId
      * @param url
      * @param user
@@ -370,7 +367,7 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
     @Override
     public ResourceState deleteResource( String id ) {
         throw new UnsupportedOperationException(
-                                                 "Deleting of connection pools not supported. Deleted JDBCParams resource instead." );
+                                "Deleting of connection pools not supported. Deleted JDBCParams resource instead." );
     }
 
     @Override
@@ -383,7 +380,7 @@ public class ConnectionManager extends AbstractBasicResourceManager implements R
     @Override
     public ResourceState activate( String id ) {
         throw new UnsupportedOperationException(
-                                                 "Activating of connection pools not supported. Activate JDBCParams resource instead." );
+                                "Activating of connection pools not supported. Activate JDBCParams resource instead." );
     }
 
     @Override

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/param/JDBCParamsManager.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/param/JDBCParamsManager.java
@@ -65,10 +65,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Manages the {@link JDBCParams} resources in a {@link DeegreeWorkspace}.
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
- * 
  * @version $Revision$, $Date$
  */
 @SuppressWarnings("unchecked")
@@ -84,12 +83,13 @@ public class JDBCParamsManager extends AbstractResourceManager<JDBCParams> {
         try {
             for ( Driver d : ServiceLoader.load( Driver.class, workspace.getModuleClassLoader() ) ) {
                 registerDriver( new DriverWrapper( d ) );
+                registerDriver( new DriverWrapper( new org.sqlite.JDBC() ) );
                 LOG.info( "Found and loaded {}", d.getClass().getName() );
             }
         } catch ( SQLException e ) {
             LOG.debug( "Unable to load driver: {}", e.getLocalizedMessage() );
         }
-        System.out.println(workspace);
+        System.out.println( workspace );
         super.startup( workspace );
     }
 
@@ -141,6 +141,7 @@ public class JDBCParamsManager extends AbstractResourceManager<JDBCParams> {
             try {
                 // no need to check for class loader, the driver manager does that already
                 DriverManager.deregisterDriver( driver );
+                DriverManager.deregisterDriver( new org.sqlite.JDBC() );
             } catch ( SQLException e1 ) {
                 LOG.error( "Cannot unload driver: " + driver );
             }

--- a/deegree-core/deegree-core-coverage/pom.xml
+++ b/deegree-core/deegree-core-coverage/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-cs/pom.xml
+++ b/deegree-core/deegree-core-cs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-feature/pom.xml
+++ b/deegree-core/deegree-core-feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-featureinfo/pom.xml
+++ b/deegree-core/deegree-core-featureinfo/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-filter/pom.xml
+++ b/deegree-core/deegree-core-filter/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-filterfunctions/pom.xml
+++ b/deegree-core/deegree-core-filterfunctions/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-layer/pom.xml
+++ b/deegree-core/deegree-core-layer/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-metadata/pom.xml
+++ b/deegree-core/deegree-core-metadata/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wmts/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wmts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-protocol/pom.xml
+++ b/deegree-core/deegree-core-protocol/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-commons/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-remoteows/pom.xml
+++ b/deegree-core/deegree-core-remoteows/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-rendering-2d/pom.xml
+++ b/deegree-core/deegree-core-rendering-2d/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>deegree-sqldialect-gpkg</artifactId>
+  <name>deegree-sqldialect-gpkg</name>
+  <packaging>jar</packaging>
+  <description>SQL dialect for GeoPackage</description>
+
+  <properties>
+    <deegree.module.status>rework</deegree.module.status>
+  </properties>
+
+  <parent>
+    <groupId>org.deegree</groupId>
+    <artifactId>deegree-core-sqldialect</artifactId>
+    <version>3.3.12-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>deegree-repo</id>
+      <url>http://repo.deegree.org/content/groups/public</url>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-sqldialect-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgDialect.java
@@ -1,0 +1,174 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.sqldialect.gpkg;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.deegree.commons.jdbc.ConnectionManager.Type;
+import org.deegree.commons.jdbc.SQLIdentifier;
+import org.deegree.commons.jdbc.TableName;
+import org.deegree.commons.tom.primitive.PrimitiveType;
+import org.deegree.commons.tom.sql.DefaultPrimitiveConverter;
+import org.deegree.commons.tom.sql.PrimitiveParticleConverter;
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.filter.FilterEvaluationException;
+import org.deegree.filter.OperatorFilter;
+import org.deegree.filter.sort.SortProperty;
+import org.deegree.geometry.Envelope;
+import org.deegree.geometry.utils.GeometryParticleConverter;
+import org.deegree.sqldialect.SQLDialect;
+import org.deegree.sqldialect.filter.AbstractWhereBuilder;
+import org.deegree.sqldialect.filter.PropertyNameMapper;
+import org.deegree.sqldialect.filter.UnmappableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link SQLDialect} for GeoPackage databases.
+ * 
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+public class GpkgDialect implements SQLDialect {
+
+    private static Logger LOG = LoggerFactory.getLogger( GpkgDialect.class );
+
+    @Override
+    public Type getDBType() {
+        return Type.GeoPackage;
+    }
+
+    @Override
+    public int getMaxColumnNameLength() {
+        return 2000;
+    }
+
+    @Override
+    public int getMaxTableNameLength() {
+        return 2000;
+    }
+
+    public String getDefaultSchema() {
+        return "main";
+    }
+
+    public String stringPlus() {
+        return "||";
+    }
+
+    public String stringIndex( String pattern, String string ) {
+        return "INSTR(" + string + "," + pattern + ")";
+    }
+
+    public String cast( String expr, String type ) {
+        return "CAST(" + expr + " AS " + type + ")";
+    }
+
+    @Override
+    public String geometryMetadata( TableName qTable, String column, boolean isGeographical ) {
+        return null;
+    }
+
+    @Override
+    public AbstractWhereBuilder getWhereBuilder( PropertyNameMapper mapper, OperatorFilter filter,
+                                                 SortProperty[] sortCrit, boolean allowPartialMappings )
+                            throws UnmappableException, FilterEvaluationException {
+        return new GpkgWhereBuilder( this, mapper, filter, sortCrit, allowPartialMappings );
+    }
+
+    @Override
+    public String getUndefinedSrid() {
+        return "-1";
+    }
+
+    @Override
+    public String getBBoxAggregateSnippet( String column ) {
+        return null;
+    }
+
+    @Override
+    public Envelope getBBoxAggregateValue( ResultSet rs, int colIdx, ICRS crs )
+                            throws SQLException {
+        return null;
+    }
+
+    @Override
+    public GeometryParticleConverter getGeometryConverter( String column, ICRS crs, String srid, boolean is2D ) {
+        return new GpkgGeometryConverter( column, crs, srid );
+    }
+
+    @Override
+    public PrimitiveParticleConverter getPrimitiveConverter( String column, PrimitiveType pt ) {
+        return new DefaultPrimitiveConverter( pt, column );
+    }
+
+    @Override
+    public void createDB( Connection adminConn, String dbName )
+                            throws SQLException {
+    }
+
+    @Override
+    public void dropDB( Connection adminConn, String dbName )
+                            throws SQLException {
+    }
+
+    @Override
+    public void createAutoColumn( StringBuffer currentStmt, List<StringBuffer> additionalSmts, SQLIdentifier column,
+                                  SQLIdentifier table ) {
+        currentStmt.append( column );
+    }
+
+    @Override
+    public ResultSet getTableColumnMetadata( DatabaseMetaData md, TableName qTable )
+                            throws SQLException {
+        String schema = qTable.getSchema() != null ? qTable.getSchema() : getDefaultSchema();
+        String table = qTable.getTable();
+        return md.getColumns( null, schema.toLowerCase(), table.toLowerCase(), null );
+    }
+
+    @Override
+    public boolean requiresTransactionForCursorMode() {
+        return false;
+    }
+
+    @Override
+    public String getSelectSequenceNextVal( String sequence ) {
+        return null;
+    }
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgDialectProvider.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgDialectProvider.java
@@ -1,0 +1,86 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2012 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.sqldialect.gpkg;
+
+import static org.deegree.commons.jdbc.ConnectionManager.Type.GeoPackage;
+import static org.deegree.commons.utils.JDBCUtils.close;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.deegree.commons.config.DeegreeWorkspace;
+import org.deegree.commons.config.ResourceInitException;
+import org.deegree.commons.jdbc.ConnectionManager;
+import org.deegree.commons.jdbc.ConnectionManager.Type;
+import org.deegree.sqldialect.SQLDialect;
+import org.deegree.sqldialect.SQLDialectProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link SQLDialectProvider} for GeoPackage databases.
+ * 
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+public class GpkgDialectProvider implements SQLDialectProvider {
+
+    private static Logger LOG = LoggerFactory.getLogger( GpkgDialectProvider.class );
+
+    @Override
+    public Type getSupportedType() {
+        return GeoPackage;
+    }
+
+    @Override
+    public SQLDialect create( String connId, DeegreeWorkspace ws )
+                            throws ResourceInitException {
+        Connection conn = null;
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            ConnectionManager mgr = ws.getSubsystemManager( ConnectionManager.class );
+            conn = mgr.get( connId );
+            if ( conn == null ) {
+                throw new ResourceInitException( "JDBC connection " + connId + " is not available." );
+            }
+        } finally {
+            close( rs, stmt, conn, LOG );
+        }
+        return new GpkgDialect();
+    }
+
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgGeometryConverter.java
@@ -1,0 +1,179 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2011 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.sqldialect.gpkg;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.geometry.Geometry;
+import org.deegree.geometry.io.WKBReader;
+import org.deegree.geometry.utils.GeometryParticleConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link GeometryParticleConverter} for GeoPackage databases.
+ * 
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+public class GpkgGeometryConverter implements GeometryParticleConverter {
+
+    private static Logger LOG = LoggerFactory.getLogger( GpkgGeometryConverter.class );
+
+    private final String column;
+
+    private final ICRS crs;
+
+    private final String srid;
+
+    /**
+     * Creates a new {@link GpkgGeometryConverter} instance.
+     * 
+     * @param column
+     *            (unqualified) column that stores the geometry, must not be <code>null</code>
+     * @param crs
+     *            CRS of the stored geometries, can be <code>null</code>
+     * @param srid
+     *            PostGIS spatial reference identifier, must not be <code>null</code>
+     */
+    public GpkgGeometryConverter( String column, ICRS crs, String srid ) {
+        this.column = column;
+        this.crs = crs;
+        this.srid = srid;
+    }
+
+    @Override
+    public String getSelectSnippet( String tableAlias ) {
+        if ( tableAlias != null ) {
+            return tableAlias + "." + column;
+        }
+        return column;
+    }
+
+    @Override
+    public String getSetSnippet( Geometry particle ) {
+        return null;
+    }
+
+    @Override
+    public Geometry toParticle( ResultSet rs, int colIndex )
+                            throws SQLException {
+        ByteBuffer bb = ByteBuffer.wrap( rs.getBytes( colIndex ) );
+        if ( bb == null ) {
+            return null;
+        }
+        try {
+            int[] header = parseGpkgHeader( bb );
+            int headerLength = header[0];
+            int endian = header[1];
+            return parseGpkgGeometry( bb, headerLength, endian );
+        } catch ( Throwable t ) {
+            throw new IllegalArgumentException( t.getMessage(), t );
+        }
+    }
+
+    private int[] parseGpkgHeader( ByteBuffer pgb )
+                            throws Exception {
+        byte bytes = pgb.get( 3 );
+        int endian = bytes & 0x01;
+        int headerLength = getFlags( bytes );
+        return new int[] { headerLength, endian };
+    }
+
+    private int getFlags( byte bytes )
+                            throws Exception {
+        int flags = ( bytes & 0x0E ) >> 1;
+        return getHeaderLength( flags );
+    }
+
+    @SuppressWarnings("unchecked")
+    private int getHeaderLength( int flag )
+                            throws Exception {
+        Map<Integer, Integer> eb = new HashMap();
+        eb.put( 0, 8 );
+        eb.put( 1, 40 );
+        eb.put( 2, 56 );
+        eb.put( 3, 56 );
+        eb.put( 4, 72 );
+
+        int envelopeLength = 0;
+        try {
+            envelopeLength = eb.get( flag );
+        } catch ( Exception e ) {
+            System.out.println( "Invalid envelope code value:" + flag );
+        }
+        return envelopeLength;
+    }
+
+    private Geometry parseGpkgGeometry( ByteBuffer byb, int headerLength, int endian )
+                            throws Exception {
+        WKBReader wkbReader = new WKBReader();
+        if ( endian == 0 )
+            byb.order( ByteOrder.BIG_ENDIAN );
+        else {
+            byb.order( ByteOrder.LITTLE_ENDIAN );
+        }
+        byte[] wkb = new byte[byb.capacity() - headerLength];
+        byb.position( headerLength );
+        byb.get( wkb, 0, wkb.length );
+        Geometry gpkgGeom = wkbReader.read( wkb, crs );
+        if ( gpkgGeom == null ) {
+            throw new Exception( "Unable to parse the GeoPackage geometry" );
+        }
+        return gpkgGeom;
+    }
+
+    @Override
+    public void setParticle( PreparedStatement stmt, Geometry particle, int paramIndex )
+                            throws SQLException {
+    }
+
+    @Override
+    public String getSrid() {
+        return srid;
+    }
+
+    @Override
+    public ICRS getCrs() {
+        return crs;
+    }
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/java/org/deegree/sqldialect/gpkg/GpkgWhereBuilder.java
@@ -1,0 +1,109 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2009 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.sqldialect.gpkg;
+
+import org.deegree.filter.FilterEvaluationException;
+import org.deegree.filter.OperatorFilter;
+import org.deegree.filter.comparison.PropertyIsLike;
+import org.deegree.filter.expression.ValueReference;
+import org.deegree.filter.sort.SortProperty;
+import org.deegree.filter.spatial.SpatialOperator;
+import org.deegree.sqldialect.filter.AbstractWhereBuilder;
+import org.deegree.sqldialect.filter.PropertyNameMapper;
+import org.deegree.sqldialect.filter.UnmappableException;
+import org.deegree.sqldialect.filter.expression.SQLExpression;
+import org.deegree.sqldialect.filter.expression.SQLOperation;
+import org.deegree.sqldialect.filter.expression.SQLOperationBuilder;
+
+/**
+ * {@link AbstractWhereBuilder} implementation for GeoPackage databases.
+ * 
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+public class GpkgWhereBuilder extends AbstractWhereBuilder {
+
+    /**
+     * Creates a new {@link GpkgWhereBuilder} instance.
+     * 
+     * @param dialect
+     *            SQL dialect
+     * @param mapper
+     *            provides the mapping from {@link ValueReference}s to DB columns, must not be <code>null</code>
+     * @param filter
+     *            Filter to use for generating the WHERE clause, can be <code>null</code>
+     * @param sortCrit
+     *            criteria to use for generating the ORDER BY clause, can be <code>null</code>
+     * @param allowPartialMappings
+     *            if false, any unmappable expression will cause an {@link UnmappableException} to be thrown
+     * @throws FilterEvaluationException
+     *             if the expression contains invalid {@link ValueReference}s
+     * @throws UnmappableException
+     *             if allowPartialMappings is false and an expression could not be mapped to the db
+     */
+    public GpkgWhereBuilder( GpkgDialect dialect, PropertyNameMapper mapper, OperatorFilter filter,
+                             SortProperty[] sortCrit, boolean allowPartialMappings ) throws FilterEvaluationException,
+                            UnmappableException {
+        super( dialect, mapper, filter, sortCrit );
+        build( allowPartialMappings );
+    }
+
+    /**
+     * Translates the given {@link PropertyIsLike} into an {@link SQLOperation}
+     * 
+     * @param op
+     *            comparison operator to be translated, must not be <code>null</code>
+     * @return corresponding SQL expression, never <code>null</code>
+     * @throws UnmappableException
+     *             if translation is not possible (usually due to unmappable property names)
+     * @throws FilterEvaluationException
+     *             if the expression contains invalid {@link ValueReference}s
+     */
+    @Override
+    protected SQLOperation toProtoSQL( PropertyIsLike op )
+                            throws UnmappableException, FilterEvaluationException {
+        return null;
+    }
+
+    @Override
+    protected SQLOperation toProtoSQL( SpatialOperator op )
+                            throws UnmappableException, FilterEvaluationException {
+        return null;
+    }
+
+    @Override
+    protected void addExpression( SQLOperationBuilder builder, SQLExpression expr, Boolean matchCase ) {
+    }
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/resources/META-INF/services/org.deegree.sqldialect.SQLDialectProvider
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-gpkg/src/main/resources/META-INF/services/org.deegree.sqldialect.SQLDialectProvider
@@ -1,0 +1,1 @@
+org.deegree.sqldialect.gpkg.GpkgDialectProvider

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-sqldialect/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -41,6 +41,7 @@
 
   <modules>
     <module>deegree-sqldialect-commons</module>
+    <module>deegree-sqldialect-gpkg</module>
     <module>deegree-sqldialect-postgis</module>
   </modules>
 

--- a/deegree-core/deegree-core-style/pom.xml
+++ b/deegree-core/deegree-core-style/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-theme/pom.xml
+++ b/deegree-core/deegree-core-theme/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-tile/pom.xml
+++ b/deegree-core/deegree-core-tile/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/deegree-core-time/pom.xml
+++ b/deegree-core/deegree-core-time/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-core/pom.xml
+++ b/deegree-core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-featurestore-sql</artifactId>
   <packaging>jar</packaging>
@@ -12,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -56,6 +57,11 @@
     </dependency>
     <dependency>
       <artifactId>deegree-sqldialect-postgis</artifactId>
+      <groupId>org.deegree</groupId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>deegree-sqldialect-gpkg</artifactId>
       <groupId>org.deegree</groupId>
       <version>${project.version}</version>
     </dependency>

--- a/deegree-datastores/deegree-featurestores/pom.xml
+++ b/deegree-datastores/deegree-featurestores/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-mdstores/pom.xml
+++ b/deegree-datastores/deegree-mdstores/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>deegree-tilestore-gpkg</artifactId>
+  <name>deegree-tilestore-gpkg</name>
+  <packaging>jar</packaging>
+  <description>Tile store implementation that accesses tiles stored in GeoPackage databases</description>
+
+  <properties>
+    <deegree.module.status>ok</deegree.module.status>
+  </properties>
+
+  <parent>
+    <groupId>org.deegree</groupId>
+    <artifactId>deegree-tilestores</artifactId>
+    <version>3.3.12-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>deegree-repo</id>
+      <url>http://repo.deegree.org/content/groups/public</url>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-tilestore-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-core-coverage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jai</groupId>
+      <artifactId>jai-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jai</groupId>
+      <artifactId>jai-imageio</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jai</groupId>
+      <artifactId>jai-mlibwrapper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>it.geosolutions.imageio-ext</groupId>
+      <artifactId>imageio-ext-tiff</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTile.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTile.java
@@ -1,0 +1,105 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ Occam Labs UG (haftungsbeschränkt)
+ Godesberger Allee 139, 53175 Bonn
+ Germany
+ http://www.occamlabs.de/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+
+package org.deegree.tile.persistence.gpkg;
+
+import org.deegree.feature.FeatureCollection;
+import org.deegree.geometry.Envelope;
+import org.deegree.tile.Tile;
+import org.deegree.tile.TileIOException;
+import org.deegree.tile.TileMatrix;
+import org.slf4j.Logger;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * A GpkgTile.
+ * 
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+public class GpkgTile implements Tile {
+
+    private static final Logger LOG = getLogger( GpkgTile.class );
+
+    private TileMatrix tm;
+
+    private byte[] bytes;
+
+    public GpkgTile( TileMatrix tm, byte[] bytes ) {
+        this.tm = tm;
+        this.bytes = bytes;
+    }
+
+    @Override
+    public BufferedImage getAsImage()
+                            throws TileIOException {
+        try {
+            return ImageIO.read( new ByteArrayInputStream( bytes ) );
+        } catch ( IOException e ) {
+            String msg = "Error decoding image from byte array: " + e.getMessage();
+            LOG.trace( msg, e );
+            throw new TileIOException( e.getMessage(), e );
+        }
+    }
+
+    @Override
+    public InputStream getAsStream() {
+        return new ByteArrayInputStream( bytes );
+    }
+
+    @Override
+    public Envelope getEnvelope() {
+        return tm.getSpatialMetadata().getEnvelope();
+    }
+
+    @Override
+    public FeatureCollection getFeatures( int i, int j, int limit )
+                            throws UnsupportedOperationException {
+        throw new UnsupportedOperationException( "Feature retrieval is not supported by the GpkgTileStore." );
+    }
+}

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTileDataLevel.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTileDataLevel.java
@@ -1,0 +1,83 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ Occam Labs UG (haftungsbeschränkt)
+ Godesberger Allee 139, 53175 Bonn
+ Germany
+ http://www.occamlabs.de/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+
+package org.deegree.tile.persistence.gpkg;
+
+import org.deegree.commons.utils.Pair;
+import org.deegree.geometry.GeometryFactory;
+import org.deegree.tile.Tile;
+import org.deegree.tile.TileDataLevel;
+import org.deegree.tile.TileMatrix;
+
+import java.util.Map;
+
+/**
+ * A GpkgTileDataLevel
+ * 
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+
+public class GpkgTileDataLevel implements TileDataLevel {
+
+    private final TileMatrix tm;
+
+    private Map<Pair<Long, Long>, byte[]> tileMap;
+
+    public GpkgTileDataLevel( TileMatrix tm, Map<Pair<Long, Long>, byte[]> tileMap ) {
+        this.tm = tm;
+        this.tileMap = tileMap;
+    }
+
+    @Override
+    public TileMatrix getMetadata() {
+        return tm;
+    }
+
+    @Override
+    public Tile getTile( long x, long y ) {
+        Pair<Long, Long> k = new Pair<Long, Long>();
+        k.setFirst( x );
+        k.setSecond( y );
+        byte[] byteArr = tileMap.get( k );
+        return new GpkgTile( tm, byteArr );
+    }
+}

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTileDataSetBuilder.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTileDataSetBuilder.java
@@ -1,0 +1,132 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2012 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - Occam Labs UG (haftungsbeschränkt) -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ Occam Labs UG (haftungsbeschränkt)
+ Godesberger Allee 139, 53175 Bonn
+ Germany
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.tile.persistence.gpkg;
+
+import org.deegree.commons.config.DeegreeWorkspace;
+import org.deegree.commons.config.ResourceInitException;
+import org.deegree.commons.jdbc.ConnectionManager;
+import org.deegree.commons.utils.Pair;
+import org.deegree.tile.*;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds tile data sets from jaxb config beans.
+ *
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+class GpkgTileDataSetBuilder {
+
+    private final org.deegree.tile.persistence.gpkg.jaxb.GpkgTileStoreJAXB cfg;
+
+    private DeegreeWorkspace workspace;
+
+    private String format;
+
+    private String identifier;
+
+    private TileMatrixSet tms;
+
+    GpkgTileDataSetBuilder( org.deegree.tile.persistence.gpkg.jaxb.GpkgTileStoreJAXB cfg, DeegreeWorkspace workspace,
+                            TileMatrixSet tms ) {
+        this.cfg = cfg;
+        this.workspace = workspace;
+        this.tms = tms;
+        this.format = cfg.getTileDataSet().getImageFormat();
+        this.identifier = cfg.getTileDataSet().getIdentifier();
+    }
+
+    Map<String, TileDataSet> extractTileDataSets()
+                            throws ResourceInitException {
+        Map<String, TileDataSet> tileDataSet = new HashMap<String, TileDataSet>();
+        tileDataSet.put( identifier, buildTileDataSet() );
+        return tileDataSet;
+    }
+
+    public TileDataSet buildTileDataSet()
+                            throws ResourceInitException {
+        List<TileDataLevel> list = new ArrayList<TileDataLevel>();
+        for ( TileMatrix tm : tms.getTileMatrices() ) {
+            String idTm = tm.getIdentifier();
+            Map<Pair<Long, Long>, byte[]> ts = getTileData( idTm );
+            TileDataLevel tdl = new GpkgTileDataLevel( tm, ts );
+            list.add( tdl );
+        }
+        if ( format == null ) {
+            format = "image/png";
+        }
+        return new DefaultTileDataSet( list, tms, format );
+    }
+
+    public Map<Pair<Long, Long>, byte[]> getTileData( String id ) {
+        Map<Pair<Long, Long>, byte[]> mapTile = new LinkedHashMap<Pair<Long, Long>, byte[]>();
+        try {
+            ConnectionManager mgr = workspace.getSubsystemManager( ConnectionManager.class );
+            Connection conn = mgr.get( cfg.getTileDataSet().getJDBCConnId() );
+            Statement stmt = conn.createStatement();
+            String table = cfg.getTileDataSet().getTileMapping().getTable();
+            String query = "select * from " + table + " where zoom_level = " + id;
+            ResultSet rs = stmt.executeQuery( query );
+            while ( rs.next() ) {
+                long row = rs.getLong( 4 );
+                long column = rs.getLong( 3 );
+                byte[] imgBytes = rs.getBytes( 5 );
+                Pair<Long, Long> keyTile = new Pair<Long, Long>();
+                keyTile.setFirst( row );
+                keyTile.setSecond( column );
+                mapTile.put( keyTile, imgBytes );
+            }
+        } catch ( SQLException e ) {
+            e.printStackTrace();
+        }
+        return mapTile;
+    }
+}

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTileStoreProvider.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/java/org/deegree/tile/persistence/gpkg/GpkgTileStoreProvider.java
@@ -1,0 +1,213 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ Occam Labs UG (haftungsbeschränkt)
+ Godesberger Allee 139, 53175 Bonn
+ Germany
+ http://www.occamlabs.de/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.tile.persistence.gpkg;
+
+import org.deegree.commons.config.DeegreeWorkspace;
+import org.deegree.commons.config.ResourceInitException;
+import org.deegree.commons.config.ResourceManager;
+import org.deegree.commons.jdbc.ConnectionManager;
+import org.deegree.commons.jdbc.ConnectionManager.Type;
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.exceptions.UnknownCRSException;
+import org.deegree.cs.persistence.CRSManager;
+import org.deegree.geometry.Envelope;
+import org.deegree.geometry.GeometryFactory;
+import org.deegree.geometry.metadata.SpatialMetadata;
+import org.deegree.tile.TileDataSet;
+import org.deegree.tile.TileMatrix;
+import org.deegree.tile.TileMatrixSet;
+import org.deegree.tile.persistence.GenericTileStore;
+import org.deegree.tile.persistence.TileStore;
+import org.deegree.tile.persistence.TileStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBException;
+import java.io.File;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static org.deegree.commons.xml.jaxb.JAXBUtils.unmarshall;
+
+/**
+ * The GpkgTileStoreProvider provides a TileSet out of a GeoPackage database.
+ *
+ * @author <a href="mailto:migliavacca@lat-lon.de">Diego Migliavacca</a>
+ * @author last edited by: $Author: dmigliavacca $
+ */
+
+public class GpkgTileStoreProvider implements TileStoreProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger( GpkgTileStoreProvider.class );
+
+    private static final URL SCHEMA = GpkgTileStoreProvider.class.getResource( "/META-INF/schemas/datasource/tile/gpkg/3.2.0/geopackage.xsd" );
+
+    private org.deegree.tile.persistence.gpkg.jaxb.GpkgTileStoreJAXB cfg;
+
+    private String table;
+
+    private DeegreeWorkspace workspace;
+
+    private Connection conn = null;
+
+    private List<TileMatrix> matrices;
+
+    private final GeometryFactory fac = new GeometryFactory();
+
+    @Override
+    public void init( DeegreeWorkspace workspace ) {
+        this.workspace = workspace;
+    }
+
+    @Override
+    public URL getConfigSchema() {
+        return SCHEMA;
+    }
+
+    @Override
+    public String getConfigNamespace() {
+        return "http://www.deegree.org/datasource/tile/gpkg";
+    }
+
+    @Override
+    public TileStore create( URL configUrl )
+                            throws ResourceInitException {
+        try {
+            cfg = (org.deegree.tile.persistence.gpkg.jaxb.GpkgTileStoreJAXB) unmarshall( "org.deegree.tile.persistence.gpkg.jaxb",
+                                                                                         SCHEMA, configUrl, workspace );
+
+            table = cfg.getTileDataSet().getTileMapping().getTable();
+            String id;
+            ConnectionManager mgr = workspace.getSubsystemManager( ConnectionManager.class );
+            conn = mgr.get( cfg.getTileDataSet().getJDBCConnId() );
+            Type connType = mgr.getType( cfg.getTileDataSet().getJDBCConnId() );
+            if ( connType == null ) {
+                throw new ResourceInitException( "No JDBC connection with id '" + cfg.getTileDataSet().getJDBCConnId() + "' defined." );
+            }
+            LOG.debug( "Connection type is {}.", connType );
+            TileMatrix tm;
+            matrices = new ArrayList<TileMatrix>();
+            try {
+                Statement stmt = conn.createStatement();
+                String query = "select * from gpkg_tile_matrix where table_name = '" + table + "'";
+                ResultSet rs = stmt.executeQuery( query );
+                if ( rs == null ) {
+                    throw new ResourceInitException(
+                                            "No information could be read from gpkg_tile_matrix table. Please add the table to the GeoPackage." );
+                }
+                SpatialMetadata sm = getTileMatrixSet().getSpatialMetadata();
+                while ( rs.next() ) {
+                    id = rs.getString( 2 );
+                    long numx = rs.getLong( 3 );
+                    long numy = rs.getLong( 4 );
+                    long tileWidth = rs.getLong( 5 );
+                    long tsx = rs.getLong( 7 );
+                    long tsy = rs.getLong( 8 );
+                    double res = (double) ( tsx / tileWidth );
+                    tm = new TileMatrix( id, sm, tsx, tsy, res, numx, numy );
+                    matrices.add( tm );
+                }
+            } catch ( SQLException e ) {
+                e.printStackTrace();
+            }
+            GpkgTileDataSetBuilder builder = new GpkgTileDataSetBuilder( cfg, workspace, getTileMatrixSet() );
+            Map<String, TileDataSet> map = builder.extractTileDataSets();
+            return new GenericTileStore( map );
+        } catch ( JAXBException e ) {
+            LOG.info( "Stack trace: ", e );
+            throw new ResourceInitException( "Error when parsing configuration: " + e.getLocalizedMessage(), e );
+        }
+    }
+
+    public TileMatrixSet getTileMatrixSet() {
+        String id = null;
+        SpatialMetadata spatialMetadata = null;
+        try {
+            Statement stmt = conn.createStatement();
+            String query = "select * from gpkg_tile_matrix_set where table_name = '" + table + "'";
+            ResultSet rs = stmt.executeQuery( query );
+            if ( rs == null ) {
+                throw new ResourceInitException(
+                                        "No information could be read from gpkg_tile_matrix_set table. Please add the table to the GeoPackage." );
+            }
+            id = rs.getString( 1 );
+            ICRS srs = CRSManager.lookup( "EPSG:" + rs.getString( 2 ) );
+            if ( srs == null ) {
+                throw new ResourceInitException(
+                                        "No SRS information could be read from GeoPackage. Please add one to the GeoPackage." );
+            }
+            double minx = rs.getDouble( 3 );
+            double miny = rs.getDouble( 4 );
+            double maxx = rs.getDouble( 5 );
+            double maxy = rs.getDouble( 6 );
+            Envelope env = fac.createEnvelope( minx, miny, maxx, maxy, srs );
+            if ( env == null ) {
+                throw new ResourceInitException(
+                                        "No envelope information could be read from GeoPackage. Please add one to the GeoPackage." );
+            }
+            spatialMetadata = new SpatialMetadata( env, singletonList( env.getCoordinateSystem() ) );
+        } catch ( SQLException e ) {
+            e.printStackTrace();
+        } catch ( UnknownCRSException e ) {
+            e.printStackTrace();
+        } catch ( ResourceInitException e ) {
+            e.printStackTrace();
+        }
+        return new TileMatrixSet( id, null, matrices, spatialMetadata );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<? extends ResourceManager>[] getDependencies() {
+        return new Class[] { };
+    }
+
+    @Override
+    public List<File> getTileStoreDependencies( File config ) {
+        return Collections.<File>emptyList();
+    }
+
+}

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/resources/META-INF/schemas/datasource/tile/gpkg/3.2.0/example.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/resources/META-INF/schemas/datasource/tile/gpkg/3.2.0/example.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<GpkgTileStore xmlns="http://www.deegree.org/datasource/tile/gpkg" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.deegree.org/datasource/tile/gpkg http://schemas.deegree.org/datasource/tile/gpkg/3.2.0/geopackage.xsd"
+               configVersion="3.2.0">
+
+  <TileDataSet>
+    <JDBCConnId>gpkg</JDBCConnId>
+    <!-- [0..1]: the identifier for the tile data set -->
+    <Identifier>test</Identifier>
+    <TileMapping table=""></TileMapping>
+    <!-- [0..1]: the mime type of the desired image output format. Default is image/png -->
+    <ImageFormat>image/png</ImageFormat>
+  </TileDataSet>
+
+</GpkgTileStore>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/resources/META-INF/schemas/datasource/tile/gpkg/3.2.0/geopackage.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/resources/META-INF/schemas/datasource/tile/gpkg/3.2.0/geopackage.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://www.deegree.org/datasource/tile/gpkg"
+        xmlns:t="http://www.deegree.org/datasource/tile/gpkg" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        jaxb:version="2.1">
+
+  <annotation>
+    <appinfo>
+      <jaxb:schemaBindings>
+        <jaxb:package name="org.deegree.tile.persistence.gpkg.jaxb"/>
+      </jaxb:schemaBindings>
+    </appinfo>
+  </annotation>
+
+  <element name="GpkgTileStore">
+    <annotation>
+      <appinfo>
+        <jaxb:class name="GpkgTileStoreJAXB"/>
+      </appinfo>
+    </annotation>
+    <complexType>
+      <sequence maxOccurs="1">
+        <element name="TileDataSet">
+          <complexType>
+            <sequence>
+              <element name="JDBCConnId" type="string" minOccurs="1"/>
+              <element name="Identifier" type="string" minOccurs="1"/>
+              <element name="TileMapping">
+                <complexType>
+                  <attribute name="table" type="string" use="required"/>
+                </complexType>
+              </element>
+              <element name="ImageFormat" type="string" minOccurs="0"/>
+            </sequence>
+          </complexType>
+        </element>
+      </sequence>
+      <attribute name="configVersion" use="required" fixed="3.2.0"/>
+    </complexType>
+  </element>
+
+</schema>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/resources/META-INF/services/org.deegree.tile.persistence.TileStoreProvider
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gpkg/src/main/resources/META-INF/services/org.deegree.tile.persistence.TileStoreProvider
@@ -1,0 +1,1 @@
+org.deegree.tile.persistence.gpkg.GpkgTileStoreProvider

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-tilestores/pom.xml
+++ b/deegree-datastores/deegree-tilestores/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -29,6 +29,7 @@
     <module>deegree-tilestore-commons</module>
     <module>deegree-tilestore-filesystem</module>
     <module>deegree-tilestore-geotiff</module>
+    <module>deegree-tilestore-gpkg</module>
     <module>deegree-tilestore-remotewms</module>
     <module>deegree-tilestore-remotewmts</module>
   </modules>

--- a/deegree-datastores/pom.xml
+++ b/deegree-datastores/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-layers/deegree-layers-coverage/pom.xml
+++ b/deegree-layers/deegree-layers-coverage/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-layers/deegree-layers-feature/pom.xml
+++ b/deegree-layers/deegree-layers-feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-layers/deegree-layers-remotewms/pom.xml
+++ b/deegree-layers/deegree-layers-remotewms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-layers/deegree-layers-tile/pom.xml
+++ b/deegree-layers/deegree-layers-tile/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-layers/pom.xml
+++ b/deegree-layers/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-misc/deegree-javacheck/pom.xml
+++ b/deegree-misc/deegree-javacheck/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-misc</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-misc/deegree-tomcat/pom.xml
+++ b/deegree-misc/deegree-tomcat/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-misc</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-misc/pom.xml
+++ b/deegree-misc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-processproviders/deegree-processprovider-example/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-example/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-processproviders</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-processproviders/deegree-processprovider-jrxml/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-jrxml/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-processproviders</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-processproviders/deegree-processprovider-style/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-style/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-processproviders</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-processproviders/pom.xml
+++ b/deegree-processproviders/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-config/pom.xml
+++ b/deegree-services/deegree-services-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-csw/pom.xml
+++ b/deegree-services/deegree-services-csw/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-wcs/pom.xml
+++ b/deegree-services/deegree-services-wcs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-wms/pom.xml
+++ b/deegree-services/deegree-services-wms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-wmts/pom.xml
+++ b/deegree-services/deegree-services-wmts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-wps/pom.xml
+++ b/deegree-services/deegree-services-wps/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-services-wpvs/pom.xml
+++ b/deegree-services/deegree-services-wpvs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-webservices-handbook/pom.xml
+++ b/deegree-services/deegree-webservices-handbook/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-services/pom.xml
+++ b/deegree-services/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-compliance-tests/pom.xml
+++ b/deegree-tests/deegree-compliance-tests/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wms-similarity-tests/pom.xml
+++ b/deegree-tests/deegree-wms-similarity-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wms-tiling-tests/pom.xml
+++ b/deegree-tests/deegree-wms-tiling-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-wmts-tests/pom.xml
+++ b/deegree-tests/deegree-wmts-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/deegree-workspace-tests/pom.xml
+++ b/deegree-tests/deegree-workspace-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tests/pom.xml
+++ b/deegree-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-themes/deegree-themes-remotewms/pom.xml
+++ b/deegree-themes/deegree-themes-remotewms/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-themes-remotewms</artifactId>
   <packaging>jar</packaging>
-  <version>3.3.11</version>
+  <version>3.3.12-SNAPSHOT</version>
   <name>deegree-themes-remotewms</name>
   <description>Map layer theme implementation for remote Web Map Services</description>
 
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-themes</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-themes/pom.xml
+++ b/deegree-themes/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tools/deegree-tools-3d/pom.xml
+++ b/deegree-tools/deegree-tools-3d/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tools/deegree-tools-alkis/pom.xml
+++ b/deegree-tools/deegree-tools-alkis/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tools/deegree-tools-base/pom.xml
+++ b/deegree-tools/deegree-tools-base/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tools/deegree-tools-migration/pom.xml
+++ b/deegree-tools/deegree-tools-migration/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-tools/pom.xml
+++ b/deegree-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-aixm/pom.xml
+++ b/deegree-workspaces/deegree-workspace-aixm/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-alkis/pom.xml
+++ b/deegree-workspaces/deegree-workspace-alkis/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-compliance-tests/pom.xml
+++ b/deegree-workspaces/deegree-workspace-compliance-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-csw-memory-tests/pom.xml
+++ b/deegree-workspaces/deegree-workspace-csw-memory-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-csw-tests/pom.xml
+++ b/deegree-workspaces/deegree-workspace-csw-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-csw/pom.xml
+++ b/deegree-workspaces/deegree-workspace-csw/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-geosciml/pom.xml
+++ b/deegree-workspaces/deegree-workspace-geosciml/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-inspire/pom.xml
+++ b/deegree-workspaces/deegree-workspace-inspire/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-osm/pom.xml
+++ b/deegree-workspaces/deegree-workspace-osm/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-utah/pom.xml
+++ b/deegree-workspaces/deegree-workspace-utah/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-wcts/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wcts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-wps-jrxml/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wps-jrxml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-wps/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wps/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-wpvs/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wpvs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/deegree-workspace-xplan40/pom.xml
+++ b/deegree-workspaces/deegree-workspace-xplan40/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-workspaces/pom.xml
+++ b/deegree-workspaces/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.3.11</version>
+    <version>3.3.12-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.deegree</groupId>
   <artifactId>deegree</artifactId>
   <packaging>pom</packaging>
-  <version>3.3.11</version>
+  <version>3.3.12-SNAPSHOT</version>
   <name>deegree</name>
   <description>Framework for OGC Web Service implementations and geospatial applications</description>
   <url>http://www.deegree.org/</url>
@@ -12,7 +13,7 @@
     <connection>scm:git:git@github.com:deegree/deegree3.git</connection>
     <developerConnection>scm:git:git@github.com:deegree/deegree3.git</developerConnection>
     <url>https://github.com/deegree/deegree3.git</url>
-    <tag>deegree-3.3.11</tag>
+    <tag>deegree-3.3.0</tag>
   </scm>
 
   <repositories>
@@ -39,9 +40,9 @@
     </snapshotRepository>
     <site>
       <id>apidoc.deegree.org</id>
-<!--
-      <url>scp://apidoc.deegree.org/var/www/apidoc.deegree.org/${project.version}/</url>
--->
+      <!--
+            <url>scp://apidoc.deegree.org/var/www/apidoc.deegree.org/${project.version}/</url>
+      -->
       <url>file:///tmp/site/${project.version}/</url>
     </site>
   </distributionManagement>
@@ -675,6 +676,12 @@
         <groupId>com.oracle</groupId>
         <artifactId>ojdbc6</artifactId>
         <version>11.2.0.2</version>
+      </dependency>
+      <!-- SQLite -->
+      <dependency>
+        <groupId>org.xerial</groupId>
+        <artifactId>sqlite-jdbc</artifactId>
+        <version>3.7.2</version>
       </dependency>
       <!-- Batik -->
       <dependency>


### PR DESCRIPTION
http://tracker.deegree.org/deegree-services/ticket/613

 "The GeoPackage specification describes an open, standards-based, platform-independent, portable, self-describing, compact format for transferring geospatial information. It is a set of conventions for SQLite to store interoperable Features and/or Tiles on a common base" (opengis/geopackage GitHub repository).

In order to access a Geopackage file, you need to create a JDBC connection which points to the Geopackage file.

```
<JDBCConnection xmlns="http://www.deegree.org/jdbc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.0.0" xsi:schemaLocation="http://www.deegree.org/jdbc http://schemas.deegree.org/jdbc/3.0.0/jdbc.xsd">
  <Url>jdbc:sqlite:/home/user/World.gpkg</Url>
  <User>null</User>
  <Password>null</Password>
</JDBCConnection>
```

User and Password can just to be set to "null", given that GeoPackage is based on SQLite.

For the feature part, the user needs to configure in Deegree:
an SQL feature store;
a WFS service;
a Feature Layer.

 For the tile part, the user needs to configure:
a WMTS service;
a Gpkg Tile Store;
a Tile Layer.

 Configuration of a Gpkg Tile Store (example):

```
<GpkgTileStore xmlns="http://www.deegree.org/datasource/tile/gpkg" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/datasource/tile/gpkg http://schemas.deegree.org/datasource/tile/gpkg/3.2.0/geopackage.xsd" configVersion="3.2.0">

  <TileDataSet>
    <JDBCConnId>gpkg</JDBCConnId>
    <Identifier>gpkg_tilelayer</Identifier>
    <TileMapping table="fromosm_tiles"/>
    <!-- [0..1]: the mime type of the desired image output format. Default is image/png -->
    <ImageFormat>image/png</ImageFormat>
</TileDataSet>

</GpkgTileStore>
```
