### PR TITLE
SQLFeatureStore: Respect configured feature resolver in BLOB mode

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -514,7 +514,7 @@ public class SQLFeatureStore implements FeatureStore {
                 LOG.debug( "Recreating object '" + id + "' from bytea." );
                 BlobCodec codec = blobMapping.getCodec();
                 geomOrFeature = codec.decode( rs.getBinaryStream( 1 ), getNamespaceContext(), getSchema(),
-                                              blobMapping.getCRS(), new FeatureStoreGMLIdResolver( this ) );
+                                              blobMapping.getCRS(), resolver );
                 if ( getCache() != null ) {
                     getCache().add( geomOrFeature );
                 }


### PR DESCRIPTION
Prior to this patch, for features queried by id in BLOB mode, the resolver was always set to a new instance of FeatureStoreGMLIdResolver.