### PR TITLE
Bugfix / enhancement: Prevent duplicate libraries

### DIFF
--- a/deegree-spring/pom.xml
+++ b/deegree-spring/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>deegree-spring</artifactId>
 	<description>deegree Spring framework integration module</description>
-    <name>deegree-spring</name>
+	<name>deegree-spring</name>
 
 	<build>
 		<plugins>
@@ -36,6 +36,12 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
 			<version>${spring.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,12 @@
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>1.8.3</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -358,6 +364,12 @@
         <groupId>commons-digester</groupId>
         <artifactId>commons-digester</artifactId>
         <version>2.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
@@ -776,6 +788,10 @@
           <exclusion>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,12 @@
         <artifactId>httpclient</artifactId>
         <version>4.2.3</version>
         <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-pool</groupId>
@@ -530,11 +536,27 @@
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-impl</artifactId>
         <version>1.2.14</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-api</artifactId>
         <version>1.2.14</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.fastinfoset</groupId>
@@ -709,8 +731,8 @@
         <version>1.7</version>
         <exclusions>
           <exclusion>
+            <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>fop</artifactId>
-            <groupId>fop</groupId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
To prevent duplicate Libraries in build i had enhanced/corrected the excludes.

Actually ther were two  diferent versions of wodstox (ASF 4.1.4 / LGP 4.2.0) and two different commons-logging libraries (commons-logging/jcl-over-slf4j) 

In addition to that change i found out that the dependecy from batik-transcoder to fop has changed and the old exclude of fop:fop didn't work nowadays.

For reference here the dependency:tree output for woodstox/commons-logging:

    [INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ deegree-core-commons ---
    [INFO] org.deegree:deegree-core-commons:jar:3.4-pre16-SNAPSHOT
    [INFO] +- org.deegree:deegree-core-workspace:jar:3.4-pre16-SNAPSHOT:compile
    [INFO] |  \- org.deegree:deegree-core-annotations:jar:3.4-pre16-SNAPSHOT:compile
    [INFO] |     +- log4j:log4j:jar:1.2.17:compile
    [INFO] |     +- org.slf4j:slf4j-api:jar:1.7.5:compile
    [INFO] |     +- org.slf4j:slf4j-log4j12:jar:1.7.5:compile
    [INFO] |     +- org.slf4j:jcl-over-slf4j:jar:1.7.5:compile
    [INFO] |     \- commons-io:commons-io:jar:2.4:compile
    [INFO] +- org.codehaus.woodstox:woodstox-core-lgpl:jar:4.2.0:compile
    [INFO] |  \- org.codehaus.woodstox:stax2-api:jar:3.1.1:compile
    [INFO] +- org.apache.ws.commons.axiom:axiom-impl:jar:1.2.14:compile
    [INFO] |  +- org.apache.geronimo.specs:geronimo-activation_1.1_spec:jar:1.1:compile
    [INFO] |  +- org.apache.geronimo.specs:geronimo-javamail_1.4_spec:jar:1.7.1:compile
    [INFO] |  +- org.codehaus.woodstox:woodstox-core-asl:jar:4.1.4:compile
    [INFO] |  +- commons-logging:commons-logging:jar:1.1.1:compile
    [INFO] |  \- org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:jar:1.0.1:compile
    [INFO] +- org.apache.ws.commons.axiom:axiom-api:jar:1.2.14:compile
    [INFO] |  \- org.apache.james:apache-mime4j-core:jar:0.7.2:compile

And the the output for fop

    [INFO] org.deegree:deegree-core-style:jar:3.4-pre16-SNAPSHOT
    ...
    [INFO] +- org.apache.xmlgraphics:batik-transcoder:jar:1.7:compile
    [INFO] |  +- org.apache.xmlgraphics:fop:jar:0.94:compile
    [INFO] |  |  +- org.apache.xmlgraphics:xmlgraphics-commons:jar:1.2:compile
    [INFO] |  |  +- commons-logging:commons-logging:jar:1.0.4:compile
    [INFO] |  |  +- org.apache.avalon.framework:avalon-framework-api:jar:4.3.1:compile
    [INFO] |  |  \- org.apache.avalon.framework:avalon-framework-impl:jar:4.3.1:compile
    [INFO] |  \- org.apache.xmlgraphics:batik-svggen:jar:1.7:compile

