### PR TITLE
Oracle GeoRaster Support for 3.4

### DIFF
--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>com.oracle</groupId>
-      <artifactId>xmlparserv2</artifactId>
+      <artifactId>xmlparserv2_sans_jaxp_services</artifactId>
     </dependency>
   </dependencies>
 

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -1,0 +1,114 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>deegree-coveragestore-oracle-georaster</artifactId>
+  <packaging>jar</packaging>
+  <name>deegree-coveragestore-oracle-georaster</name>
+  <description>Coverage store implementation for accessing coverates  stored in Oracle GeoRaster databases</description>
+
+  <properties>
+    <deegree.module.status>ok</deegree.module.status>
+  </properties>
+
+  <parent>
+    <groupId>org.deegree</groupId>
+    <artifactId>deegree-coveragestores</artifactId>
+    <version>3.4-pre17-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>deegree-repo</id>
+      <url>http://repo.deegree.org/content/groups/public</url>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <profiles>
+    <profile>
+      <id>oracle</id>
+      <repositories>
+        <repository>
+          <id>deegree-restricted</id>
+          <name>deegree-restricted</name>
+          <url>http://repo.deegree.org/content/repositories/private3rdparty</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-core-coverage</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-core-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-core-commons</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-core-db</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-core-cs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>ojdbc6</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>sdoapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>sdotype</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>sdogr</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>sdoutl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>ojdbc6</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>xdb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>xmlparserv2_grit</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>
+

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-coveragestores</artifactId>
-    <version>3.4-pre17-SNAPSHOT</version>
+    <version>3.4-pre18-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>com.oracle</groupId>
-      <artifactId>xmlparserv2_grit</artifactId>
+      <artifactId>xmlparserv2</artifactId>
     </dependency>
   </dependencies>
 

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterMetadata.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterMetadata.java
@@ -1,0 +1,78 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit GmbH -
+ and others
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ e-mail: info@deegree.org
+ website: http://www.deegree.org/
+----------------------------------------------------------------------------*/
+
+package org.deegree.coverage.raster.io.oraclegeoraster;
+
+import static org.deegree.commons.xml.jaxb.JAXBUtils.unmarshall;
+
+import javax.xml.bind.JAXBException;
+
+import org.deegree.coverage.Coverage;
+import org.deegree.coverage.persistence.oraclegeoraster.jaxb.OracleGeorasterConfig;
+import org.deegree.coverage.raster.io.oraclegeoraster.utils.OracleGeorasterBuilder;
+import org.deegree.db.ConnectionProvider;
+import org.deegree.db.ConnectionProviderProvider;
+import org.deegree.workspace.ResourceLocation;
+import org.deegree.workspace.Workspace;
+import org.deegree.workspace.standard.AbstractResourceMetadata;
+import org.deegree.workspace.standard.AbstractResourceProvider;
+import org.deegree.workspace.standard.DefaultResourceIdentifier;
+
+/**
+ * Metadata for Oracle GeoRaster coverages
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ * 
+ * @since 3.4
+ */
+public class OracleGeorasterMetadata extends AbstractResourceMetadata<Coverage> {
+
+    public OracleGeorasterMetadata( Workspace workspace, ResourceLocation<Coverage> location,
+                                    AbstractResourceProvider<Coverage> provider ) {
+        super( workspace, location, provider );
+    }
+
+    @Override
+    public OracleGeorasterBuilder prepare() {
+        OracleGeorasterConfig config;
+        try {
+            config = (OracleGeorasterConfig) unmarshall( "org.deegree.coverage.persistence.oraclegeoraster.jaxb",
+                                                         provider.getSchema(), location, workspace );
+
+            dependencies.add( new DefaultResourceIdentifier<ConnectionProvider>( ConnectionProviderProvider.class,
+                                                                                 config.getJDBCConnId() ) );
+
+            return new OracleGeorasterBuilder( config, this, workspace );
+        } catch ( JAXBException e ) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+}

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterMetadata.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterMetadata.java
@@ -62,7 +62,7 @@ public class OracleGeorasterMetadata extends AbstractResourceMetadata<Coverage> 
         OracleGeorasterConfig config;
         try {
             config = (OracleGeorasterConfig) unmarshall( "org.deegree.coverage.persistence.oraclegeoraster.jaxb",
-                                                         provider.getSchema(), location, workspace );
+                                                         provider.getSchema(), location.getAsStream(), workspace );
 
             dependencies.add( new DefaultResourceIdentifier<ConnectionProvider>( ConnectionProviderProvider.class,
                                                                                  config.getJDBCConnId() ) );

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterProvider.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterProvider.java
@@ -1,0 +1,64 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit GmbH -
+ and others
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ e-mail: info@deegree.org
+ website: http://www.deegree.org/
+----------------------------------------------------------------------------*/
+
+package org.deegree.coverage.raster.io.oraclegeoraster;
+
+import java.net.URL;
+
+import org.deegree.coverage.Coverage;
+import org.deegree.coverage.persistence.CoverageProvider;
+import org.deegree.workspace.ResourceLocation;
+import org.deegree.workspace.ResourceMetadata;
+import org.deegree.workspace.Workspace;
+
+/**
+ * Provider for Oracle GeoRaster coverages.
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ * 
+ * @since 3.4
+ */
+public class OracleGeorasterProvider extends CoverageProvider {
+
+    private static final URL CONFIG_SCHEMA = OracleGeorasterProvider.class.getResource( "/META-INF/schemas/datasource/coverage/oraclegeoraster/3.4.0/oraclegeoraster.xsd" );
+
+    @Override
+    public String getNamespace() {
+        return "http://www.deegree.org/datasource/coverage/oraclegeoraster";
+    }
+
+    @Override
+    public ResourceMetadata<Coverage> createFromLocation( Workspace workspace, ResourceLocation<Coverage> location ) {
+        return new OracleGeorasterMetadata( workspace, location, this );
+    }
+
+    @Override
+    public URL getSchema() {
+        return CONFIG_SCHEMA;
+    }
+}

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterReader.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterReader.java
@@ -303,9 +303,13 @@ public class OracleGeorasterReader implements RasterReader {
                                              "GeoRaster could not calculate Spatial extend. Please correct config or db." );
         }
 
