### PR TITLE
SQLFeatureStore: Fix lost updates in multi-part transactions

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
@@ -113,11 +113,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * {@link FeatureStoreTransaction} implementation for {@link SQLFeatureStore}.
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author$
- * 
+ *
  * @version $Revision$, $Date$
  */
 public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
@@ -141,7 +141,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
 
     /**
      * Creates a new {@link SQLFeatureStoreTransaction} instance.
-     * 
+     *
      * @param store
      *            corresponding feature store instance, must not be <code>null</code>
      * @param conn
@@ -181,11 +181,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
             LOG.debug( t.getMessage(), t );
             throw new FeatureStoreException( "Unable to commit SQL transaction: " + t.getMessage() );
         } finally {
-            try {
-                conn.close();
-            } catch ( SQLException e ) {
-                LOG.error( "Error closing connection/removing it from the pool." );
-            }
+            fs.closeAndDetachTransactionConnection();
         }
     }
 
@@ -237,11 +233,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
             LOG.debug( e.getMessage(), e );
             throw new FeatureStoreException( "Unable to rollback SQL transaction: " + e.getMessage() );
         } finally {
-            try {
-                conn.close();
-            } catch ( SQLException e ) {
-                LOG.error( "Error closing connection/removing it from the pool." );
-            }
+            fs.closeAndDetachTransactionConnection();
         }
     }
 
@@ -253,7 +245,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
     /**
      * Returns the underlying JDBC connection. Can be used for performing other operations in the same transaction
      * context.
-     * 
+     *
      * @return the underlying JDBC connection, never <code>null</code>
      */
     public Connection getConnection() {
@@ -377,7 +369,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
      * <p>
      * Deletes all joined rows and transitive join rows, but stops at joins to subfeature tables.
      * </p>
-     * 
+     *
      * @param fid
      *            feature id, must not be <code>null</code>
      * @throws FeatureStoreException
@@ -689,7 +681,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
 
     /**
      * Inserts the given feature into BLOB table and returns the generated primary key.
-     * 
+     *
      * @param stmt
      * @param feature
      * @return primary key of the feature
@@ -764,7 +756,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
             blobUpdateStmt = conn.prepareStatement( sql.toString() );
             features = fs.query( query );
             for ( final Feature feature : features ) {
-                new FeatureUpdater().update( feature, replacementProps );               
+                new FeatureUpdater().update( feature, replacementProps );
                 updateFeatureBlob( blobUpdateStmt, feature );
                 updatedFids.add( feature.getId() );
             }


### PR DESCRIPTION
Prior to this patch, multi-part transactions against the SQLFeatureStore could lead to lost updates. Here's an example of such a transaction (in the form of a WFS 2.0 transaction):

```
<?xml version="1.0"?>
<wfs:Transaction xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:aixm="http://www.aixm.aero/schema/5.1" xmlns:gml="http://www.opengis.net/gml/3.2" version="2.0.0" service="WFS">
  <wfs:Update typeName="aixm:Airspace">
    <wfs:Property>
      <wfs:ValueReference action="insertBefore">aixm:timeSlice[1]</wfs:ValueReference>
      <wfs:Value>
        <aixm:AirportHeliportTimeSlice gml:id="TEST_11111111-1111-1111-1111-111111111111_3">
          <gml:validTime>
            <gml:TimePeriod gml:id="TEST_11111111-1111-1111-1111-111111111111_4">
              <gml:beginPosition>2015-01-02T00:00:00Z</gml:beginPosition>
              <gml:endPosition>2015-01-03T00:00:00Z</gml:endPosition>
            </gml:TimePeriod>
          </gml:validTime>
          <aixm:interpretation>TEMPDELTA</aixm:interpretation>
          <aixm:sequenceNumber>1</aixm:sequenceNumber>
        </aixm:AirportHeliportTimeSlice>
      </wfs:Value>
    </wfs:Property>
    <fes:Filter>
      <fes:ResourceId rid="uuid.11111111-1111-1111-1111-111111111111"/>
    </fes:Filter>
  </wfs:Update>
  <wfs:Update typeName="aixm:Airspace">
    <wfs:Property>
      <wfs:ValueReference action="insertBefore">aixm:timeSlice[1]</wfs:ValueReference>
      <wfs:Value>
        <aixm:AirportHeliportTimeSlice gml:id="TEST_11111111-1111-1111-1111-111111111111_5">
          <gml:validTime>
            <gml:TimePeriod gml:id="TEST_11111111-1111-1111-1111-111111111111_6">
              <gml:beginPosition>2015-01-06T00:00:00Z</gml:beginPosition>
              <gml:endPosition>2015-01-07T00:00:00Z</gml:endPosition>
            </gml:TimePeriod>
          </gml:validTime>
          <aixm:interpretation>TEMPDELTA</aixm:interpretation>
          <aixm:sequenceNumber>2</aixm:sequenceNumber>
        </aixm:AirportHeliportTimeSlice>
      </wfs:Value>
    </wfs:Property>
    <fes:Filter>
      <fes:ResourceId rid="uuid.11111111-1111-1111-1111-111111111111"/>
    </fes:Filter>
  </wfs:Update>
</wfs:Transaction>
```

For this example, the first update was lost and only the second one was applied. This has been observed for BLOB mode.

The cause for the problem was that the SQLFeatureStore always acquired a new JDBC connection, even when being used by an SQLFeatureStoreTransaction object as part of the transaction. After the patch, the SQLFeatureStore uses a ThreadLocal object to determine if the current thread has an active transaction and uses it, if this is the case.

It may not be ideal to limit the use of an SQLFeatureStoreTransaction instance to a single thread, but IMHO, there is no realistic use case for using it from multiple threads. Therefore, I consider the patch to be "good enough", unless somebody wants to fully correct and refactor the design of SQLFeatureStore and SQLFeatureStoreTransaction (which would involve a lot of changes).