### PR TITLE
GMLObjectWalker: Add support for non-feature/non-geometry object types

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/utils/GMLObjectVisitor.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/utils/GMLObjectVisitor.java
@@ -36,22 +36,23 @@
 package org.deegree.gml.utils;
 
 import org.deegree.commons.tom.Reference;
+import org.deegree.commons.tom.gml.GMLObject;
 import org.deegree.feature.Feature;
 import org.deegree.geometry.Geometry;
 
 /**
  * Visitor interface for the {@link GMLObjectWalker}.
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
 public interface GMLObjectVisitor {
 
     /**
      * Called when a {@link Geometry} node is encountered.
-     * 
+     *
      * @param geom
      *            geometry, never <code>null</code>
      * @return <code>true</code>, if children of this node shall be traversed, <code>false</code> otherwise
@@ -60,7 +61,7 @@ public interface GMLObjectVisitor {
 
     /**
      * Called when a {@link Feature} node is encountered.
-     * 
+     *
      * @param feature
      *            feature, never <code>null</code>
      * @return <code>true</code>, if children of this node shall be traversed, <code>false</code> otherwise
@@ -68,11 +69,21 @@ public interface GMLObjectVisitor {
     public boolean visitFeature( Feature feature );
 
     /**
+     * Called when a {@link GMLObject} node (not geometry, not feature) is encountered.
+     *
+     * @param o
+     *            object, never <code>null</code>
+     * @return <code>true</code>, if children of this node shall be traversed, <code>false</code> otherwise
+     */
+    public boolean visitObject( GMLObject o );
+
+    /**
      * Called when a {@link Reference} node is encountered.
-     * 
+     *
      * @param ref
      *            reference, never <code>null</code>
      * @return <code>true</code>, if the referenced object shall be traversed, <code>false</code> otherwise
      */
     public boolean visitReference( Reference<?> ref );
+
 }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/utils/GMLObjectWalker.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/utils/GMLObjectWalker.java
@@ -133,10 +133,11 @@ public class GMLObjectWalker {
                     traverseGeometry( g );
                 }
             } else {
-                traverseGMLObject( node );
+                if ( visitor.visitObject( node ) ) {
+                    traverseGMLObject( node );
+                }
             }
         }
-
     }
 
     private void traverseGMLObject( GMLObject node ) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
@@ -83,13 +83,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * {@link FeatureStoreTransaction} implementation used by the {@link MemoryFeatureStore}.
- * 
+ *
  * @see MemoryFeatureStore
  * @see StoredFeatures
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
 class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
@@ -108,7 +108,7 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
 
     /**
      * Creates a new {@link MemoryFeatureStoreTransaction} instance.
-     * 
+     *
      * @param fs
      *            invoking feature store instance, must not be <code>null</code>
      * @param sf
@@ -277,6 +277,11 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
             }
 
             @Override
+            public boolean visitObject( GMLObject o ) {
+                return true;
+            }
+
+            @Override
             public boolean visitReference( Reference<?> ref ) {
                 return true;
             }
@@ -290,7 +295,7 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
 
     /**
      * Assigns an id to every {@link Feature} / {@link Geometry} in the given collection.
-     * 
+     *
      * @param fc
      *            feature collection, must not be <code>null</code>
      * @param mode
@@ -334,6 +339,11 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
             public boolean visitReference( Reference<?> ref ) {
                 return true;
             }
+
+            @Override
+            public boolean visitObject( GMLObject o ) {
+                return true;
+            }
         };
         try {
             new GMLObjectWalker( visitor ).traverse( fc );
@@ -359,6 +369,11 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
             @Override
             public boolean visitReference( Reference<?> ref ) {
                 fixReference( ref );
+                return true;
+            }
+
+            @Override
+            public boolean visitObject( GMLObject o ) {
                 return true;
             }
         };

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/StoredFeatures.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/StoredFeatures.java
@@ -1,5 +1,5 @@
 //$HeadURL$
-/*---------------------------------------------------------------------------- 
+/*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
  Copyright (C) 2001-2013 by:
  Department of Geography, University of Bonn
@@ -86,10 +86,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates stored feature instances plus index structures for id and spatial queries.
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
 class StoredFeatures {
@@ -110,7 +110,7 @@ class StoredFeatures {
 
     /**
      * Creates a new {@link StoredFeatures} instance.
-     * 
+     *
      * @param schema
      *            application schema, must not be <code>null</code>
      * @param storageCRS
@@ -143,7 +143,7 @@ class StoredFeatures {
 
     /**
      * Returns the stored features of the given type.
-     * 
+     *
      * @param ft
      *            feature type, must not be <code>null</code>
      * @return stored features of the given type, never <code>null</code>
@@ -154,7 +154,7 @@ class StoredFeatures {
 
     /**
      * Performs the given {@link Query} on the stored features.
-     * 
+     *
      * @param query
      *            query to be performed, must not be <code>null</code>
      * @return resulting features, never <code>null</code>
@@ -234,7 +234,7 @@ class StoredFeatures {
 
     /**
      * Returns the {@link Envelope} for the stored features of the specified type.
-     * 
+     *
      * @param ftName
      *            feature type name, must not be <code>null</code>
      * @return envelope, can be <code>null</code>
@@ -245,7 +245,7 @@ class StoredFeatures {
 
     /**
      * Adds the given {@link Feature} instance and updates the index structures.
-     * 
+     *
      * @param features
      *            feature to be added, must not be <code>null</code> and must have an id (as well as every geometry)
      */
@@ -270,7 +270,7 @@ class StoredFeatures {
 
     /**
      * Removes the given {@link Feature} instance and updates the index structures.
-     * 
+     *
      * @param feature
      *            feature to be removed, must not be <code>null</code>
      */
@@ -289,9 +289,10 @@ class StoredFeatures {
 
     /**
      * Updates the given {@link Feature} instance and updates the index structures.
-     * 
-     * TODO Use a copy of the original feature to avoid modifications on rollback. Difficult part: Consider updating of references.
-     * 
+     *
+     * TODO Use a copy of the original feature to avoid modifications on rollback. Difficult part: Consider updating of
+     * references.
+     *
      * @param feature
      *            feature to be updated, must not be <code>null</code>
      * @param replacementProps
@@ -299,7 +300,7 @@ class StoredFeatures {
      */
     void updateFeature( Feature feature, List<ParsedPropertyReplacement> replacementProps )
                             throws FeatureStoreException {
-       
+
         for ( ParsedPropertyReplacement replacement : replacementProps ) {
             Property prop = replacement.getNewValue();
             UpdateAction updateAction = replacement.getUpdateAction();
@@ -481,6 +482,11 @@ class StoredFeatures {
                     return false;
                 }
                 idToObject.put( feature.getId(), feature );
+                return true;
+            }
+
+            @Override
+            public boolean visitObject( GMLObject o ) {
                 return true;
             }
 


### PR DESCRIPTION
Add support for non-feature/non-geometry object types to the GMLObjectWalker and GMLObjectVisitor utility classes. This is needed for full traversal of object graphs that contain TimeSlice and TimeObject instances.