-        if ( envelope == null || maxLevel < 0 || rasterRect == null )
+        if ( envelope == null || rasterRect == null )
             throw new ResourceInitException(
-                                             "GeoRaster has no Spatial / Pyramid / Size information. Please correct config or db." );
+                                             "GeoRaster has no Spatial and/or Size information. Please correct config or db." );
+        if ( maxLevel <= 0 ) {
+            maxLevel = 0;
+            LOG.warn( "Raster {}.{}:{} has no Pyramid, this is not recommended", rasterTable, rasterColumn, rasterId );
+        }
 
         if ( info.mbr != null && info.mbr.length > 3 ) {
             LOG.info( "Raster {}.{}:{} Size: {}x{} Levels:  0 - {} BBOX: {} {} - {} {}", rasterTable, rasterColumn,

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterReader.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterReader.java
@@ -306,7 +306,7 @@ public class OracleGeorasterReader implements RasterReader {
         if ( envelope == null || rasterRect == null )
             throw new ResourceInitException(
                                              "GeoRaster has no Spatial and/or Size information. Please correct config or db." );
-        if ( maxLevel <= 0 ) {
+        if ( maxLevel < 0 ) {
             maxLevel = 0;
             LOG.warn( "Raster {}.{}:{} has no Pyramid, this is not recommended", rasterTable, rasterColumn, rasterId );
         }

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterReader.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/OracleGeorasterReader.java
@@ -1,0 +1,776 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit GmbH -
+ and others
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ e-mail: info@deegree.org
+ website: http://www.deegree.org/
+----------------------------------------------------------------------------*/
+
+package org.deegree.coverage.raster.io.oraclegeoraster;
+
+import static org.deegree.commons.utils.ColorUtils.decodeWithAlpha;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.nio.ByteBuffer;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import oracle.spatial.georaster.JGeoRaster;
+import oracle.spatial.georaster.image.GeoRasterImage;
+import oracle.sql.STRUCT;
+
+import org.deegree.commons.config.ResourceInitException;
+import org.deegree.commons.utils.JDBCUtils;
+import org.deegree.coverage.persistence.oraclegeoraster.jaxb.AbstractOracleGeorasterType;
+import org.deegree.coverage.persistence.oraclegeoraster.jaxb.AbstractOracleGeorasterType.StorageBBox;
+import org.deegree.coverage.persistence.oraclegeoraster.jaxb.OracleGeorasterConfig;
+import org.deegree.coverage.raster.AbstractRaster;
+import org.deegree.coverage.raster.data.container.BufferResult;
+import org.deegree.coverage.raster.data.info.BandType;
+import org.deegree.coverage.raster.data.info.DataType;
+import org.deegree.coverage.raster.data.info.InterleaveType;
+import org.deegree.coverage.raster.data.info.RasterDataInfo;
+import org.deegree.coverage.raster.data.nio.ByteBufferRasterData;
+import org.deegree.coverage.raster.geom.RasterGeoReference;
+import org.deegree.coverage.raster.geom.RasterGeoReference.OriginLocation;
+import org.deegree.coverage.raster.geom.RasterRect;
+import org.deegree.coverage.raster.io.RasterIOOptions;
+import org.deegree.coverage.raster.io.RasterReader;
+import org.deegree.coverage.raster.utils.RasterFactory;
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.persistence.CRSManager;
+import org.deegree.db.ConnectionProvider;
+import org.deegree.db.ConnectionProviderProvider;
+import org.deegree.geometry.Envelope;
+import org.deegree.geometry.GeometryFactory;
+import org.deegree.workspace.Workspace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Oracle GeoRaster Reader
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ * 
+ * @since 3.4
+ */
+public class OracleGeorasterReader implements RasterReader {
+
+    class MetaInfo {
+
+        public double[] mbr = null;
+
+        public String mbrLocation;
+
+        public int bands = -1;
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger( OracleGeorasterReader.class );
+
+    private static final Color[] DBG_COLORS = new Color[] { Color.RED, Color.YELLOW, Color.BLUE, Color.CYAN,
+                                                           Color.ORANGE };
+
+    private static final String ORACLE_RASTER_META_NS = "xmlns=\"http://xmlns.oracle.com/spatial/georaster\"";
+
+    private static int DBG_COLOR_CNT = -1;
+
+    private Object LOCK = new Object();
+
+    private Rectangle rasterRect;
+
+    private Envelope envelope;
+
+    private RasterGeoReference rasterReference;
+
+    private String dataLocationId;
+
+    private RasterDataInfo rdi;
+
+    private ICRS crs = null;
+
+    private String jdbcConnId;
+
+    private String rasterTable;
+
+    private String rasterRDTTable;
+
+    private String rasterColumn;
+
+    private int rasterId;
+
+    private int bandR = -1;
+
+    private int bandG = -1;
+
+    private int bandB = -1;
+
+    // private byte[] nodata = null;
+
+    private int level;
+
+    private int maxLevel;
+
+    private Workspace workspace;
+
+    private int debug = 0;
+
+    private Color noData;
+
+    private MetaInfo info;
+
+    private OracleGeorasterReader( Workspace workspace, OracleGeorasterReader base, int lvl ) {
+        this.workspace = workspace;
+        this.crs = base.crs;
+        this.jdbcConnId = base.jdbcConnId;
+        this.rasterId = base.rasterId;
+        this.rasterTable = base.rasterTable;
+        this.rasterRDTTable = base.rasterRDTTable;
+        this.rasterColumn = base.rasterColumn;
+
+        this.bandR = base.bandR;
+        this.bandG = base.bandG;
+        this.bandB = base.bandB;
+        this.noData = base.noData;
+        this.maxLevel = base.maxLevel;
+        this.level = lvl;
+        this.dataLocationId = base.dataLocationId + "." + lvl;
+        this.envelope = base.envelope;
+        this.debug = base.debug;
+
+        double sc = Math.pow( 2.0d, lvl );
+        int lvlCurWidth = (int) ( ( (double) base.rasterRect.width ) / sc );
+        int lvlCurHeight = (int) ( ( (double) base.rasterRect.height ) / sc );
+
+        rasterRect = new Rectangle( 0, 0, lvlCurWidth, lvlCurHeight );
+        rasterReference = RasterGeoReference.create( OriginLocation.OUTER, envelope, lvlCurWidth, lvlCurHeight );
+    }
+
+    public OracleGeorasterReader( Workspace workspace, OracleGeorasterConfig config ) throws IOException,
+                            ResourceInitException {
+        this.workspace = workspace;
+
+        initBase( config );
+
+        init( config.getRaster(), config.getStorageBBox(), config.getBands() );
+    }
+
+    public OracleGeorasterReader( Workspace workspace, OracleGeorasterConfig config,
+                                  AbstractOracleGeorasterType.Part part ) throws IOException, ResourceInitException {
+        this.workspace = workspace;
+
+        initBase( config );
+
+        init( part.getRaster(), part.getStorageBBox(), part.getBands() );
+    }
+
+    private void initBase( OracleGeorasterConfig config ) {
+        // retrieve data from config
+        info = new MetaInfo();
+        jdbcConnId = config.getJDBCConnId();
+
+        if ( config.getDebug() != null ) {
+            debug = config.getDebug().intValue();
+        }
+
+        if ( config.getStorageCRS() != null && config.getStorageCRS().trim().length() > 0 ) {
+            crs = CRSManager.getCRSRef( config.getStorageCRS() );
+        }
+
+    }
+
+    private void init( AbstractOracleGeorasterType.Raster raster, StorageBBox storageBBox,
+                       AbstractOracleGeorasterType.Bands bands )
+                            throws ResourceInitException, IOException {
+        rasterTable = emptyToNull( raster.getTable() );
+        rasterRDTTable = emptyToNull( raster.getRDTTable() );
+        rasterColumn = emptyToNull( raster.getColumn() );
+        rasterId = raster.getId();
+        // 3.4.0
+        if ( raster.getRows() > 0 && raster.getColumns() > 0 ) {
+            rasterRect = new Rectangle( 0, 0, raster.getColumns(), raster.getRows() );
+        }
+        maxLevel = raster.getMaxLevel();
+
+        if ( bands != null ) {
+            if ( bands.getSingle() != null ) {
+                int val = bands.getSingle().intValue();
+                bandR = val;
+                bandG = val;
+                bandB = val;
+            } else if ( bands.getRGB() != null ) {
+                bandR = bands.getRGB().getRed();
+                bandG = bands.getRGB().getGreen();
+                bandB = bands.getRGB().getBlue();
+            }
+
+            if ( bands.getNodata() != null ) {
+                noData = decodeWithAlpha( bands.getNodata().replaceFirst( "^0[xX]", "#" ) );
+            }
+        }
+
+        if ( storageBBox != null ) {
+            List<Double> ll = storageBBox.getLowerCorner();
+            List<Double> ur = storageBBox.getUpperCorner();
+            if ( ll != null && ur != null && ll.size() > 1 && ur.size() > 1 ) {
+                try {
+                    double[] dbllst = new double[4];
+                    dbllst[0] = ll.get( 0 ).doubleValue();
+                    dbllst[1] = ll.get( 1 ).doubleValue();
+                    dbllst[2] = ur.get( 0 ).doubleValue();
+                    dbllst[3] = ur.get( 1 ).doubleValue();
+                    this.info.mbr = dbllst;
+                } catch ( Exception ex ) {
+                    LOG.warn( "Failed loading StorageBBox from config: {}", ex.getMessage() );
+                    LOG.trace( "Exception", ex );
+                }
+            }
+        }
+
+        Connection con = null;
+        ConnectionProvider connProvider;
+        try {
+            boolean needBase = ( rasterTable == null || rasterColumn == null );
+            if ( needBase || needsMetadataLookup() ) {
+                connProvider = workspace.getResource( ConnectionProviderProvider.class, jdbcConnId );
+                con = connProvider.getConnection();
+                if ( needBase )
+                    loadGeoRasterBaseDate( con );
+
+                if ( needsMetadataLookup() )
+                    loadGeoRasterMetadata( con );
+            }
+
+        } catch ( IOException ioe ) {
+            LOG.warn( "Raster {}.{}:{} failed (error see next log entry)", this.rasterTable, this.rasterColumn,
+                      this.rasterId );
+            throw ioe;
+        } catch ( Exception othere ) {
+            LOG.warn( "Raster {}.{}:{} failed (error see next log entry)", this.rasterTable, this.rasterColumn,
+                      this.rasterId );
+            throw new ResourceInitException( "Failed to init GeoRaster", othere );
+        } finally {
+            JDBCUtils.close( con );
+        }
+
+        // output loaded infos
+        StringBuilder id = new StringBuilder();
+        id.append( "oracle://" ).append( this.jdbcConnId ).append( "localhost/oraclegeorasterid" );
+        id.append( "/" ).append( this.rasterTable ).append( "/" ).append( this.rasterRDTTable );
+        id.append( "/" ).append( this.rasterRDTTable ).append( "/" ).append( this.rasterColumn );
+        id.append( "/" ).append( this.rasterId );
+        this.dataLocationId = id.toString();
+
+        try {
+            calculateEnvelopeAndReference();
+        } catch ( Exception ex ) {
+            LOG.trace( "Execption", ex );
+            throw new ResourceInitException(
+                                             "GeoRaster could not calculate Spatial extend. Please correct config or db." );
+        }
+
+        if ( envelope == null || maxLevel < 0 || rasterRect == null )
+            throw new ResourceInitException(
+                                             "GeoRaster has no Spatial / Pyramid / Size information. Please correct config or db." );
+
+        if ( info.mbr != null && info.mbr.length > 3 ) {
+            LOG.info( "Raster {}.{}:{} Size: {}x{} Levels:  0 - {} BBOX: {} {} - {} {}", rasterTable, rasterColumn,
+                      rasterId, rasterRect.width, rasterRect.height, maxLevel, info.mbr[0], info.mbr[1], info.mbr[2],
+                      info.mbr[3] );
+        }
+    }
+
+    private boolean needsMetadataLookup() {
+        return ( rasterRDTTable == null || maxLevel < 0 || info == null || info.mbr == null || rasterRect == null );
+    }
+
+    private String emptyToNull( String inp ) {
+        if ( inp != null && inp.trim().length() == 0 )
+            return null;
+
+        return inp;
+    }
+
+    private void calculateEnvelopeAndReference() {
+        boolean isOuter = info.mbrLocation == null || "upperleft".equalsIgnoreCase( info.mbrLocation );
+        if ( info.mbr == null || rasterRect == null ) {
+            return;
+        }
+
+        MathContext mc = MathContext.DECIMAL128;
+        BigDecimal min0 = BigDecimal.valueOf( info.mbr[0] ).min( BigDecimal.valueOf( info.mbr[2] ) );
+        BigDecimal min1 = BigDecimal.valueOf( info.mbr[1] ).min( BigDecimal.valueOf( info.mbr[3] ) );
+        BigDecimal max0 = BigDecimal.valueOf( info.mbr[0] ).max( BigDecimal.valueOf( info.mbr[2] ) );
+        BigDecimal max1 = BigDecimal.valueOf( info.mbr[1] ).max( BigDecimal.valueOf( info.mbr[3] ) );
+
+        BigDecimal span0 = max0.subtract( min0, mc );
+        BigDecimal span1 = max1.subtract( min1, mc );
+
+        if ( !isOuter ) {
+            BigDecimal two = new BigDecimal( 2 );
+            BigDecimal half0 = span0.divide( new BigDecimal( rasterRect.width ), mc ).divide( two, mc ).abs( mc );
+            BigDecimal half1 = span1.divide( new BigDecimal( rasterRect.height ), mc ).divide( two, mc ).abs( mc );
+
+            min0 = min0.add( half0, mc );
+            min1 = min1.subtract( half1, mc );
+            max0 = max0.add( half0, mc );
+            max1 = max1.subtract( half1, mc );
+        }
+
+        envelope = ( new GeometryFactory() ).createEnvelope( min0.doubleValue(), min1.doubleValue(),
+                                                             max0.doubleValue(), max1.doubleValue(), crs );
+
+        rasterReference = RasterGeoReference.create( OriginLocation.OUTER, envelope, rasterRect.width,
+                                                     rasterRect.height );
+    }
+
+    public AbstractRaster getRaster() {
+        RasterDataInfo rdi = getRasterDataInfo();
+        // RasterIOOptions options = new RasterIOOptions();
+        // options.setNoData(nodata);
+        // return RasterFactory.createEmptyRaster( rdi, envelope, rasterReference, this, false, options );
+        return RasterFactory.createEmptyRaster( rdi, envelope, rasterReference, this, false, null );
+    }
+
+    private void loadGeoRasterBaseDate( Connection con )
+                            throws IOException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            ps = con.prepareStatement( "SELECT TABLE_NAME, COLUMN_NAME, RDT_TABLE_NAME FROM USER_SDO_GEOR_SYSDATA WHERE RASTER_ID = ?" );
+            ps.setInt( 1, this.rasterId );
+
+            rs = ps.executeQuery();
+            if ( !rs.next() )
+                throw new SQLException( "No GeoRaster object with rasterid = " + this.rasterId
+                                        + " registered in USER_SDO_GEOR_SYSDATA" );
+
+            if ( this.rasterTable == null )
+                this.rasterTable = rs.getString( 1 );
+
+            if ( this.rasterColumn == null )
+                this.rasterColumn = rs.getString( 2 );
+
+            if ( this.rasterRDTTable == null )
+                this.rasterRDTTable = rs.getString( 3 );
+
+        } catch ( Exception ex ) {
+            throw new IOException( ex.getMessage() );
+        } finally {
+            JDBCUtils.close( rs );
+            JDBCUtils.close( ps );
+        }
+    }
+
+    private void loadGeoRasterMetadata( Connection con )
+                            throws IOException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            StringBuilder sb = new StringBuilder();
+            sb.append( "SELECT" );
+            sb.append( " SDO_GEOM.SDO_MIN_MBR_ORDINATE( x." ).append( rasterColumn ).append( ".spatialExtent ,1 )," ); // minX
+            sb.append( " SDO_GEOM.SDO_MIN_MBR_ORDINATE( x." ).append( rasterColumn ).append( ".spatialExtent ,2 )," ); // minY
+            sb.append( " SDO_GEOM.SDO_MAX_MBR_ORDINATE( x." ).append( rasterColumn ).append( ".spatialExtent ,1 )," ); // maxX
+            sb.append( " SDO_GEOM.SDO_MAX_MBR_ORDINATE( x." ).append( rasterColumn ).append( ".spatialExtent ,2 )," ); // maxY
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/rasterInfo/dimensionSize[@type=\"ROW\"]/size', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')," ); // rowSize
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/rasterInfo/dimensionSize[@type=\"COLUMN\"]/size', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')," );// colSize
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/rasterInfo/dimensionSize[@type=\"BAND\"]/size', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')," );// bandSize
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/spatialReferenceInfo/modelCoordinateLocation', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')," );// modelCoordinateLocation
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/rasterInfo/pyramid/maxLevel', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')," );// maxLevel
+            sb.append( " x." ).append( rasterColumn ).append( ".rasterDataTable," ); // rdtTable
+            // optional stuff
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/rasterInfo/ULTCoordinate/row', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')," );// ultRow
+            sb.append( " EXTRACTVALUE( x." ).append( rasterColumn ).append( ".metadata, '/georasterMetadata/rasterInfo/ULTCoordinate/column', '" );
+            sb.append( ORACLE_RASTER_META_NS ).append( "')" );// ultCol
+
+            sb.append( " FROM " ).append( rasterTable );
+            sb.append( " x WHERE x." ).append( rasterColumn ).append( ".rasterid = ?" );
+            if ( this.rasterRDTTable != null ) {
+                sb.append( " AND UPPER(x." ).append( rasterColumn ).append( ".rasterdatatable) = ?" );
+            }
+            ps = con.prepareStatement( sb.toString() );
+
+            ps.setInt( 1, this.rasterId );
+            if ( this.rasterRDTTable != null ) {
+                ps.setString( 2, this.rasterRDTTable.toUpperCase() );
+            }
+
+            rs = ps.executeQuery();
+            if ( !rs.next() )
+                throw new SQLException( "No GeoRaster object exists at rasterid = " + this.rasterId + " (RDT = "
+                                        + this.rasterRDTTable + ")" );
+
+            if ( this.info == null )
+                this.info = new MetaInfo();
+
+            boolean mbrOk = true;
+            double[] mbrSql = new double[4];
+            for ( int i = 0; i < 4; i++ ) {
+                mbrSql[i] = rs.getDouble( 1 + i );
+                if ( rs.wasNull() )
+                    mbrOk = false;
+            }
+            if ( this.info.mbr == null && mbrOk )
+                this.info.mbr = mbrSql;
+
+            boolean lastNull, rowNull, colNull;
+            int lastInt, rows, cols;
+
+            rows = rs.getInt( 5 );
+            rowNull = rs.wasNull();
+            cols = rs.getInt( 6 );
+            colNull = rs.wasNull();
+            if ( !rowNull && !colNull && rasterRect == null )
+                rasterRect = new Rectangle( 0, 0, cols, rows );
+
+            lastInt = rs.getInt( 7 );
+            lastNull = rs.wasNull();
+            if ( this.info.bands < 0 && !lastNull )
+                this.info.bands = lastInt;
+
+            this.info.mbrLocation = rs.getString( 8 );
+
+            lastInt = rs.getInt( 9 );
+            lastNull = rs.wasNull();
+            if ( this.maxLevel < 0 && !lastNull ) {
+                this.maxLevel = lastInt;
+            }
+
+            if ( rasterRDTTable == null )
+                rasterRDTTable = emptyToNull( rs.getString( 10 ) );
+
+            int ultRow, ultCol;
+            ultRow = rs.getInt( 11 );
+            ultCol = rs.getInt( 12 );
+            if ( ultRow != 0 || ultCol != 0 ) {
+                LOG.info( "Raster {}.{}:{} ULTCoordinate: row {} col {} currently ignored", this.rasterTable,
+                          this.rasterColumn, this.rasterId, ultRow, ultCol );
+            }
+        } catch ( Exception ex ) {
+            throw new IOException( ex.getMessage() );
+        } finally {
+            JDBCUtils.close( rs );
+            JDBCUtils.close( ps );
+        }
+    }
+
+    private JGeoRaster getGeoraster( Connection con )
+                            throws IOException {
+        JGeoRaster res = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            StringBuilder sb = new StringBuilder();
+            sb.append( "SELECT " ).append( this.rasterColumn );
+            sb.append( " FROM " ).append( this.rasterTable );
+            sb.append( " a WHERE a." ).append( this.rasterColumn );
+            sb.append( ".rasterid = ? AND UPPER(a." ).append( this.rasterColumn );
+            sb.append( ".rasterdatatable) = ?" );
+            ps = con.prepareStatement( sb.toString() );
+            ps.setInt( 1, this.rasterId );
+            ps.setString( 2, this.rasterRDTTable.toUpperCase() );
+
+            rs = ps.executeQuery();
+
+            if ( !rs.next() )
+                throw new SQLException( "No GeoRaster object exists at rasterid = " + this.rasterId + ", RDT = "
+                                        + this.rasterRDTTable );
+
+            STRUCT struct = (STRUCT) rs.getObject( 1 );
+            res = new JGeoRaster( struct );
+        } catch ( Exception ex ) {
+            throw new IOException( ex.getMessage() );
+        } finally {
+            JDBCUtils.close( rs );
+            JDBCUtils.close( ps );
+        }
+
+        return res;
+    }
+
+    @Override
+    public BufferResult read( RasterRect rect, ByteBuffer result )
+                            throws IOException {
+        Rectangle intersect = rasterRect.intersection( new Rectangle( rect.x, rect.y, rect.width, rect.height ) );
+
+        if ( LOG.isDebugEnabled() ) {
+            LOG.debug( "Reading Rasterdata from {}", this.dataLocationId );
+            LOG.debug( " Inters X = {}", intersect.x );
+            LOG.debug( " Inters Y = {}", intersect.y );
+            LOG.debug( " Inters W = {}", intersect.width );
+            LOG.debug( " Inters H = {}", intersect.height );
+        }
+
+        if ( intersect.width == 0 || intersect.height == 0 )
+            return null;
+
+        if ( LOG.isDebugEnabled() ) {
+            LOG.debug( " Raster X = {}", rasterRect.x );
+            LOG.debug( " Raster Y = {}", rasterRect.y );
+            LOG.debug( " Raster W = {}", rasterRect.width );
+            LOG.debug( " Raster H = {}", rasterRect.height );
+
+            LOG.debug( " Rect   X = {}", rect.x );
+            LOG.debug( " Rect   Y = {}", rect.y );
+            LOG.debug( " Rect   W = {}", rect.width );
+            LOG.debug( " Rect   H = {}", rect.height );
+
+            LOG.debug( " Level    = {} ( max = {} )", level, maxLevel );
+        }
+
+        Connection con = null;
+        BufferResult res = null;
+        RenderedImage img = null;
+
+        ConnectionProvider connProvider;
+        try {
+            connProvider = workspace.getResource( ConnectionProviderProvider.class, jdbcConnId );
+            con = connProvider.getConnection();
+
+            JGeoRaster jGeoRaster = getGeoraster( con );
+            GeoRasterImage geoRasterImg = jGeoRaster.getGeoRasterImageObject();
+
+            if ( this.bandR > 0 && this.bandG > 0 && this.bandG > 0 ) {
+                geoRasterImg.setRed( this.bandR );
+                geoRasterImg.setGreen( this.bandG );
+                geoRasterImg.setBlue( this.bandB );
+            }
+
+            long[] outWindow = new long[4];
+            img = geoRasterImg.getRasterImage( level, (long) intersect.y, (long) intersect.x,
+                                               (long) ( intersect.y + intersect.height - 1 ),
+                                               (long) ( intersect.x + intersect.width - 1 ), outWindow );
+
+            BufferedImage bimg;
+            Graphics2D bg = null;
+
+            if ( img == null ) {
+                //
+                // TRICKY Look into pyramid level below or above if current raster block is corrupted in database
+                //
+                LOG.warn( "*** Loading Raster from {}:{}/{}.{}={} for level {} failed in the range of {}-{} / {}-{}",
+                          new Object[] { this.jdbcConnId, this.rasterTable, this.rasterRDTTable, this.rasterColumn,
+                                        this.rasterId, level, intersect.y, intersect.x,
+                                        ( intersect.y + intersect.height - 1 ), ( intersect.x + intersect.width - 1 ) } );
+
+                int newlevel;
+                long nx, ny, nw, nh;
+                if ( level <= 0 ) {
+                    newlevel = 1;
+                    nx = intersect.x / 2;
+                    ny = intersect.y / 2;
+                    nw = intersect.width / 2;
+                    nh = intersect.height / 2;
+                } else {
+                    newlevel = level - 1;
+                    nx = intersect.x * 2;
+                    ny = intersect.y * 2;
+                    nw = intersect.width * 2;
+                    nh = intersect.height * 2;
+                }
+
+                img = geoRasterImg.getRasterImage( newlevel, ny, nx, ny + nh - 1, nx + nw - 1, outWindow );
+
+                bimg = getBufferedImage( intersect.width, intersect.height );
+                bg = bimg.createGraphics();
+
+                bg.drawImage( (Image) img, 0, 0, intersect.width, intersect.height, null );
+            } else {
+                LOG.debug( " Image oW = {}, {}, {}, {}", outWindow );
+
+                bimg = getBufferedImage( img.getWidth(), img.getHeight() );
+                bg = bimg.createGraphics();
+                bg.drawImage( (Image) img, 0, 0, null );
+            }
+
+            if ( bg != null && this.debug > 0 ) {
+                LOG.warn( "Rendering additional debug graphics on top of raster data ({})", this.debug );
+                if ( this.debug == 1 ) {
+                    bg.setColor( DBG_NEXT_COLOR() );
+                    // bg.setStroke( new java.awt.BasicStroke( 3 ) );
+                    // bg.drawRect( 1, 1, bimg.getWidth() - 3, bimg.getHeight() - 3 );
+                    bg.setStroke( new java.awt.BasicStroke( 1 ) );
+                    bg.drawRect( 0, 0, bimg.getWidth() - 1, bimg.getHeight() - 1 );
+                } else if ( this.debug == 2 ) {
+                    bg.setColor( DBG_NEXT_COLOR() );
+                    bg.setStroke( new java.awt.BasicStroke( 1 ) );
+                    bg.drawRect( 0, 0, 0, 0 );
+                    bg.drawRect( bimg.getWidth() - 1, bimg.getHeight() - 1, 0, 0 );
+                    bg.drawRect( bimg.getWidth() - 1, 0, 0, 0 );
+                    bg.drawRect( 0, bimg.getHeight() - 1, 0, 0 );
+                }
+            }
+
+            bg.dispose();
+            img = bimg;
+
+            if ( LOG.isDebugEnabled() ) {
+                LOG.debug( " Image  W = ", img.getWidth() );
+                LOG.debug( " Image  H = ", img.getHeight() );
+            }
+
+            ByteBufferRasterData rd = RasterFactory.rasterDataFromImage( img, null, result );
+            res = new BufferResult( rd.getView(), result );
+        } catch ( Exception ex ) {
+            // ignore
+            LOG.info( "Exception on Loading", ex );
+        } finally {
+            JDBCUtils.close( con );
+        }
+
+        return res;
+    }
+
+    private static synchronized Color DBG_NEXT_COLOR() {
+        DBG_COLOR_CNT++;
+        if ( DBG_COLOR_CNT >= DBG_COLORS.length )
+            DBG_COLOR_CNT = 0;
+
+        return DBG_COLORS[DBG_COLOR_CNT];
+    }
+
+    @Override
+    public AbstractRaster load( File filename, RasterIOOptions options )
+                            throws IOException {
+        throw new IOException( "Reading GeoRaster from File is not supported" );
+    }
+
+    @Override
+    public AbstractRaster load( InputStream stream, RasterIOOptions options )
+                            throws IOException {
+        throw new IOException( "Reading GeoRaster from InputStream is not supported" );
+    }
+
+    @Override
+    public boolean canLoad( File filename ) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getSupportedFormats() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean shouldCreateCacheFile() {
+        return false;
+    }
+
+    @Override
+    public File file() {
+        // no file
+        return null;
+    }
+
+    @Override
+    public int getHeight() {
+        return rasterRect.height;
+    }
+
+    @Override
+    public int getWidth() {
+        return rasterRect.width;
+    }
+
+    @Override
+    public RasterGeoReference getGeoReference() {
+        return rasterReference;
+    }
+
+    private BufferedImage getBufferedImage( int w, int h ) {
+        return new BufferedImage( w, h, BufferedImage.TYPE_4BYTE_ABGR );
+    }
+
+    @Override
+    public RasterDataInfo getRasterDataInfo() {
+
+        synchronized ( LOCK ) {
+            if ( rdi == null ) {
+                //
+                // Fixed RDI
+                //
+                rdi = new RasterDataInfo(
+                                          new BandType[] { BandType.ALPHA, BandType.BLUE, BandType.GREEN, BandType.RED },
+                                          DataType.BYTE, InterleaveType.PIXEL );
+            }
+        }
+
+        return rdi;
+    }
+
+    @Override
+    public boolean canReadTiles() {
+        return true;
+    }
+
+    @Override
+    public String getDataLocationId() {
+        return dataLocationId;
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+
+    public boolean isMultiResulution() {
+        return maxLevel > 0;
+    }
+
+    /**
+     * Return full Pyramid as array of AbstractRaster elements
+     * 
+     * @return
+     */
+    public AbstractRaster[] getPyramidRaster() {
+        if ( level != 0 )
+            return null;
+
+        AbstractRaster[] res = new AbstractRaster[maxLevel];
+        for ( int lvl = 1; lvl <= maxLevel; lvl++ ) {
+            res[lvl - 1] = new OracleGeorasterReader( workspace, this, lvl ).getRaster();
+        }
+        return res;
+    }
+}

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/utils/OracleGeorasterBuilder.java
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/java/org/deegree/coverage/raster/io/oraclegeoraster/utils/OracleGeorasterBuilder.java
@@ -1,0 +1,96 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit GmbH -
+ and others
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ e-mail: info@deegree.org
+ website: http://www.deegree.org/
+----------------------------------------------------------------------------*/
+
+package org.deegree.coverage.raster.io.oraclegeoraster.utils;
+
+import org.deegree.coverage.Coverage;
+import org.deegree.coverage.persistence.oraclegeoraster.jaxb.OracleGeorasterConfig;
+import org.deegree.coverage.raster.AbstractRaster;
+import org.deegree.coverage.raster.MultiResolutionRaster;
+import org.deegree.coverage.raster.io.oraclegeoraster.OracleGeorasterReader;
+import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceInitException;
+import org.deegree.workspace.ResourceMetadata;
+import org.deegree.workspace.Workspace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Oracle GeoRaster Builder
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ * 
+ * @since 3.4
+ */
+public class OracleGeorasterBuilder implements ResourceBuilder<Coverage> {
+
+    private static final Logger LOG = LoggerFactory.getLogger( OracleGeorasterBuilder.class );
+
+    private OracleGeorasterConfig config;
+
+    private ResourceMetadata<Coverage> metadata;
+
+    private Workspace workspace;
+
+    public OracleGeorasterBuilder( OracleGeorasterConfig config, ResourceMetadata<Coverage> metadata,
+                                   Workspace workspace ) {
+        this.config = config;
+        this.metadata = metadata;
+        this.workspace = workspace;
+    }
+
+    @Override
+    public Coverage build() {
+        try {
+            OracleGeorasterReader rdr;
+            rdr = new OracleGeorasterReader( workspace, config );
+
+            return buildPyramidIfNeeded( rdr, rdr.getRaster() );
+        } catch ( Exception e ) {
+            LOG.trace( "Exception", e );
+            throw new ResourceInitException( "Could not build Oracle GeoRaster Reader: " + e.getMessage() );
+        }
+    }
+
+    private Coverage buildPyramidIfNeeded( OracleGeorasterReader rdr, AbstractRaster rasterLvl0 ) {
+
+        if ( rdr.isMultiResulution() ) {
+            AbstractRaster[] ary = rdr.getPyramidRaster();
+            MultiResolutionRaster mrr = new MultiResolutionRaster( metadata );
+            mrr.setCoordinateSystem( rasterLvl0.getCoordinateSystem() );
+            mrr.addRaster( rasterLvl0 );
+            for ( int i = 0; i < ary.length; i++ ) {
+                mrr.addRaster( ary[i] );
+            }
+            return mrr;
+        } else {
+            rasterLvl0.setMetadata( metadata );
+            return rasterLvl0;
+        }
+    }
+}

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/console/resourceprovider/org.deegree.coverage.raster.io.oraclegeoraster.OracleGeorasterProvider
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/console/resourceprovider/org.deegree.coverage.raster.io.oraclegeoraster.OracleGeorasterProvider
@@ -1,0 +1,4 @@
+name=Oracle GeoRaster Coverage
+example1_name=example
+example1_description=GeoRaster coverage stored in Oracle database.
+example1_location=/META-INF/schemas/datasource/coverage/oraclegeoraster/3.4.0/example.xml

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/schemas/datasource/coverage/oraclegeoraster/3.4.0/example.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/schemas/datasource/coverage/oraclegeoraster/3.4.0/example.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OracleGeoraster configVersion="3.4.0"
+	xmlns="http://www.deegree.org/datasource/coverage/oraclegeoraster"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.deegree.org/datasource/coverage/oraclegeoraster http://schemas.deegree.org/datasource/coverage/oraclegeoraster/3.4.0/oraclegeoraster.xsd">
+	<JDBCConnId>oracle</JDBCConnId>
+	<StorageCRS>EPSG:31468</StorageCRS>
+	
+	<!-- optional -->
+	<!-- 
+	<StorageBBox> 
+		<LowerCorner>4508000.0 5652000.0</LowerCorner>
+		<UpperCorner>4518000.0 5642000.0</UpperCorner>
+	</StorageBBox>
+	-->
+	 
+	<Raster id="42" maxLevel="9" rows="10000" columns="10000">
+		<Table>RASTER</Table>
+		<RDTTable>RASTER_RDT</RDTTable>
+		<Column>IMAGE</Column>
+	</Raster>
+	
+	<!-- optional: single band / gray scale -->
+	<!-- 
+	<Bands> 
+		<Single>1</Single>
+	</Bands>
+	-->
+	
+	<!-- optional: multiple bands -->
+	<!-- 
+	<Bands>
+		<RGB red="1" green="2" blue="3" />
+	</Bands> 
+	-->
+</OracleGeoraster>

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/schemas/datasource/coverage/oraclegeoraster/3.4.0/oraclegeoraster.xsd
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/schemas/datasource/coverage/oraclegeoraster/3.4.0/oraclegeoraster.xsd
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns:raster="http://www.deegree.org/datasource/coverage/oraclegeoraster" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/coverage/oraclegeoraster"
+	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+	<annotation>
+		<appinfo>
+			<jaxb:schemaBindings>
+				<jaxb:package name="org.deegree.coverage.persistence.oraclegeoraster.jaxb" />
+			</jaxb:schemaBindings>
+		</appinfo>
+	</annotation>
+
+	<element name="OracleGeoraster">
+		<annotation>
+			<documentation>CoverageStore that is backed by an Oracle SQL database with
+				spatial extension
+			</documentation>
+			<appinfo>
+				<jaxb:class name="OracleGeorasterConfig" />
+			</appinfo>
+		</annotation>
+		<complexType>
+			<complexContent>
+				<extension base="raster:AbstractOracleGeorasterType">
+					<attribute name="configVersion" type="raster:ConfigVersionType" use="required" />
+				</extension>
+			</complexContent>
+		</complexType>
+	</element>
+
+	<group name="GeoRasterDefinition">
+		<sequence>
+			<element name="StorageBBox" minOccurs="0" maxOccurs="1">
+				<complexType>
+					<sequence>
+						<element name="LowerCorner" type="raster:PositionType" />
+						<element name="UpperCorner" type="raster:PositionType" />
+					</sequence>
+				</complexType>
+			</element>
+			<element name="Raster" minOccurs="1" maxOccurs="1">
+				<complexType>
+					<sequence>
+						<element name="Table" minOccurs="0" maxOccurs="1" type="string" />
+						<element name="RDTTable" minOccurs="0" maxOccurs="1" type="string" />
+						<element name="Column" minOccurs="0" maxOccurs="1" type="string" />
+					</sequence>
+					<attribute name="id" type="int" use="required" />
+					<attribute name="maxLevel" type="int" use="optional" default="-1" />
+					<attribute name="rows" type="int" use="optional" default="-1" />
+					<attribute name="columns" type="int" use="optional" default="-1" />
+				</complexType>
+			</element>
+			<element name="Bands" minOccurs="0" maxOccurs="1">
+				<complexType>
+					<choice minOccurs="1" maxOccurs="1">
+						<element name="Single" type="int" />
+						<element name="RGB">
+							<complexType>
+								<attribute name="red" type="int" use="required" />
+								<attribute name="green" type="int" use="required" />
+								<attribute name="blue" type="int" use="required" />
+							</complexType>
+						</element>
+					</choice>
+					<attribute name="nodata" type="string" use="optional" />
+				</complexType>
+			</element>
+		</sequence>
+	</group>
+
+	<complexType name="AbstractOracleGeorasterType" abstract="true">
+		<sequence>
+			<element name="Debug" minOccurs="0" maxOccurs="1" type="int" />
+
+			<element name="JDBCConnId" minOccurs="1" maxOccurs="1" type="string" />
+			<element name="StorageCRS" minOccurs="1" maxOccurs="1" type="string" />
+			<choice>
+				<group ref="raster:GeoRasterDefinition" minOccurs="1" maxOccurs="1"/>
+				<element name="Part" minOccurs="1" maxOccurs="unbounded">
+					<complexType>
+						<sequence>
+							<group ref="raster:GeoRasterDefinition" minOccurs="1" maxOccurs="1" />
+						</sequence>
+						<attribute name="name" type="string" use="required" />
+					</complexType>
+				</element>
+			</choice>
+		</sequence>
+	</complexType>
+
+	<!-- start copied from commons -->
+	<simpleType name="PositionType">
+		<annotation>
+			<documentation>
+				Position instances hold the coordinates of a position
+				in a coordinate reference system (CRS)referenced by the related
+				"crs" attribute or elsewhere. For an
+				angular coordinate axis that is
+				physically continuous for multiple revolutions, but whose recorded
+				values can be discontinuous, special conditions apply when the
+				bounding
+				box is continuous across the value discontinuity: a) If the
+				bounding box is continuous clear around this angular axis, then
+				ordinate values of minus and plus infinity
+				shall be used. b) If the
+				bounding box is continuous across the value discontinuity but is not
+				continuous clear around this angular axis, then some non-normal
+				value can be
+				used if specified for a specific OWS use of the
+				BoundingBoxType. For more information, see Subclauses 10.2.5 and
+				C.13.
+			</documentation>
+			<documentation>
+				This type is adapted from DirectPositionType and
+				doubleList of GML 3.1. The adaptations include omission of all the
+				attributes, since the needed information
+				is included in the
+				BoundingBoxType.
+			</documentation>
+		</annotation>
+		<list itemType="double" />
+	</simpleType>
+
+	<simpleType name="ConfigVersionType">
+		<restriction base="string">
+			<enumeration value="3.1.0" />
+			<enumeration value="3.4.0" />
+		</restriction>
+	</simpleType>
+	<!-- end copied from commons -->
+</schema>

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/services/org.deegree.coverage.persistence.CoverageProvider
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/services/org.deegree.coverage.persistence.CoverageProvider
@@ -1,0 +1,1 @@
+org.deegree.coverage.raster.io.oraclegeoraster.OracleGeorasterProvider

