### PR TITLE
Improve XPath support for TimeInstant/TimePeriod objects

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/TypedObjectNodeXPathEvaluator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/TypedObjectNodeXPathEvaluator.java
@@ -45,6 +45,7 @@ import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.gml.GMLObject;
 import org.deegree.commons.tom.gml.property.Property;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
+import org.deegree.feature.Feature;
 import org.deegree.feature.xpath.node.GMLObjectNode;
 import org.deegree.feature.xpath.node.PropertyNode;
 import org.deegree.feature.xpath.node.XMLElementNode;
@@ -109,7 +110,7 @@ public class TypedObjectNodeXPathEvaluator implements XPathEvaluator<TypedObject
                 simplePropName = altName;
             }
         }
-        if ( simplePropName != null ) {
+        if ( simplePropName != null && context instanceof Feature ) {
             List<Property> props = context.getProperties( simplePropName );
             TypedObjectNode[] propArray = new TypedObjectNode[props.size()];
             return props.toArray( propArray );

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/node/TimePositionAdapter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/node/TimePositionAdapter.java
@@ -1,5 +1,7 @@
 package org.deegree.feature.xpath.node;
 
+import static org.deegree.commons.tom.primitive.BaseType.STRING;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -10,6 +12,7 @@ import javax.xml.namespace.QName;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.genericxml.GenericXMLElement;
 import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.feature.property.GenericProperty;
 import org.deegree.time.position.TimePosition;
@@ -18,6 +21,11 @@ public class TimePositionAdapter {
 
     public Property getAsXMLElement( final QName name, final TimePosition timeInstant ) {
         final Map<QName, PrimitiveValue> attrs = new HashMap<QName, PrimitiveValue>();
+        if ( timeInstant.getIndeterminatePosition() != null ) {
+            final String indeterminateValue = timeInstant.getIndeterminatePosition().name().toLowerCase();
+            final PrimitiveValue pv = new PrimitiveValue( indeterminateValue, new PrimitiveType( STRING ) );
+            attrs.put( new QName( "indeterminatePosition" ), pv );
+        }
         final PrimitiveValue value = new PrimitiveValue( timeInstant.getValue() );
         final List<TypedObjectNode> children = new ArrayList<TypedObjectNode>();
         children.add( value );

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/feature/xpath/TimePeriodXPathTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/feature/xpath/TimePeriodXPathTest.java
@@ -52,17 +52,32 @@ public class TimePeriodXPathTest {
         assertEquals( "2001-05-23", value.getAsText() );
     }
 
+    @Test
+    public void evaluateEndPositionIndeterminatePosition()
+                            throws Exception {
+        final TypedObjectNode[] result = evaluate( "time_period_indeterminate.gml",
+                                                   "/gml:TimePeriod/gml:endPosition/@indeterminatePosition" );
+        assertEquals( 1, result.length );
+        final PrimitiveValue value = (PrimitiveValue) result[0];
+        assertEquals( "unknown", value.getAsText() );
+    }
+
     private TypedObjectNode[] evaluate( final String xpath )
+                            throws Exception, FilterEvaluationException {
+        return evaluate( "time_period_minimal.gml", xpath );
+    }
+
+    private TypedObjectNode[] evaluate( final String example, final String xpath )
                             throws Exception, FilterEvaluationException {
         final SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
         nsContext.addNamespace( "gml", "http://www.opengis.net/gml/3.2" );
-        final TimeObject object = readMinimalExample();
+        final TimeObject object = readExample( example );
         return new TypedObjectNodeXPathEvaluator().eval( object, new ValueReference( xpath, nsContext ) );
     }
 
-    private TimeObject readMinimalExample()
+    private TimeObject readExample( final String example )
                             throws Exception {
-        final GMLStreamReader reader = getGmlStreamReader( "time_period_minimal.gml" );
+        final GMLStreamReader reader = getGmlStreamReader( example );
         final XMLStreamReader xmlStream = reader.getXMLReader();
         return new GmlTimePeriodReader( reader ).read( xmlStream );
     }

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/time/gml/reader/time_period_indeterminate.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/time/gml/reader/time_period_indeterminate.gml
@@ -1,0 +1,4 @@
+<TimePeriod gml:id="p1" xmlns="http://www.opengis.net/gml/3.2" xmlns:gml="http://www.opengis.net/gml/3.2">
+  <beginPosition>2001-05-23</beginPosition>
+  <endPosition indeterminatePosition="unknown" />
+</TimePeriod>

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/sql/DefaultPrimitiveConverter.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/sql/DefaultPrimitiveConverter.java
@@ -49,8 +49,8 @@ import java.util.Calendar;
 
 import org.deegree.commons.tom.datetime.Date;
 import org.deegree.commons.tom.datetime.DateTime;
-import org.deegree.commons.tom.datetime.Time;
 import org.deegree.commons.tom.datetime.Temporal;
+import org.deegree.commons.tom.datetime.Time;
 import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
@@ -347,6 +347,9 @@ public class DefaultPrimitiveConverter implements PrimitiveParticleConverter {
             value = new Timestamp( timeInstant.getTimeInMilliseconds() );
         } else {
             String s = input.toString();
+            if ( s.isEmpty() ) {
+                return null;
+            }
             DateTime timeInstant = parseDateTime( s );
             value = toSqlTimestamp( timeInstant );
         }


### PR DESCRIPTION
This patch improves the support for accessing XML nodes inside of TimeInstant/TimePeriod objects.

Consider that the following GML example has been parsed into deegree's object model:

```
<TimePeriod gml:id="p1" xmlns="http://www.opengis.net/gml/3.2" xmlns:gml="http://www.opengis.net/gml/3.2">
  <beginPosition>2001-05-23</beginPosition>
  <endPosition indeterminatePosition="unknown" />
</TimePeriod>
```

Before the patch, it was not possible to access the value of the "indeterminatePosition" attribute. After the patch xpaths that target this attribute are properly evaluated, e.g.

```
gml:TimePeriod/gml:endPosition/@indeterminatePosition
```