### PR TITLE
Bugfix: Prevent NPE if no style store is referenced in auto layer creation

### DIFF
--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/AutoCoverageLayerBuilder.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/AutoCoverageLayerBuilder.java
@@ -86,7 +86,10 @@ class AutoCoverageLayerBuilder {
         String cid = cfg.getCoverageStoreId();
         String sid = cfg.getStyleStoreId();
         Coverage cov = workspace.getResource( CoverageProvider.class, cid );
-        StyleStore sstore = workspace.getResource( StyleStoreProvider.class, sid );
+        StyleStore sstore = null;
+        if ( sid != null ) {
+            sstore = workspace.getResource( StyleStoreProvider.class, sid );
+        }
 
         SpatialMetadata smd = new SpatialMetadata( cov.getEnvelope(),
                                                    Collections.singletonList( cov.getCoordinateSystem() ) );

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/AutoFeatureLayerBuilder.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/AutoFeatureLayerBuilder.java
@@ -95,7 +95,10 @@ class AutoFeatureLayerBuilder {
                                              + " is not available." );
         }
         id = auto.getStyleStoreId();
-        StyleStore sstore = workspace.getResource( StyleStoreProvider.class, id );
+        StyleStore sstore = null;
+        if ( id != null ) {
+            sstore = workspace.getResource( StyleStoreProvider.class, id );
+        }
         if ( id != null && sstore == null ) {
             throw new ResourceInitException( "Feature layer config was invalid, style store with id " + id
                                              + " is not available." );


### PR DESCRIPTION
Currently the Workspace.getResource defines that "id" is not null, so creating a autolayer for coverage (or feature) creates a NPE if no stylestore is referenced.

This pull prevents the NPE so the layer will be created like stated in the webservices handbook. 

References:
[Workspace.getResource(...)](/deegree/deegree3/blob/master/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/Workspace.java#L112)
[Hanbook Autolayer of Feature](/deegree/deegree3/blob/master/deegree-services/deegree-webservices-handbook/src/main/sphinx/layers.rst#auto-layers)
[Hanbook Autolayer of Coverage](/deegree/deegree3/blob/master/deegree-services/deegree-webservices-handbook/src/main/sphinx/layers.rst#auto-layers-1)
