### PR TITLE
Enhance WMS GetMap response for unsupported image formats and make the supported image output format configurable

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -113,6 +113,7 @@ import org.deegree.services.controller.utils.StandardFeatureInfoContext;
 import org.deegree.services.jaxb.controller.DeegreeServiceControllerType;
 import org.deegree.services.jaxb.metadata.DeegreeServicesMetadataType;
 import org.deegree.services.jaxb.wms.DeegreeWMS;
+import org.deegree.services.jaxb.wms.GetMapFormatsType;
 import org.deegree.services.jaxb.wms.DeegreeWMS.ExtendedCapabilities;
 import org.deegree.services.jaxb.wms.FeatureInfoFormatsType;
 import org.deegree.services.jaxb.wms.FeatureInfoFormatsType.GetFeatureInfoFormat;
@@ -234,14 +235,7 @@ public class WMSController extends AbstractOWS {
         }
 
         try {
-            // put in the default formats
-            supportedImageFormats.add( "image/png" );
-            supportedImageFormats.add( "image/png; subtype=8bit" );
-            supportedImageFormats.add( "image/png; mode=8bit" );
-            supportedImageFormats.add( "image/gif" );
-            supportedImageFormats.add( "image/jpeg" );
-            supportedImageFormats.add( "image/tiff" );
-            supportedImageFormats.add( "image/x-ms-bmp" );
+           addSupportedImageFormats( conf );
 
             if ( conf.getFeatureInfoFormats() != null ) {
                 for ( GetFeatureInfoFormat t : conf.getFeatureInfoFormats().getGetFeatureInfoFormat() ) {
@@ -730,6 +724,27 @@ public class WMSController extends AbstractOWS {
         return featureInfoManager;
     }
 
+    private void addSupportedImageFormats( DeegreeWMS conf ) {
+        if ( conf.getGetMapFormats() != null ) {
+            GetMapFormatsType getMapFormats = conf.getGetMapFormats();
+            List<String> getMapFormatList = getMapFormats.getGetMapFormat();
+            for ( String getMapFormat : getMapFormatList ) {
+                supportedImageFormats.add( getMapFormat );
+            }
+        }
+        if ( supportedImageFormats.isEmpty() ) {
+            // put in the default formats
+            supportedImageFormats.add( "image/png" );
+            supportedImageFormats.add( "image/png; subtype=8bit" );
+            supportedImageFormats.add( "image/png; mode=8bit" );
+            supportedImageFormats.add( "image/gif" );
+            supportedImageFormats.add( "image/jpeg" );
+            supportedImageFormats.add( "image/tiff" );
+            supportedImageFormats.add( "image/x-ms-bmp" );
+        }
+    }
+
+    
     /**
      * <code>Controller</code>
      * 

--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
@@ -28,6 +28,7 @@
         <element name="MetadataURLTemplate" minOccurs="0" type="string" />
         <element name="ServiceConfiguration" type="wms:ServiceConfigurationType" />
         <element name="FeatureInfoFormats" minOccurs="0" type="wms:FeatureInfoFormatsType" />
+        <element name="GetMapFormats" minOccurs="0" type="wms:GetMapFormatsType" />
         <element name="ExtendedCapabilities" minOccurs="0" maxOccurs="unbounded">
           <complexType>
             <sequence>
@@ -88,6 +89,24 @@
     <attribute name="enableDefaultFormats" type="boolean" default="true"/>
   </complexType>
 
+  <complexType name="GetMapFormatsType">
+    <sequence>
+      <element name="GetMapFormat" minOccurs="0" maxOccurs="unbounded">
+        <simpleType>
+          <restriction base="string">
+            <enumeration value="image/png" />
+            <enumeration value="image/png; subtype=8bit" />
+            <enumeration value="image/png; mode=8bit" />
+            <enumeration value="image/gif" />
+            <enumeration value="image/jpeg" />
+            <enumeration value="image/tiff" />
+            <enumeration value="image/x-ms-bmp" />
+          </restriction>
+        </simpleType>
+      </element>
+    </sequence>
+  </complexType>
+  
   <complexType name="LayerOptionsType">
     <sequence>
       <element name="AntiAliasing" type="string" minOccurs="0" />

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -320,6 +320,8 @@ The following table shows what top level options are available.
 +--------------------------+--------------+---------+------------------------------------------------------------------------------+
 | FeatureInfoFormats       | 0..1         | Complex | Configures additional feature info output formats                            |
 +--------------------------+--------------+---------+------------------------------------------------------------------------------+
+| GetMapFormats            | 0..1         | Complex | Configures additional image output formats                                   |
++--------------------------+--------------+---------+------------------------------------------------------------------------------+
 | ExtendedCapabilities     | 0..n         | Complex | Extended Metadata reported in GetCapabilities response                       |
 +--------------------------+--------------+---------+------------------------------------------------------------------------------+
 | LayerLimit               | 0..1         | Integer | Maximum number of layers in a GetMap request, default: unlimited             |
@@ -576,6 +578,32 @@ The selector for properties and features is a kind of pattern matching on the ob
 +--------------------------+----------------------------------------------------------+
 | *selector1*, *selector2* | matches all objects matching *selector1* and *selector2* |
 +--------------------------+----------------------------------------------------------+
+
+.. _anchor-image-output-configuration:
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Custom image output formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Any mime type of the following output formats can be configured to be available as response format for GetMap requests.
+
+ * ``image/png``
+ * ``image/png; subtype=8bit``
+ * ``image/png; mode=8bit``
+ * ``image/gif``
+ * ``image/jpeg``
+ * ``image/tiff``
+ * ``image/x-ms-bmp``
+
+If no format has been configured, all formats are supported.
+
+This is how the configuration section looks like for configuring only ``image/png`` as image output format:
+
+.. code-block:: xml
+
+  <GetMapFormats>
+    <GetMapFormat>image/png</GetMapFormat>
+  </GetMapFormats>
 
 ^^^^^^^^^^^^^^^^^^^^^
 Extended capabilities


### PR DESCRIPTION
With this pull request it is possible to configure supported output formats for GetMap requests. Only configured image formats are supported as output format. If no format has been configured, all formats are supported.

For requests with unsupported output formats, deegree will respond with an exception (```XML```, ```INIMAGE```).