### PR TITLE
Enhance handling of nodata values in coverages

### DIFF
--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/DefaultCoverageBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/DefaultCoverageBuilder.java
@@ -41,6 +41,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.coverage.persistence;
 
+import static org.deegree.coverage.raster.utils.RasterBuilder.setNoDataValue;
 import static org.deegree.coverage.raster.utils.RasterFactory.loadRasterFromFile;
 
 import java.io.File;
@@ -274,6 +275,7 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
                     if ( raster != null ) {
                         raster.setCoordinateSystem( crs );
                     }
+                    setNoDataValue( raster, config.getNodata() );
                     return raster;
                 }
             } catch ( IOException e ) {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/DefaultCoverageBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/DefaultCoverageBuilder.java
@@ -46,6 +46,7 @@ import static org.deegree.coverage.raster.utils.RasterFactory.loadRasterFromFile
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -110,7 +111,7 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
             return fromJAXB( (MultiResolutionRasterConfig) config, null );
         }
         if ( config instanceof RasterConfig ) {
-            return fromJAXB( (RasterConfig) config, null, null );
+            return fromJAXB( (RasterConfig) config, null, null, ( (RasterConfig) config ).getNodata() );
         }
         LOG.warn( "An unknown object '{}' came out of JAXB parsing. This is probably a bug.", config.getClass() );
         return null;
@@ -204,7 +205,7 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
             mrr.setCoordinateSystem( crs );
             for ( Resolution resolution : mrrConfig.getResolution() ) {
                 if ( resolution != null ) {
-                    AbstractRaster rasterLevel = fromJAXB( resolution, options, crs );
+                    AbstractRaster rasterLevel = fromJAXB( resolution, options, crs, mrrConfig.getNodata() );
                     mrr.addRaster( rasterLevel );
                 }
             }
@@ -228,7 +229,8 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
      * @param adapter
      * @return a corresponding raster, null if files could not be fund
      */
-    private AbstractRaster fromJAXB( AbstractRasterType config, RasterIOOptions options, ICRS parentCrs ) {
+    private AbstractRaster fromJAXB( AbstractRasterType config, RasterIOOptions options, ICRS parentCrs,
+                                     BigDecimal noData ) {
         if ( config != null ) {
             String defCRS = config.getStorageCRS();
             ICRS crs = null;
@@ -275,7 +277,7 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
                     if ( raster != null ) {
                         raster.setCoordinateSystem( crs );
                     }
-                    setNoDataValue( raster, config.getNodata() );
+                    setNoDataValue( raster, noData );
                     return raster;
                 }
             } catch ( IOException e ) {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageBuilder.java
@@ -44,6 +44,7 @@ package org.deegree.coverage.persistence.pyramid;
 import static org.deegree.coverage.raster.io.RasterIOOptions.CRS;
 import static org.deegree.coverage.raster.io.RasterIOOptions.IMAGE_INDEX;
 import static org.deegree.coverage.raster.io.RasterIOOptions.OPT_FORMAT;
+import static org.deegree.coverage.raster.utils.RasterBuilder.setNoDataValue;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageReader;
 
 import java.util.Iterator;
@@ -129,8 +130,10 @@ public class PyramidCoverageBuilder implements ResourceBuilder<Coverage> {
                 opts.add( IMAGE_INDEX, "" + i );
                 opts.add( OPT_FORMAT, "tiff" );
                 opts.add( CRS, crs.getAlias() );
+
                 AbstractRaster raster = RasterFactory.loadRasterFromFile( metadata.getLocation().resolveToFile( file ),
                                                                           opts, metadata );
+                setNoDataValue( raster, config.getNodata() );
                 raster.setCoordinateSystem( crs );
                 mrr.addRaster( raster );
             }
@@ -140,6 +143,7 @@ public class PyramidCoverageBuilder implements ResourceBuilder<Coverage> {
             throw new ResourceInitException( "Could not read pyramid configuration file.", e );
         }
     }
+
 
     private static ICRS getCRS( IIOMetadata metaData ) {
         GeoTiffIIOMetadataAdapter geoTIFFMetaData = new GeoTiffIIOMetadataAdapter( metaData );

--- a/deegree-core/deegree-core-coverage/src/main/resources/META-INF/schemas/datasource/coverage/raster/3.1.0/pyramid.xsd
+++ b/deegree-core/deegree-core-coverage/src/main/resources/META-INF/schemas/datasource/coverage/raster/3.1.0/pyramid.xsd
@@ -17,6 +17,8 @@
         <!-- overrides the one in the geotiff -->
         <element name="CRS" type="string" minOccurs="0" />
       </sequence>
+      <!-- value assigned to the no data pixels (e.g the background) -->
+      <attribute name="nodata" type="decimal" />
       <attribute name="configVersion" use="required" fixed="3.1.0" />
     </complexType>
   </element>

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/coveragestores.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/coveragestores.rst
@@ -104,3 +104,4 @@ The following example shows, how to configure a coverage pyramid:
 
 * A Pyramid contains a PyramidFile parameter with the path to the pyramid as its value.
 * A Pyramid contains a CRS parameter describing the source CRS of the pyramid as EPSG code.
+* As in Raster, the nodata attribute can be optionally used to declare a nodata value.


### PR DESCRIPTION
Until now, pyramid configurations did not provide a way to set a nodata value. That results in unexpected images, if the bounding box is not completely covered by the provided image or i.e. the image is cut with the elevation parameter.
Pixels not covered by the image or cut out are assigned a value of 0, but that is not neccessarily the nodata value of the image. So it may be rendered in an unexpected colour.

This pull request provides the possibility to configure the value set for nodata pixels. If it is set to the appropriate value (like nodata or background colour in style configuration), it will be rendered as expected.