### PR TITLE
removed outdated library-ref sections

### DIFF
--- a/deegree-services/deegree-webservices/src/main/webapp/WEB-INF/weblogic.xml
+++ b/deegree-services/deegree-webservices/src/main/webapp/WEB-INF/weblogic.xml
@@ -8,32 +8,4 @@
     <principal-name>deegree</principal-name>
   </security-role-assignment>
 
-  <library-ref>
-    <library-name>jsf</library-name>
-    <specification-version>2.0</specification-version>
-    <implementation-version>1.0.0.0_2-0-2</implementation-version>
-    <exact-match>true</exact-match>
-  </library-ref>
-
-  <library-ref>
-    <library-name>jersey-bundle</library-name>
-    <specification-version>2.0</specification-version>
-    <implementation-version>1.9.1</implementation-version>
-    <exact-match>true</exact-match>
-  </library-ref>
-
-  <library-ref>
-    <library-name>jsr311-api</library-name>
-    <specification-version>1.1.1</specification-version>
-    <implementation-version>1.1.1</implementation-version>
-    <exact-match>true</exact-match>
-  </library-ref>
-
-  <library-ref>
-    <library-name>jstl</library-name>
-    <specification-version>1.2</specification-version>
-    <implementation-version>1.2.0.1</implementation-version>
-    <exact-match>true</exact-match>
-  </library-ref>
-
 </weblogic-web-app> 


### PR DESCRIPTION
Not needed for WLS 12.1.2; the libs are in the server classpath