--- a/deegree-datastores/deegree-coveragestores/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.4-pre17-SNAPSHOT</version>
+    <version>3.4-pre18-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/deegree-datastores/deegree-coveragestores/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/pom.xml
@@ -1,15 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>deegree-datastores</artifactId>
+  <artifactId>deegree-coveragestores</artifactId>
   <packaging>pom</packaging>
-  <name>deegree-datastores</name>
-  <description>Abstraction layers for geospatial data persistence and backend implementations</description>
+  <name>deegree-coveragestores</name>
+  <description>Abstraction layer for coverage persistence and backend implementations</description>
 
   <parent>
     <groupId>org.deegree</groupId>
-    <artifactId>deegree</artifactId>
-    <version>3.4-pre18-SNAPSHOT</version>
+    <artifactId>deegree-datastores</artifactId>
+    <version>3.4-pre17-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -25,11 +24,14 @@
     </repository>
   </repositories>
 
-  <modules>
-    <module>deegree-featurestores</module>
-    <module>deegree-mdstores</module>
-    <module>deegree-tilestores</module>
-    <module>deegree-coveragestores</module>
-  </modules>
-
+  <profiles>
+    <profile>
+      <id>oracle</id>
+      <modules>
+        <module>deegree-coveragestore-oracle-georaster</module>
+      </modules>
+    </profile>
+  </profiles>
+  
 </project>
