### PR TITLE
Jpeg transparency

### DIFF
--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/ImageUtils.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/ImageUtils.java
@@ -81,7 +81,7 @@ public class ImageUtils {
         }
 
         BufferedImage img = new BufferedImage( width, height, getType( transparent, format ) );
-        if ( !transparent ) {
+        if ( !isTransparentAndTransparencySupported( format, transparent ) ) {
             Graphics2D g = img.createGraphics();
             g.setBackground( bgColor );
             g.clearRect( 0, 0, width, height );
@@ -92,7 +92,7 @@ public class ImageUtils {
     }
 
     private static boolean isTransparentAndTransparencySupported( String format, boolean transparent ) {
-        if ( format.equals( "image/x-ms-bmp" ) ) {
+        if ( format.equals( "image/x-ms-bmp" ) || format.equals( "image/jpeg" ) ) {
             return false;
         }
         return transparent;


### PR DESCRIPTION
Bug: An image with black background color is returned, when requesting a JPEG image and setting transparency to true (GetMap request).
Example request for utah workspace to reproduce the bug: [1].

The fix solves this problem by always using the given background color when requesting a JPEG image, as JPEG does not support transparency.

[1] http://localhost:8080/deegree/services/wms?FORMAT=image%2Fjpeg&TRANSPARENT=true&BGCOLOR=0xffffff&LAYERS=countyboundaries&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&EXCEPTIONS=application%2Fvnd.ogc.se_inimage&SRS=EPSG%3A900913&BBOX=-12914551.936364,4165602.5406961,-11780837.933042,5691897.1212211&WIDTH=927&HEIGHT=1248
