### PR TITLE
Fixed creation of new resources via console

### DIFF
--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/connection/remoteows/CreateRemoteOwsBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/connection/remoteows/CreateRemoteOwsBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.connection.remoteows;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.remoteows.RemoteOWSManager;
 
 /**
  * JSF backing bean for "Create new remote OWS connection" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.4
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateRemoteOwsBean extends AbstractCreateResourceBean {
 
     public CreateRemoteOwsBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/coverage/CreateCoverageBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/coverage/CreateCoverageBean.java
@@ -28,20 +28,20 @@
 package org.deegree.console.datastore.coverage;
 
 import javax.faces.bean.ManagedBean;
-import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.coverage.persistence.CoverageManager;
 
 /**
  * JSF backing bean for "Create new coverage" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateCoverageBean extends AbstractCreateResourceBean {
 
     public CreateCoverageBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/feature/CreateFeatureStoreBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/feature/CreateFeatureStoreBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.datastore.feature;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.feature.persistence.FeatureStoreManager;
 
 /**
  * JSF backing bean for "Create new feature store" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.4
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateFeatureStoreBean extends AbstractCreateResourceBean {
 
     public CreateFeatureStoreBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/metadata/CreateMetadataStoreBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/metadata/CreateMetadataStoreBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.datastore.metadata;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.metadata.persistence.MetadataStoreManager;
 
 /**
  * JSF backing bean for "Create new metadata store" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateMetadataStoreBean extends AbstractCreateResourceBean {
 
     public CreateMetadataStoreBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/tile/CreateTileStoreBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/datastore/tile/CreateTileStoreBean.java
@@ -28,20 +28,20 @@
 package org.deegree.console.datastore.tile;
 
 import javax.faces.bean.ManagedBean;
-import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.tile.persistence.TileStoreManager;
 
 /**
  * JSF backing bean for "Create new tile store" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateTileStoreBean extends AbstractCreateResourceBean {
 
     public CreateTileStoreBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/layer/layer/CreateLayerBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/layer/layer/CreateLayerBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.layer.layer;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.layer.persistence.LayerStoreManager;
 
 /**
  * JSF backing bean for "Create new layer" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateLayerBean extends AbstractCreateResourceBean {
 
     public CreateLayerBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/layer/style/CreateStyleBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/layer/style/CreateStyleBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.layer.style;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.style.persistence.StyleStoreManager;
 
 /**
  * JSF backing bean for "Create new style" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateStyleBean extends AbstractCreateResourceBean {
 
     public CreateStyleBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/layer/theme/CreateThemeBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/layer/theme/CreateThemeBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.layer.theme;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.theme.persistence.ThemeManager;
 
 /**
  * JSF backing bean for "Create new theme" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateThemeBean extends AbstractCreateResourceBean {
 
     public CreateThemeBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/process/CreateProcessBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/process/CreateProcessBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.process;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.services.wps.ProcessManager;
 
 /**
  * JSF backing bean for "Create new process" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateProcessBean extends AbstractCreateResourceBean {
 
     public CreateProcessBean() {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/webservices/CreateServiceBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/webservices/CreateServiceBean.java
@@ -29,19 +29,20 @@ package org.deegree.console.webservices;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
+import javax.faces.bean.ViewScoped;
 
 import org.deegree.console.AbstractCreateResourceBean;
 import org.deegree.services.OwsManager;
 
 /**
  * JSF backing bean for "Create new webservice" view.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.3
  */
 @ManagedBean
-@RequestScoped
+@ViewScoped
 public class CreateServiceBean extends AbstractCreateResourceBean {
 
     public CreateServiceBean() {


### PR DESCRIPTION
Fixes the dreaded "j_idt78:j_idt87: Validation Error: Value is not valid" when creating new resources.

This was caused by the wrong scope for the managed beans. Due to Ajax-updating of the templates-drop-down menu, request scope is not enough. Changed relevant JSF beans to view scope.

Fixes #340, #341, #343, #344, #345