### PR TITLE
Fixed creation of GdalLayerStore via console

### DIFF
--- a/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.layer.persistence.gdal.GdalLayerStoreProvider
+++ b/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.layer.persistence.gdal.GdalLayerStoreProvider
@@ -1,0 +1,2 @@
+name=GDALLayerStore
+example1_location=/META-INF/schemas/layers/gdal/3.4.0/example.xml


### PR DESCRIPTION
Creation of a GdalLayerStore via console fails as there is no template available.

This fix adds the missing GdalLayerStoreProvider resource provider referencing the templates.