### PR TITLE
3.3 bugfix featureinfo queryable

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -229,12 +229,12 @@ public class ConfigUtils {
         }
         if ( cfg.getFeatureInfo() != null ) {
             if ( cfg.getFeatureInfo().isEnabled() ) {
-                rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+                rad = Math.max( 0, cfg.getFeatureInfo().getPixelRadius().intValue() );
             } else {
                 rad = 0;
             }
         } else if ( cfg.getFeatureInfoRadius() != null ) {
-            rad = cfg.getFeatureInfoRadius();
+            rad = Math.max( 0, cfg.getFeatureInfoRadius() );
         }
         return new MapOptions( quali, interpol, alias, maxFeats, rad );
     }

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -227,8 +227,12 @@ public class ConfigUtils {
         if ( cfg.getMaxFeatures() != null ) {
             maxFeats = cfg.getMaxFeatures();
         }
-        if ( cfg.getFeatureInfo() != null && cfg.getFeatureInfo().isEnabled() ) {
-            rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+        if ( cfg.getFeatureInfo() != null ) {
+            if ( cfg.getFeatureInfo().isEnabled() ) {
+                rad = cfg.getFeatureInfo().getPixelRadius().intValue();
+            } else {
+                rad = 0;
+            }
         } else if ( cfg.getFeatureInfoRadius() != null ) {
             rad = cfg.getFeatureInfoRadius();
         }

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -208,7 +208,7 @@ public class ConfigUtils {
         Quality quali = null;
         Interpolation interpol = null;
         int maxFeats = -1;
-        int rad = 1;
+        int rad = -1;
         try {
             alias = Antialias.valueOf( cfg.getAntiAliasing() );
         } catch ( Throwable e ) {

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/metadata/LayerMetadata.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/metadata/LayerMetadata.java
@@ -155,13 +155,16 @@ public class LayerMetadata {
     }
 
     /**
-     * @return the queryable
+     * @return true if the layer can be queried
+     * @see MapOptions#getFeatureInfoRadius()
      */
     public boolean isQueryable() {
         if ( mapOptions == null ) {
             return true;
         }
-        return mapOptions.getFeatureInfoRadius() > 0;
+        
+        //TRICKY assume that, the service is query able by default (<0) 
+        return mapOptions.getFeatureInfoRadius() != 0;
     }
 
     /**

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
@@ -38,9 +38,7 @@ package org.deegree.rendering.r2d.context;
 /**
  * 
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
- * @author last edited by: $Author: stranger $
- * 
- * @version $Revision: $, $Date: $
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public class MapOptions {
 
@@ -60,7 +58,7 @@ public class MapOptions {
         this.interpol = interpol;
         this.antialias = antialias;
         this.maxFeatures = maxFeatures;
-        this.setFeatureInfoRadius( featureInfoRadius );
+        this.featureInfoRadius = featureInfoRadius;
     }
 
     /**
@@ -124,7 +122,7 @@ public class MapOptions {
     }
 
     /**
-     * @return the featureInfoRadius, a value < 1 means disabled
+     * @return the featureInfoRadius, a value < 1 means default, 0 means disabled and > 0 for the radius
      */
     public int getFeatureInfoRadius() {
         return featureInfoRadius;
@@ -132,7 +130,7 @@ public class MapOptions {
 
     /**
      * @param featureInfoRadius
-     *            the featureInfoRadius to set, a value < 1 means disabled
+     *            the featureInfoRadius to set, a value < 1 means default, 0 means disabled and > 0 for the radius
      */
     public void setFeatureInfoRadius( int featureInfoRadius ) {
         this.featureInfoRadius = featureInfoRadius;
@@ -246,5 +244,4 @@ public class MapOptions {
             }
         };
     }
-
 }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
@@ -130,7 +130,11 @@ public class CoverageLayer extends AbstractLayer {
     public CoverageLayerData infoQuery( LayerQuery query, List<String> headers )
                             throws OWSException {
         try {
-            Envelope bbox = query.calcClickBox( query.getRenderingOptions().getFeatureInfoRadius( getMetadata().getName() ) );
+            int layerRadius = -1;
+            if ( getMetadata().getMapOptions() != null ) {
+                layerRadius = getMetadata().getMapOptions().getFeatureInfoRadius();
+            }
+            final Envelope bbox = query.calcClickBox( layerRadius > -1 ? layerRadius : query.getLayerRadius() );
 
             RangeSet filter = dimensionHandler.getDimensionFilter( query.getDimensions(), headers );
 

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
@@ -165,7 +165,11 @@ public class FeatureLayer extends AbstractLayer {
         filter = Filters.and( filter, getStyleFilters( style, query.getScale() ) );
         filter = Filters.and( filter, query.getFilter() );
 
-        final Envelope clickBox = query.calcClickBox( query.getLayerRadius() );
+        int layerRadius = -1;
+        if ( getMetadata().getMapOptions() != null ) {
+            layerRadius = getMetadata().getMapOptions().getFeatureInfoRadius();
+        }
+        final Envelope clickBox = query.calcClickBox( layerRadius > -1 ? layerRadius : query.getLayerRadius() );
 
         filter = (OperatorFilter) Filters.addBBoxConstraint( clickBox, filter, null );
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -458,15 +458,7 @@ public class MapService {
             LayerRef lr = layerItr.next();
             StyleRef sr = styleItr.next();
             OperatorFilter f = filterItr == null ? null : filterItr.next();
-            int layerRadius = 0;
-            for ( org.deegree.layer.Layer l : Themes.getAllLayers( themeMap.get( lr.getName() ) ) ) {
-                if ( l.getMetadata().getMapOptions() != null
-                     && l.getMetadata().getMapOptions().getFeatureInfoRadius() != 1 ) {
-                    layerRadius = l.getMetadata().getMapOptions().getFeatureInfoRadius();
-                } else {
-                    layerRadius = defaultLayerOptions.getFeatureInfoRadius();
-                }
-            }
+            final int layerRadius = defaultLayerOptions.getFeatureInfoRadius();
             LayerQuery query = new LayerQuery( gfi.getEnvelope(), gfi.getWidth(), gfi.getHeight(), gfi.getX(),
                                                gfi.getY(), gfi.getFeatureCount(), f, sr, gfi.getParameterMap(),
                                                gfi.getDimensions(), new MapOptionsMaps(), gfi.getEnvelope(),
@@ -562,7 +554,7 @@ public class MapService {
         return getLegendHandler.getLegendSize( style );
     }
 
-    public BufferedImage getLegend( GetLegendGraphic req ) {
+    public BufferedImage getLegend( GetLegendGraphic req ) throws OWSException {
         return getLegendHandler.getLegend( req );
     }
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -420,6 +420,11 @@ public class MapService {
                      || l.getMetadata().getScaleDenominators().second < scale ) {
                     continue;
                 }
+                
+                if (!l.getMetadata().isQueryable()) {
+                    continue;
+                }
+                
                 list.add( l.infoQuery( query, headers ) );
             }
         }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities111ThemeWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities111ThemeWriter.java
@@ -65,6 +65,7 @@ import org.deegree.geometry.metadata.SpatialMetadata;
 import org.deegree.layer.metadata.LayerMetadata;
 import org.deegree.rendering.r2d.legends.Legends;
 import org.deegree.services.wms.controller.WMSController;
+import org.deegree.services.wms.controller.capabilities.theme.LayerMetadataQueryable;
 import org.deegree.style.se.unevaluated.Style;
 import org.deegree.theme.Theme;
 import org.deegree.theme.Themes;
@@ -97,7 +98,9 @@ class WmsCapabilities111ThemeWriter {
         LayerMetadata md = theme.getMetadata();
         // TODO think about a push approach instead of a pull approach
         LayerMetadata lmd = null;
+        int layerQueryable = 0;
         for ( org.deegree.layer.Layer l : Themes.getAllLayers( theme ) ) {
+            layerQueryable |= LayerMetadataQueryable.analyseQueryable( l.getMetadata() );
             if ( lmd == null ) {
                 lmd = l.getMetadata();
             } else {
@@ -105,6 +108,7 @@ class WmsCapabilities111ThemeWriter {
             }
         }
         md.merge( lmd );
+        LayerMetadataQueryable.applyQueryable( md, layerQueryable );
 
         if ( md.isQueryable() && md.getName() != null ) {
             writer.writeAttribute( "queryable", "1" );

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities130ThemeWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities130ThemeWriter.java
@@ -66,6 +66,7 @@ import org.deegree.layer.metadata.LayerMetadata;
 import org.deegree.rendering.r2d.legends.Legends;
 import org.deegree.services.metadata.OWSMetadataProvider;
 import org.deegree.services.wms.controller.WMSController;
+import org.deegree.services.wms.controller.capabilities.theme.LayerMetadataQueryable;
 import org.deegree.style.se.unevaluated.Style;
 import org.deegree.theme.Theme;
 import org.deegree.theme.Themes;
@@ -101,7 +102,9 @@ class WmsCapabilities130ThemeWriter {
         LayerMetadata md = theme.getMetadata();
         // TODO think about a push approach instead of a pull approach
         LayerMetadata lmd = null;
+        int layerQueryable = 0;
         for ( org.deegree.layer.Layer l : Themes.getAllLayers( theme ) ) {
+            layerQueryable |= LayerMetadataQueryable.analyseQueryable( l.getMetadata() );
             if ( lmd == null ) {
                 lmd = l.getMetadata();
             } else {
@@ -109,6 +112,7 @@ class WmsCapabilities130ThemeWriter {
             }
         }
         md.merge( lmd );
+        LayerMetadataQueryable.applyQueryable( md, layerQueryable );
 
         writer.writeStartElement( WMSNS, "Layer" );
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataQueryable.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataQueryable.java
@@ -1,0 +1,87 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.services.wms.controller.capabilities.theme;
+
+import org.deegree.layer.metadata.LayerMetadata;
+import org.deegree.rendering.r2d.context.MapOptions;
+import org.deegree.theme.Theme;
+
+/**
+ * Merges {@link LayerMetadata} of {@link Theme} objects.
+ *
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ */
+public class LayerMetadataQueryable {
+    
+    private static final int QUERYABLE_DEFAULT_MASK = 1;
+    
+    private static final int QUERYABLE_DISABLED_MASK = 2;
+    
+    private static final int QUERYABLE_ENABLED_MASK = 4;
+    
+    public static int analyseQueryable( LayerMetadata m ) {
+        if ( m.getMapOptions() == null )
+            return QUERYABLE_DEFAULT_MASK;
+        
+        int r = m.getMapOptions().getFeatureInfoRadius();
+        
+        if ( r < 0 )
+            return QUERYABLE_DEFAULT_MASK;
+        else if ( r == 0 )
+            return QUERYABLE_DISABLED_MASK;
+        else
+            return QUERYABLE_ENABLED_MASK;
+    }
+    
+    public static void applyQueryable( LayerMetadata themeMetadata, int analyseResult ) {
+        if ( themeMetadata.getMapOptions() == null ) {
+            themeMetadata.setMapOptions( new MapOptions( null, null, null, -1, -1 ) );
+        }
+        
+        if ( analyseResult == QUERYABLE_DISABLED_MASK ) {
+            themeMetadata.getMapOptions().setFeatureInfoRadius( 0 );
+        } else {
+            themeMetadata.getMapOptions().setFeatureInfoRadius( -1 );
+        }
+    }
+    
+}


### PR DESCRIPTION
This Pull Requests fixes the the issue #517 by
 * correcting the loading of the layer options (correct the `enabled=false`)
 * enhancement of handling of the three states of the feature info radius
  * < 0 ==> default (as specified in service endpoint)
  * = 0 ==> disabled
  * > 0 ==> user specified radius
 * porting the 3.4 layer analiesis method to a single helper class to make a Layer in WMS/GetCapabilties only `queryable=0` if all layers in the sub structure are not queryable