### PR TITLE
fixed NPE occurred when schema is missing

### DIFF
--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/serializing/XsltFeatureInfoSerializer.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/serializing/XsltFeatureInfoSerializer.java
@@ -15,6 +15,7 @@ import org.deegree.commons.xml.XsltUtils;
 import org.deegree.commons.xml.stax.IndentingXMLStreamWriter;
 import org.deegree.feature.Feature;
 import org.deegree.feature.FeatureCollection;
+import org.deegree.feature.types.AppSchema;
 import org.deegree.featureinfo.FeatureInfoContext;
 import org.deegree.featureinfo.FeatureInfoParams;
 import org.deegree.gml.GMLStreamWriter;
@@ -55,7 +56,9 @@ public class XsltFeatureInfoSerializer implements FeatureInfoSerializer {
                 nsBindings = new HashMap<String, String>();
             }
             for ( Feature f : col ) {
-                nsBindings.putAll( f.getType().getSchema().getNamespaceBindings() );
+                AppSchema schema = f.getType().getSchema();
+                if ( schema != null )
+                    nsBindings.putAll( schema.getNamespaceBindings() );
             }
             writer.setNamespaceBindings( nsBindings );
             writer.write( col );


### PR DESCRIPTION
Fixes a null pointer exception for cascaded GFI requests, that occurs when schema is missing in original output.
