### PR TITLE
Fixed path to filesystem tile store template

### DIFF
--- a/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.filesystem.FileSystemTileStoreProvider
+++ b/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.filesystem.FileSystemTileStoreProvider
@@ -1,2 +1,2 @@
 name=Filesystem
-example1_location=/META-INF/schemas/datasource/tile/filesystem/3.2.0/example.xml
+example1_location=/META-INF/schemas/datasource/tile/filesystem/3.4.0/example.xml


### PR DESCRIPTION
During startup following error appears:
[11:20:50] ERROR: [ResourceProviderMetadata] Configuration example file '/META-INF/schemas/datasource/tile/filesystem/3.2.0/example.xml' is missing on classpath.
...
[11:41:38] ERROR: [JsfUtils] Internal error: Example template missing!?

Also, no filesystem tile store can be created with the GUI as there is no template referenced.

This pull request fixes the path to the template.