### PR TITLE
SQLFeatureStore: Support all GMLObject types in relational mode feature building

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
@@ -145,6 +145,8 @@ public class GMLStreamReader {
 
     private GMLDictionaryReader dictReader;
 
+    private boolean laxMode;
+
     /**
      * Creates a new {@link GMLStreamReader} instance.
      * 
@@ -247,6 +249,25 @@ public class GMLStreamReader {
      */
     public void setResolver( GMLReferenceResolver resolver ) {
         this.resolver = resolver;
+    }
+
+    /**
+     * Enables or disables lax parsing (disable syntactical checks).
+     * 
+     * @param laxMode
+     *            <code>true</code>, if syntacical issues shall be ignored, <code>false</code> otherwise
+     */
+    public void setLaxMode( final boolean laxMode ) {
+        this.laxMode = laxMode;
+    }
+
+    /**
+     * Returns the state of lax parsing.
+     * 
+     * @return <code>true</code>, if syntacical issues shall be ignored, <code>false</code> otherwise
+     */
+    public boolean getLaxMode() {
+        return laxMode;
     }
 
     /**

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -198,6 +198,9 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 
     // required since GML 3.2
     private boolean isGmlIdRequired() {
+        if ( gmlStreamReader.getLaxMode() ) {
+            return false;
+        }
         return version != GML_2 && version != GML_30 || version != GML_31;
     }
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureReader.java
@@ -406,7 +406,7 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
             } else {
                 // current property element is not equal to active declaration
                 while ( declIter.hasNext() && findConcretePropertyType( propName, activeDecl ) == null ) {
-                    if ( propOccurences < activeDecl.getMinOccurs() ) {
+                    if ( !gmlStreamReader.getLaxMode() && propOccurences < activeDecl.getMinOccurs() ) {
                         String msg = null;
                         if ( activeDecl.getMinOccurs() == 1 ) {
                             msg = Messages.getMessage( "ERROR_PROPERTY_MANDATORY", activeDecl.getName(), type.getName() );


### PR DESCRIPTION
Prior to this patch, a GML object other than a feature or a geometry would be recreated as GenericXMLElement by a relational-mode SQLFeatureStore. After this patch, such objects are transformed to the respective GMLObject subtype (e.g. TimeSlice or TimeObject). This is important for in-memory filtering on these kinds of objects.