+

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/coveragestores.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/coveragestores.rst
@@ -105,3 +105,81 @@ The following example shows, how to configure a coverage pyramid:
 * A Pyramid contains a PyramidFile parameter with the path to the pyramid as its value.
 * A Pyramid contains a CRS parameter describing the source CRS of the pyramid as EPSG code.
 * As in Raster, the nodata attribute can be optionally used to declare a nodata value.
+
+----------------
+Oracle GeoRaster
+----------------
+
+A <OracleGeoraster> is used to wrap a connection information to a singe Oracle GeoRaster element inside a Oracle Database.
+
+To be able to use the module it is required that the Oracle GeoRaster libraries are available, see :ref:`anchor-db-libraries` for details.
+
+The following example shows, how to configure a GeoRaster coverage (minmal required options):
+
+.. code-block:: xml
+  <OracleGeoraster configVersion="3.4.0"
+    xmlns="http://www.deegree.org/datasource/coverage/oraclegeoraster"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.deegree.org/datasource/coverage/oraclegeoraster http://schemas.deegree.org/datasource/coverage/oraclegeoraster/3.4.0/oraclegeoraster.xsd">
+
+    <JDBCConnId>oracle</JDBCConnId>
+    <StorageCRS>EPSG:25832</StorageCRS>
+    
+    <Raster id="17" />
+  
+  </OracleGeoraster>
+
+The second example shows a complete configuration, which will load faster because no database lookups are required to initiate the coverage store.
+
+.. code-block:: xml
+
+  <OracleGeoraster configVersion="3.4.0"
+    xmlns="http://www.deegree.org/datasource/coverage/oraclegeoraster"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.deegree.org/datasource/coverage/oraclegeoraster http://schemas.deegree.org/datasource/coverage/oraclegeoraster/3.4.0/oraclegeoraster.xsd">
+
+    <JDBCConnId>oracle</JDBCConnId>
+    <StorageCRS>EPSG:31468</StorageCRS>
+    
+    <StorageBBox>
+      <LowerCorner>4508000.0 5652000.0</LowerCorner>
+      <UpperCorner>4518000.0 5642000.0</UpperCorner>
+    </StorageBBox>
+    
+    <Raster id="17" maxLevel="7" rows="10000" columns="10000">
+      <Table>RASTER</Table>
+      <RDTTable>RASTER_RDT</RDTTable>
+      <Column>IMAGE</Column>
+    </Raster>
+    
+    <Bands>
+      <RGB red="1" green="2" blue="3" />
+    </Bands>
+  </OracleGeoraster>
+
+If your GeoRaster coverage only consist in a greyscale coverage or you only want to server a single band you could specifiy the following:
+
+.. code-block:: xml
+    <Bands>
+      <Single>1</Single>
+    </Bands>
+
+.. table:: Options for ``<Raster>``
+
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| Option                | Cardinality | Value   | Description                                                                  |
++=======================+=============+=========+==============================================================================+
+| ``@id``               | 1           | integer | Identifier of the specified Oracle GeoRaster object                          |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| ``@maxLevel``         | 0..1        | integer | The number of pyramid levels, specify zero if no pyramid is available        |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| ``@rows``             | 0..1        | integer | Number of rows of the GeoRaster                                              |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| ``@columns``          | 0..1        | integer | Number of columns of the GeoRaster                                           |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| ``<Table>``           | 0..1        | String  | Defines the name of table name which contains the GeoRaster object           |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| ``<RDTTable>``        | 0..1        | String  | The name of the corresponding raster data table.                             |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+
+| ``<Column>``          | 0..1        | String  | The column name of the ``<Table>`` in which the ``SDO_GEORASTER`` is stored  |
++-----------------------+-------------+---------+------------------------------------------------------------------------------+

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/javamodules.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/javamodules.rst
@@ -90,6 +90,36 @@ In order to enable Oracle connectivity for these resources, you need to add two 
 * A compatible Oracle JDBC6-type driver (e.g. ``ojdbc6-11.2.0.2.jar``) [#f2]_
 * Module deegree-sqldialect-oracle [#f3]_
 
+"""""""""""""""""""""""""""""""
+Adding Oracle GeoRaster support
+"""""""""""""""""""""""""""""""
+
+The ``OracleGeoraster`` coverage store supports GeoRaster Objects stored in Oracle databases (10g, 11g).
+
+In order to enable Oracle connectivity for these resources, you need to add the following JAR files (see :ref:`anchor-adding-jars`):
+
+* A compatible Oracle JDBC6-type driver [#f2]_
+  * ojdbc6-11.2.0.2.jar
+* The Oracle Spatial and GeoRaster libraries and their dependencies
+  * sdoapi-11.2.0.2.jar
+  * sdogr-11.2.0.2.jar
+  * sdotype-11.2.0.2.jar
+  * sdoutl-11.2.0.2.jar
+  * xdb-11.2.0.2.jar
+  * xmlparserv2_sans_jaxp_services-11.2.0.2.jar
+* Module deegree-coveragestore-oracle-georaster [#f6]_
+
+.. hint:: 
+  The Oracle Spatial and GeoRaster libraries can be found, without version number in filename, inside the Oracle Database installation directory.
+  The ``sdo*`` files can be found at ``ORACLE_HOME/md/jlib``, xdb.jar at ``ORACLE_HOME/rdbms/jlib`` and xmlparserv2_sans_jaxp_services or xmlparserv2 at ``ORACLE_HOME/xdk/lib``.
+  
+
+.. note::
+  The ``xmlparserv2_sans_jaxp_services`` is the recommended library, as it does not contain  ``META-INF/services/`` entries. 
+  But if this library is not available the ``xmlparserv2`` can be used instead.
+  (In rare conditions this could set the oracle library as default XML parser, which could lead to unexpected behavior).
+
+
 """""""""""""""""""""""""""""""""""
 Adding Microsoft SQL server support
 """""""""""""""""""""""""""""""""""
@@ -112,4 +142,5 @@ In order to enable Microsoft SQL Server connectivity for these resources, you ne
 .. [#f3] http://repo.deegree.org/content/repositories/public/org/deegree/deegree-sqldialect-oracle/${project.version}/deegree-sqldialect-oracle-${project.version}.jar
 .. [#f4] http://msdn.microsoft.com/en-us/sqlserver/aa937724.aspx
 .. [#f5] http://repo.deegree.org/content/repositories/public/org/deegree/deegree-sqldialect-mssql/${project.version}/deegree-sqldialect-mssql-${project.version}.jar
+.. [#f6] http://repo.deegree.org/content/repositories/public/org/deegree/deegree-coveragestore-oracle-georaster/${project.version}/deegree-coveragestore-oracle-georaster-${project.version}.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -685,6 +685,37 @@
         <artifactId>ojdbc6</artifactId>
         <version>11.2.0.2</version>
       </dependency>
+      <!-- Oracle GeoRaster -->
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>sdoapi</artifactId>
+        <version>11.2.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>sdotype</artifactId>
+        <version>11.2.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>sdogr</artifactId>
+        <version>11.2.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>sdoutl</artifactId>
+        <version>11.2.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>xdb</artifactId>
+        <version>11.2.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle</groupId>
+        <artifactId>xmlparserv2</artifactId>
+        <version>11.2.0.2</version>
+      </dependency>
       <!-- Batik -->
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,7 @@
       </dependency>
       <dependency>
         <groupId>com.oracle</groupId>
-        <artifactId>xmlparserv2</artifactId>
+        <artifactId>xmlparserv2_sans_jaxp_services</artifactId>
         <version>11.2.0.2</version>
       </dependency>
       <!-- Batik -->


### PR DESCRIPTION
This Pull Request adds the deegree-coveragestore-oracle-georaster and a intermediate deegree-coveragestores module.

The Oracle GeoRaster module builds on top of the Oracle GeoRaster API for Java an enables deegree to access single coverages stored in the Oracle Database.

Documentation, a example configuration and a META-INF for the console is included.

The module is targeted for Oracle 11.2 drivers which can connect to 11g and 10g databases and only builds if the `oracle` profile is activated.