### PR TITLE
3.4 bugfix featureinfo queryable

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -233,12 +233,12 @@ public class ConfigUtils {
         }
         if ( cfg.getFeatureInfo() != null ) {
             if ( cfg.getFeatureInfo().isEnabled() ) {
-                rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+                rad = Math.max( 0, cfg.getFeatureInfo().getPixelRadius().intValue() );
             } else {
                 rad = 0;
             }
         } else if ( cfg.getFeatureInfoRadius() != null ) {
-            rad = cfg.getFeatureInfoRadius();
+            rad = Math.max( 0, cfg.getFeatureInfoRadius() );
         }
         return new MapOptions( quali, interpol, alias, maxFeats, rad );
     }

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -231,8 +231,12 @@ public class ConfigUtils {
         if ( cfg.getMaxFeatures() != null ) {
             maxFeats = cfg.getMaxFeatures();
         }
-        if ( cfg.getFeatureInfo() != null && cfg.getFeatureInfo().isEnabled() ) {
-            rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+        if ( cfg.getFeatureInfo() != null ) {
+            if ( cfg.getFeatureInfo().isEnabled() ) {
+                rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+            } else {
+                rad = 0;
+            }
         } else if ( cfg.getFeatureInfoRadius() != null ) {
             rad = cfg.getFeatureInfoRadius();
         }

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -212,7 +212,7 @@ public class ConfigUtils {
         Quality quali = null;
         Interpolation interpol = null;
         int maxFeats = -1;
-        int rad = 1;
+        int rad = -1;
         try {
             alias = Antialias.valueOf( cfg.getAntiAliasing() );
         } catch ( Throwable e ) {

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/metadata/LayerMetadata.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/metadata/LayerMetadata.java
@@ -165,13 +165,16 @@ public class LayerMetadata {
     }
 
     /**
-     * @return the queryable
+     * @return true if the layer can be queried
+     * @see MapOptions#getFeatureInfoRadius()
      */
     public boolean isQueryable() {
         if ( mapOptions == null ) {
             return true;
         }
-        return mapOptions.getFeatureInfoRadius() > 0;
+        
+        //TRICKY assume that, the service is query able by default (<0) 
+        return mapOptions.getFeatureInfoRadius() != 0;
     }
 
     /**

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
@@ -38,9 +38,7 @@ package org.deegree.rendering.r2d.context;
 /**
  * 
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
- * @author last edited by: $Author: stranger $
- * 
- * @version $Revision: $, $Date: $
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public class MapOptions {
 
@@ -60,7 +58,7 @@ public class MapOptions {
         this.interpol = interpol;
         this.antialias = antialias;
         this.maxFeatures = maxFeatures;
-        this.setFeatureInfoRadius( featureInfoRadius );
+        this.featureInfoRadius = featureInfoRadius;
     }
 
     /**
@@ -124,7 +122,7 @@ public class MapOptions {
     }
 
     /**
-     * @return the featureInfoRadius, a value < 1 means disabled
+     * @return the featureInfoRadius, a value < 1 means default, 0 means disabled and > 0 for the radius
      */
     public int getFeatureInfoRadius() {
         return featureInfoRadius;
@@ -132,7 +130,7 @@ public class MapOptions {
 
     /**
      * @param featureInfoRadius
-     *            the featureInfoRadius to set, a value < 1 means disabled
+     *            the featureInfoRadius to set, a value < 1 means default, 0 means disabled and > 0 for the radius
      */
     public void setFeatureInfoRadius( int featureInfoRadius ) {
         this.featureInfoRadius = featureInfoRadius;
@@ -246,5 +244,4 @@ public class MapOptions {
             }
         };
     }
-
 }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
@@ -130,7 +130,11 @@ public class CoverageLayer extends AbstractLayer {
     public CoverageLayerData infoQuery( LayerQuery query, List<String> headers )
                             throws OWSException {
         try {
-            Envelope bbox = query.calcClickBox( query.getRenderingOptions().getFeatureInfoRadius( getMetadata().getName() ) );
+            int layerRadius = -1;
+            if ( getMetadata().getMapOptions() != null ) {
+                layerRadius = getMetadata().getMapOptions().getFeatureInfoRadius();
+            }
+            final Envelope bbox = query.calcClickBox( layerRadius > -1 ? layerRadius : query.getLayerRadius() );
 
             RangeSet filter = dimensionHandler.getDimensionFilter( query.getDimensions(), headers );
 

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
@@ -166,7 +166,11 @@ public class FeatureLayer extends AbstractLayer {
         filter = Filters.and( filter, getStyleFilters( style, query.getScale() ) );
         filter = Filters.and( filter, query.getFilter() );
 
-        final Envelope clickBox = query.calcClickBox( query.getLayerRadius() );
+        int layerRadius = -1;
+        if ( getMetadata().getMapOptions() != null ) {
+            layerRadius = getMetadata().getMapOptions().getFeatureInfoRadius();
+        }
+        final Envelope clickBox = query.calcClickBox( layerRadius > -1 ? layerRadius : query.getLayerRadius() );
 
         filter = (OperatorFilter) addBBoxConstraint( clickBox, filter, null, false );
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -292,6 +292,11 @@ public class MapService {
                      || l.getMetadata().getScaleDenominators().second < scale ) {
                     continue;
                 }
+                
+                if (!l.getMetadata().isQueryable()) {
+                    continue;
+                }
+                
                 list.add( l.infoQuery( query, headers ) );
             }
         }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -330,15 +330,7 @@ public class MapService {
             LayerRef lr = layerItr.next();
             StyleRef sr = styleItr.next();
             OperatorFilter f = filterItr == null ? null : filterItr.next();
-            int layerRadius = 0;
-            for ( org.deegree.layer.Layer l : Themes.getAllLayers( themeMap.get( lr.getName() ) ) ) {
-                if ( l.getMetadata().getMapOptions() != null
-                     && l.getMetadata().getMapOptions().getFeatureInfoRadius() != 1 ) {
-                    layerRadius = l.getMetadata().getMapOptions().getFeatureInfoRadius();
-                } else {
-                    layerRadius = defaultLayerOptions.getFeatureInfoRadius();
-                }
-            }
+            final int layerRadius = defaultLayerOptions.getFeatureInfoRadius();
             LayerQuery query = new LayerQuery( gfi.getEnvelope(), gfi.getWidth(), gfi.getHeight(), gfi.getX(),
                                                gfi.getY(), gfi.getFeatureCount(), f, sr, gfi.getParameterMap(),
                                                gfi.getDimensions(), new MapOptionsMaps(), gfi.getEnvelope(),
@@ -381,7 +373,7 @@ public class MapService {
         return getLegendHandler.getLegendSize( style );
     }
 
-    public BufferedImage getLegend( GetLegendGraphic req ) {
+    public BufferedImage getLegend( GetLegendGraphic req ) throws OWSException {
         return getLegendHandler.getLegend( req );
     }
 


### PR DESCRIPTION
This Pull Requests fixes the the issue #516 by
 * correcting the loading of the layer options (correct the `enabled=false`)
 * enhancement of handling of the three states of the feature info radius
  * < 0 ==> default (as specified in service endpoint)
  * = 0 ==> disabled
  * > 0 ==> user specified radius
 * fixing the `LyerMetadateMerger` to make a Layer in WMS/GetCapabilties only `queryable=0` if all layers in the sub structure are not queryable