### PR TITLE
Replace the outdated codehaus plugin by the official Apache Tomcat Maven plugin

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -60,10 +60,10 @@
         </executions>
       </plugin>    
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <configuration>
-          <ignorePackaging>true</ignorePackaging>
+          <path>/</path>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -133,9 +133,9 @@
           <version>1.1</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>tomcat-maven-plugin</artifactId>
-          <version>1.1</version>
+          <groupId>org.apache.tomcat.maven</groupId>
+          <artifactId>tomcat7-maven-plugin</artifactId>
+          <version>2.2</version>
         </plugin>
         <plugin>
           <groupId>org.antlr</groupId>


### PR DESCRIPTION
Modifies the maven plugin to run the web application to the official Apache Tomcat Maven plugin.
To use the plugin run
```deegree-services/deegree-webservices> mvn tomcat7:run```
or
```deegree-services/deegree-webservices> mvn tomcat7:run-war```
and then open <http://localhost:8080/> to access the deegree console.