### PR TITLE
SQLFeatureStore: SELECT improvement and streaming fix for multiple-featuretype queries (BLOB mode)

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -507,6 +507,7 @@ public class SQLFeatureStore implements FeatureStore {
 
             conn = connProvider.getConnection();
             stmt = conn.prepareStatement( sql.toString() );
+            stmt.setFetchSize( fetchSize );
             stmt.setString( 1, id );
             rs = stmt.executeQuery();
             if ( rs.next() ) {
@@ -788,6 +789,7 @@ public class SQLFeatureStore implements FeatureStore {
 
             begin = System.currentTimeMillis();
             rs = stmt.executeQuery();
+            stmt.setFetchSize( fetchSize );
             LOG.debug( "Executing SELECT took {} [ms] ", System.currentTimeMillis() - begin );
             rs.next();
             hits = rs.getInt( 1 );
@@ -967,12 +969,12 @@ public class SQLFeatureStore implements FeatureStore {
             }
             stmt = conn.prepareStatement( "SELECT gml_id,binary_object FROM " + blobMapping.getTable()
                                           + " A WHERE A.gml_id in (" + sb + ")" );
+            stmt.setFetchSize( fetchSize );
             int idx = 0;
             for ( String id : filter.getMatchingIds() ) {
                 stmt.setString( ++idx, id );
             }
             rs = stmt.executeQuery();
-
             FeatureBuilder builder = new FeatureBuilderBlob( this, blobMapping );
             result = new IteratorFeatureInputStream( new FeatureResultSetIterator( builder, rs, conn, stmt ) );
         } catch ( Exception e ) {
@@ -1063,6 +1065,7 @@ public class SQLFeatureStore implements FeatureStore {
             LOG.debug( "SQL: {}", sql );
 
             stmt = conn.prepareStatement( sql.toString() );
+            stmt.setFetchSize( fetchSize );
             LOG.debug( "Preparing SELECT took {} [ms] ", System.currentTimeMillis() - begin );
 
             int i = 1;
@@ -1390,6 +1393,7 @@ public class SQLFeatureStore implements FeatureStore {
                 sql.append( " ORDER BY QUERY_POS" );
             }
             stmt = conn.prepareStatement( sql.toString() );
+            stmt.setFetchSize( fetchSize );
             int argIdx = 1;
             for ( final short ftId2 : ftId ) {
                 stmt.setShort( argIdx++, ftId2 );


### PR DESCRIPTION
Adds the following improvements for BLOB-mode queries that target multiple feature types:
- Better SELECT strategy that uses UNIONs and an ORDER BY based on constants instead of the crude string function used before
- Add missing calls to Statement.setFetchSize (...) to enable streaming result sets
