### PR TITLE
Switch travis to new container-based infrastructure and enable caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# cache for public repo on container-based infrastructure see:
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure
+# http://docs.travis-ci.com/user/caching
+#
+sudo: false
 language: java
 jdk:
   - openjdk7
@@ -5,3 +10,6 @@ jdk:
 install: "travis_retry mvn install -Pintegration-tests -DskipTests=true -B -V"
 script: "travis_retry mvn verify -Pintegration-tests -B -V"
 env: MAVEN_OPTS="-XX:MaxPermSize=128m"
+cache:
+  directories:
+    - $HOME/.m2/repository/


### PR DESCRIPTION
This Pull Request tests the new container-based infrastructure of travis which enables public repositories to use a faster an cacheing enabled build environment [1]. 

[1] http://docs.travis-ci.com/user/workers/container-based-infrastructure
[2] http://docs.travis-ci.com/user/caching

Before this pull Request can be used, the travis build result has to be checked.