### PR TITLE
Bugfix/3.4 fix JDK 6 compatibility

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/GMLObjectNavigator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/GMLObjectNavigator.java
@@ -35,7 +35,6 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.feature.xpath;
 
-import static java.util.Collections.emptyIterator;
 import static org.deegree.commons.xml.CommonNamespaces.GML3_2_NS;
 import static org.deegree.commons.xml.CommonNamespaces.GMLNS;
 import static org.jaxen.JaxenConstants.EMPTY_ITERATOR;
@@ -65,7 +64,6 @@ import org.deegree.feature.xpath.node.PropertyNode;
 import org.deegree.feature.xpath.node.XMLElementNode;
 import org.deegree.feature.xpath.node.XPathNode;
 import org.jaxen.DefaultNavigator;
-import org.jaxen.JaxenConstants;
 import org.jaxen.XPath;
 import org.jaxen.saxpath.SAXPathException;
 import org.jaxen.util.SingleObjectIterator;
@@ -147,7 +145,7 @@ class GMLObjectNavigator extends DefaultNavigator {
                 return attrNodes.iterator();
             }
         }
-        return JaxenConstants.EMPTY_ITERATOR;
+        return EMPTY_ITERATOR;
     }
 
     /**
@@ -261,7 +259,7 @@ class GMLObjectNavigator extends DefaultNavigator {
                     iter = new SingleObjectIterator( new PrimitiveNode<Property>( (PropertyNode) node,
                                                                                   (PrimitiveValue) propValue ) );
                 } else if ( propValue == null ) {
-                    iter = emptyIterator();
+                    iter = EMPTY_ITERATOR;
                 } else {
                     // TODO remove this case
                     iter = new SingleObjectIterator(


### PR DESCRIPTION
In Pull Request #466 a JDK 6 the Collections.emptyIterator() was used which is not available in JDK6 see [1].
The class also used the Jaxen.EMPTY_ITERATOR constant, so i switched to this and i also harmonized the use of the constant.

[1] http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#emptyIterator%28%29