### PR TITLE
Bugfix/Enhancement: Prevent duplicyte dependency to jsr173 in 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,6 +525,12 @@
         <groupId>com.sun.xml.fastinfoset</groupId>
         <artifactId>FastInfoset</artifactId>
         <version>1.2.12</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jsr173_api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>jaxen</groupId>


### PR DESCRIPTION
The dependecy com.sun.xml.fastinfoset:FastInfoset depends on the jsr173 api which was integrated into the JDK 1.6 in [1] which made this depdendency obsolete.

On Weblogic 10.3 this dependecy creates in special cases realy ugly jaxb/xml processing errors.

[1] http://www.oracle.com/technetwork/java/javase/features-141434.html (Search for jsr173)
