### PR TITLE
Fixed creation of MergingTileStore via console

### DIFF
--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/resources/META-INF/schemas/datasource/tile/merge/3.4.0/example.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/resources/META-INF/schemas/datasource/tile/merge/3.4.0/example.xml
@@ -1,0 +1,5 @@
+<mer:MergingTileStore configVersion="3.4.0" xmlns:mer="http://www.deegree.org/datasource/tile/merge">
+  <mer:TileMatrixSetId>string</mer:TileMatrixSetId>
+  <!--1 or more repetitions:-->
+  <mer:TileStoreId>string</mer:TileStoreId>
+</mer:MergingTileStore>

--- a/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.merge.MergingTileStoreProvider
+++ b/deegree-services/deegree-webservices/src/main/resources/META-INF/console/resourceprovider/org.deegree.tile.persistence.merge.MergingTileStoreProvider
@@ -1,0 +1,2 @@
+name=MergingTileStore
+example1_location=/META-INF/schemas/datasource/tile/merge/3.4.0/example.xml


### PR DESCRIPTION
MergingTileStores could not be created via console as the template was missing.

This pull request fixes the issue by creating a MergingTileStore resource provider and an example.xml (was automatically generated from schema).