### PR TITLE
Bugfix/3.4 renderer clipping and crash fix

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/GeometryClipper.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/GeometryClipper.java
@@ -41,6 +41,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.rendering.r2d;
 
+import static org.deegree.commons.utils.math.MathUtils.isZero;
 import static org.deegree.rendering.r2d.OrientationFixer.fixOrientation;
 
 import org.deegree.geometry.Envelope;
@@ -51,6 +52,9 @@ import org.deegree.geometry.primitive.Polygon;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.DefaultEnvelope;
 import org.deegree.geometry.standard.primitive.DefaultPoint;
+import org.deegree.style.styling.LineStyling;
+import org.deegree.style.styling.PolygonStyling;
+import org.deegree.style.styling.components.Stroke;
 
 /**
  * Responsible for clipping geometries to the area of the viewport.
@@ -108,4 +112,27 @@ class GeometryClipper {
         return geom;
     }
 
+    public static boolean isGenerationExpensive( PolygonStyling styling ) {
+        if ( styling == null )
+            return false;
+        
+        return ( !isZero( styling.perpendicularOffset ) || isGenerationExpensive( styling.stroke ));
+    }
+
+    public static boolean isGenerationExpensive( LineStyling styling ) {
+        if ( styling == null )
+            return false;
+        
+        return ( !isZero( styling.perpendicularOffset ) || isGenerationExpensive( styling.stroke ) );
+    }
+
+    private static boolean isGenerationExpensive( Stroke styling ) {
+        if ( styling == null )
+            return false;
+
+        if ( styling.dasharray != null || styling.stroke != null )
+            return true;
+
+        return false;
+    }
 }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
@@ -37,6 +37,7 @@
 package org.deegree.rendering.r2d;
 
 import static org.deegree.geometry.utils.GeometryUtils.envelopeToPolygon;
+import static org.deegree.rendering.r2d.GeometryClipper.isGenerationExpensive;
 import static org.deegree.rendering.r2d.RenderHelper.calculateResolution;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -176,7 +177,7 @@ public class Java2DRenderer implements Renderer {
             return;
         }
         Geometry renderGeometry = null;
-        if ( isPathGenerationExpensive( styling ) ) {
+        if ( isGenerationExpensive( styling ) ) {
             renderGeometry = transformToWorldCrsAndClip( geom );
             if ( renderGeometry == null ) {
                 return;
@@ -198,10 +199,6 @@ public class Java2DRenderer implements Renderer {
         }
     }
 
-    private boolean isPathGenerationExpensive( LineStyling styling ) {
-        return styling.stroke != null && styling.stroke.stroke != null;
-    }
-
     @Override
     public void render( final PolygonStyling styling, final Geometry geom ) {
         if ( geom == null ) {
@@ -214,8 +211,8 @@ public class Java2DRenderer implements Renderer {
             LOG.warn( "Trying to render line with polygon styling." );
         }
         Geometry renderGeometry = null;
-        if ( isPathGenerationExpensive( styling ) ) {
-            renderGeometry = transformToWorldCrsAndClip( renderGeometry );
+        if ( isGenerationExpensive( styling ) ) {
+            renderGeometry = transformToWorldCrsAndClip( geom );
             if ( renderGeometry == null ) {
                 return;
             }
@@ -233,10 +230,6 @@ public class Java2DRenderer implements Renderer {
                 render( styling, g );
             }
         }
-    }
-
-    private boolean isPathGenerationExpensive( PolygonStyling styling ) {
-        return styling.stroke != null && styling.stroke.stroke != null;
     }
 
     @Override
@@ -275,6 +268,10 @@ public class Java2DRenderer implements Renderer {
 
     Geometry transformToWorldCrsAndClip( final Geometry geom ) {
         final Geometry geomInWorldCrs = rendererContext.geomHelper.transform( geom );
+        if ( rendererContext.clipper == null ) {
+            LOG.warn( "No clipper defined, geometry will be ignored for rendering" );
+            return null;
+        }
         return rendererContext.clipper.clipGeometry( geomInWorldCrs );
     }
 


### PR DESCRIPTION
This Bugfix fixes the Polygon rendering of clipped Polygons and also extends the logic of clipping for circumstances to be more robust.

I also moved the clipping 	decision methods to the GeometryClipper to be easier readable.

Currently if a stroke contains a dasharray an a logical defect geometry (for example one point a million meter away from the rest of the points) the jdk renderer will either consume a extrem large ammount of time or in the worst case the jdk will crash.

As this situation is extreamly annoying i also created a testcase to prevent the clipper from missing this situation.
(So for example if the patch would be reversed the JUnit Testcase will catch the timeout and fail)