### PR TITLE
Fixed creation of GdalTileStore via GUI

### DIFF
--- a/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.gdal.GdalTileStoreProvider
+++ b/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.gdal.GdalTileStoreProvider
@@ -1,0 +1,5 @@
+name=GDALTileStore
+example1_name=minimal
+example1_location=/META-INF/schemas/datasource/tile/gdal/3.4.0/example_minimal.xml
+example2_name=complex
+example2_location=/META-INF/schemas/datasource/tile/gdal/3.4.0/example_complex.xml


### PR DESCRIPTION
Creation of a GdalTileStore via GUI fails as there is no template available.

This fix adds the missing GdalTileStoreProvider resource provider referencing the templates.