### PR TITLE
Remove GetMapFormat enumeration

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -735,15 +735,20 @@ public class WMSController extends AbstractOWS {
         return featureInfoManager;
     }
     
-    private void addSupportedImageFormats( DeegreeWMS conf ) {
+    private void addSupportedImageFormats( DeegreeWMS conf ) {        
         if ( conf.getGetMapFormats() != null ) {
             GetMapFormatsType getMapFormats = conf.getGetMapFormats();
             List<String> getMapFormatList = getMapFormats.getGetMapFormat();
+            
+            Collection<String> providedFormats = ouputFormatProvider.getSupportedOutputFormats();
             for ( String getMapFormat : getMapFormatList ) {
-                supportedImageFormats.add( getMapFormat );
+                if ( providedFormats.contains ( getMapFormat ) ) {                
+                    supportedImageFormats.add( getMapFormat );
+                } else {
+                    LOG.warn( "Unsupported GetMapFormat configured: {}", getMapFormat );
+                }
             }
-        }
-        if ( supportedImageFormats.isEmpty() ) {
+        } else {
             supportedImageFormats.addAll( ouputFormatProvider.getSupportedOutputFormats() );
         }
     }

--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
@@ -91,20 +91,7 @@
 
   <complexType name="GetMapFormatsType">
     <sequence>
-      <element name="GetMapFormat" minOccurs="0" maxOccurs="unbounded">
-        <simpleType>
-          <restriction base="string">
-            <enumeration value="image/png" />
-            <enumeration value="image/png; subtype=8bit" />
-            <enumeration value="image/png; mode=8bit" />
-            <enumeration value="image/gif" />
-            <enumeration value="image/jpeg" />
-            <enumeration value="image/tiff" />
-            <enumeration value="image/x-ms-bmp" />
-            <enumeration value="image/svg+xml" />
-          </restriction>
-        </simpleType>
-      </element>
+      <element name="GetMapFormat" minOccurs="0" maxOccurs="unbounded" type="string" />        
     </sequence>
   </complexType>
   


### PR DESCRIPTION
Suggest to remove the GetMapFormat from the wms configuration xml schema.

Rationale: 
- prevent inconsistencies between Java code and this xml schema.
- the wms shouldn't deal directly with supported image formats because output format handling is provided by the OutputFormatProvider. At the moment we've only one implementation of this OutputFormatProvider but this could (should?) be an interesting extension point.
