### PR TITLE
SQLFeatureStore: Allow arbitrary SQL expressions in primitive particle mappings

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/property/GenericProperty.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/property/GenericProperty.java
@@ -169,6 +169,12 @@ public class GenericProperty implements Property {
         this.children = Collections.singletonList( value );
     }
 
+    public GenericProperty( PropertyType declaration, QName name, TypedObjectNode value, Map<QName,PrimitiveValue> attrs ) {
+        this( declaration, name, value );
+        this.attrs = attrs;
+        this.children = Collections.singletonList( value );
+    }    
+    
     @Override
     public QName getName() {
         return name;

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
@@ -145,6 +145,8 @@ public class GMLStreamReader {
 
     private GMLDictionaryReader dictReader;
 
+    private boolean laxMode;
+
     /**
      * Creates a new {@link GMLStreamReader} instance.
      * 
@@ -247,6 +249,25 @@ public class GMLStreamReader {
      */
     public void setResolver( GMLReferenceResolver resolver ) {
         this.resolver = resolver;
+    }
+
+    /**
+     * Enables or disables lax parsing (disable syntactical checks).
+     * 
+     * @param laxMode
+     *            <code>true</code>, if syntacical issues shall be ignored, <code>false</code> otherwise
+     */
+    public void setLaxMode( final boolean laxMode ) {
+        this.laxMode = laxMode;
+    }
+
+    /**
+     * Returns the state of lax parsing.
+     * 
+     * @return <code>true</code>, if syntacical issues shall be ignored, <code>false</code> otherwise
+     */
+    public boolean getLaxMode() {
+        return laxMode;
     }
 
     /**

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -429,10 +429,10 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
             if ( xmlStream.nextTag() == START_ELEMENT ) {
                 final GmlTimeGeometricPrimitiveReader timeReader = new GmlTimeGeometricPrimitiveReader( gmlStreamReader );
                 final TimeGeometricPrimitive timeObject = timeReader.read( xmlStream );
-                property = new GenericProperty( propDecl, propName, timeObject, isNilled );
+                property = new GenericProperty( propDecl, propName, timeObject, attrs );
                 xmlStream.nextTag();
             } else {
-                property = new GenericProperty( propDecl, propName, null, isNilled );
+                property = new GenericProperty( propDecl, propName, null, attrs );
             }
         }
         return property;

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -198,6 +198,9 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 
     // required since GML 3.2
     private boolean isGmlIdRequired() {
+        if ( gmlStreamReader.getLaxMode() ) {
+            return false;
+        }
         return version != GML_2 && version != GML_30 || version != GML_31;
     }
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureReader.java
@@ -406,7 +406,7 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
             } else {
                 // current property element is not equal to active declaration
                 while ( declIter.hasNext() && findConcretePropertyType( propName, activeDecl ) == null ) {
-                    if ( propOccurences < activeDecl.getMinOccurs() ) {
+                    if ( !gmlStreamReader.getLaxMode() && propOccurences < activeDecl.getMinOccurs() ) {
                         String msg = null;
                         if ( activeDecl.getMinOccurs() == 1 ) {
                             msg = Messages.getMessage( "ERROR_PROPERTY_MANDATORY", activeDecl.getName(), type.getName() );

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/time/gml/writer/GmlTimePeriodWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/time/gml/writer/GmlTimePeriodWriter.java
@@ -86,7 +86,7 @@ public class GmlTimePeriodWriter {
                             throws XMLStreamException {
         if ( timePositionOrInstant instanceof TimeInstant ) {
             writeBegin( writer, (org.deegree.time.primitive.TimeInstant) timePositionOrInstant );
-        } else {
+        } else if ( timePositionOrInstant instanceof TimePosition ) {
             writeBeginPosition( writer, (TimePosition) timePositionOrInstant );
         }
     }
@@ -95,7 +95,7 @@ public class GmlTimePeriodWriter {
                             throws XMLStreamException {
         if ( timePositionOrInstant instanceof TimeInstant ) {
             writeEnd( writer, (org.deegree.time.primitive.TimeInstant) timePositionOrInstant );
-        } else {
+        } else if ( timePositionOrInstant instanceof TimePosition ) {
             writeEndPosition( writer, (TimePosition) timePositionOrInstant );
         }
     }

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/sql/DefaultPrimitiveConverter.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/sql/DefaultPrimitiveConverter.java
@@ -90,6 +90,9 @@ public class DefaultPrimitiveConverter implements PrimitiveParticleConverter {
     @Override
     public String getSelectSnippet( String tableAlias ) {
         if ( tableAlias != null ) {
+            if (column.startsWith( "'" ) || column.contains( " " )) {
+                return column.replace( "$0", tableAlias );
+            }
             return tableAlias + "." + column;
         }
         return column;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/FeatureBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/FeatureBuilder.java
@@ -52,11 +52,11 @@ import org.deegree.feature.Feature;
 public interface FeatureBuilder {
 
     /**
-     * Returns the columns for the SELECT statement that is used to retrieve the {@link ResultSet}.
+     * Returns the columns/expression for the SELECT statement that is used to retrieve the {@link ResultSet}.
      * 
-     * @return list of columns, never <code>null</code>
+     * @return list of columns/expression, never <code>null</code>
      */
-    public List<String> getInitialSelectColumns();
+    public List<String> getInitialSelectList();
 
     /**
      * Builds a {@link Feature} instance from the current row of the given {@link ResultSet}.

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -135,6 +135,7 @@ import org.deegree.sqldialect.filter.PropertyNameMapping;
 import org.deegree.sqldialect.filter.TableAliasManager;
 import org.deegree.sqldialect.filter.UnmappableException;
 import org.deegree.sqldialect.filter.expression.SQLArgument;
+import org.deegree.sqldialect.filter.expression.SQLExpression;
 import org.deegree.workspace.Resource;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceMetadata;
@@ -1036,7 +1037,7 @@ public class SQLFeatureStore implements FeatureStore {
             String tableAlias = "X1";
             FeatureBuilder builder = new FeatureBuilderRelational( this, ft, ftMapping, conn, tableAlias,
                                                                    nullEscalation );
-            List<String> columns = builder.getInitialSelectColumns();
+            List<String> columns = builder.getInitialSelectList();
             StringBuilder sql = new StringBuilder( "SELECT " );
             sql.append( columns.get( 0 ) );
             for ( int i = 1; i < columns.size(); i++ ) {
@@ -1120,16 +1121,11 @@ public class SQLFeatureStore implements FeatureStore {
             FeatureTypeMapping ftMapping = getMapping( ftName );
             BlobMapping blobMapping = getSchema().getBlobMapping();
             FeatureBuilder builder = new FeatureBuilderBlob( this, blobMapping );
-
-            List<String> columns = builder.getInitialSelectColumns();
-
-            if ( query.getPrefilterBBox() != null ) {
-                OperatorFilter bboxFilter = new OperatorFilter( query.getPrefilterBBox() );
-                wb = getWhereBuilderBlob( bboxFilter, conn );
-                LOG.debug( "WHERE clause: " + wb.getWhere() );
-                // LOG.debug( "ORDER BY clause: " + wb.getOrderBy() );
-            }
-            String alias = wb != null ? wb.getAliasManager().getRootTableAlias() : "X1";
+            List<String> columns = builder.getInitialSelectList();
+            wb = getWhereBuilderBlob( filter, conn );
+            final SQLExpression where = wb.getWhere();
+            LOG.debug( "WHERE clause: " + where );
+            String alias = wb.getAliasManager().getRootTableAlias();
 
             StringBuilder sql = new StringBuilder( "SELECT " );
             sql.append( columns.get( 0 ) );
@@ -1279,7 +1275,7 @@ public class SQLFeatureStore implements FeatureStore {
 
             FeatureBuilder builder = new FeatureBuilderRelational( this, ft, ftMapping, conn, ftTableAlias,
                                                                    nullEscalation );
-            List<String> columns = builder.getInitialSelectColumns();
+            List<String> columns = builder.getInitialSelectList();
 
             BlobMapping blobMapping = getSchema().getBlobMapping();
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
@@ -650,8 +650,9 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
                 for ( Feature feature : features ) {
                     FeatureTypeMapping ftMapping = fs.getMapping( feature.getName() );
                     if ( ftMapping == null ) {
-                        throw new FeatureStoreException( "Cannot insert feature of type '" + feature.getName()
-                                                         + "'. No mapping defined and BLOB mode is off." );
+                        continue;
+//                        throw new FeatureStoreException( "Cannot insert feature of type '" + feature.getName()
+//                                                         + "'. No mapping defined and BLOB mode is off." );
                     }
                     idAssignments.add( insertManager.insertFeature( feature, ftMapping ) );
                     Pair<TableName, GeometryMapping> mapping = ftMapping.getDefaultGeometryMapping();

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/FeatureBuilderBlob.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/FeatureBuilderBlob.java
@@ -83,7 +83,7 @@ public class FeatureBuilderBlob implements FeatureBuilder {
     }
 
     @Override
-    public List<String> getInitialSelectColumns() {
+    public List<String> getInitialSelectList() {
         List<String> columns = new ArrayList<String>();
         columns.add( blobMapping.getGMLIdColumn() );
         columns.add( blobMapping.getDataColumn() );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
@@ -64,6 +64,7 @@ import org.deegree.feature.persistence.FeatureStoreException;
 import org.deegree.feature.persistence.mapping.antlr.FMLLexer;
 import org.deegree.feature.persistence.mapping.antlr.FMLParser;
 import org.deegree.feature.persistence.sql.MappedAppSchema;
+import org.deegree.feature.persistence.sql.expressions.Function;
 import org.deegree.feature.persistence.sql.expressions.TableJoin;
 import org.deegree.feature.persistence.sql.id.AutoIDGenerator;
 import org.deegree.feature.persistence.sql.id.IDGenerator;
@@ -197,7 +198,8 @@ public abstract class AbstractMappedSchemaBuilder {
             try {
                 mapping = parser.mappingExpr().value;
             } catch ( RecognitionException e ) {
-                LOG.warn( "Unable to parse mapping expression '" + s + "': " + e.getMessage() );
+                LOG.warn( "Unable to parse mapping expression '" + s + "': treating as SQL expression" );
+                return new Function( s );
             }
         }
         return mapping;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
@@ -65,7 +65,6 @@ import org.deegree.commons.jdbc.SQLIdentifier;
 import org.deegree.commons.jdbc.TableName;
 import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveType;
-import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.utils.Pair;
 import org.deegree.commons.xml.NamespaceBindings;
 import org.deegree.commons.xml.XMLAdapter;
@@ -78,7 +77,6 @@ import org.deegree.feature.persistence.sql.GeometryStorageParams;
 import org.deegree.feature.persistence.sql.MappedAppSchema;
 import org.deegree.feature.persistence.sql.blob.BlobCodec;
 import org.deegree.feature.persistence.sql.blob.BlobMapping;
-import org.deegree.feature.persistence.sql.expressions.StringConst;
 import org.deegree.feature.persistence.sql.expressions.TableJoin;
 import org.deegree.feature.persistence.sql.id.AutoIDGenerator;
 import org.deegree.feature.persistence.sql.id.FIDMapping;
@@ -97,7 +95,6 @@ import org.deegree.feature.persistence.sql.jaxb.SQLFeatureStoreJAXB.NamespaceHin
 import org.deegree.feature.persistence.sql.jaxb.StorageCRS;
 import org.deegree.feature.persistence.sql.mapper.XPathSchemaWalker;
 import org.deegree.feature.persistence.sql.rules.CompoundMapping;
-import org.deegree.feature.persistence.sql.rules.ConstantMapping;
 import org.deegree.feature.persistence.sql.rules.FeatureMapping;
 import org.deegree.feature.persistence.sql.rules.GeometryMapping;
 import org.deegree.feature.persistence.sql.rules.Mapping;
@@ -113,7 +110,6 @@ import org.deegree.filter.expression.ValueReference;
 import org.deegree.gml.GMLVersion;
 import org.deegree.gml.schema.GMLAppSchemaReader;
 import org.deegree.gml.schema.GMLSchemaInfoSet;
-import org.deegree.sqldialect.filter.DBField;
 import org.deegree.sqldialect.filter.MappingExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -402,19 +398,10 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
         }
 
         MappingExpression me = parseMappingExpression( config.getMapping() );
-        if ( me instanceof DBField ) {
-            List<TableJoin> joinedTable = buildJoinTable( currentTable, config.getJoin() );
-            LOG.debug( "Targeted primitive type: " + pt );
-            boolean escalateVoid = determineParticleVoidability( pt.second, config.getNullEscalation() );
-            return new PrimitiveMapping( path, escalateVoid, me, pt.first, joinedTable, config.getCustomConverter() );
-        } else if ( me instanceof StringConst ) {
-            String s = me.toString();
-            s = s.substring( 1, s.length() - 1 );
-            PrimitiveValue value = new PrimitiveValue( s, pt.first );
-            return new ConstantMapping<PrimitiveValue>( path, value, config.getCustomConverter() );
-        }
-        throw new IllegalArgumentException( "Mapping expressions of type '" + me.getClass()
-                                            + "' are not supported yet." );
+        List<TableJoin> joinedTable = buildJoinTable( currentTable, config.getJoin() );
+        LOG.debug( "Targeted primitive type: " + pt );
+        boolean escalateVoid = determineParticleVoidability( pt.second, config.getNullEscalation() );
+        return new PrimitiveMapping( path, escalateVoid, me, pt.first, joinedTable, config.getCustomConverter() );
     }
 
     private GeometryMapping buildMapping( TableName currentTable, Pair<XSElementDeclaration, Boolean> elDecl,

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/DDLCreator.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/DDLCreator.java
@@ -50,7 +50,7 @@ import org.deegree.feature.persistence.sql.expressions.TableJoin;
 import org.deegree.feature.persistence.sql.id.AutoIDGenerator;
 import org.deegree.feature.persistence.sql.id.FIDMapping;
 import org.deegree.feature.persistence.sql.rules.CompoundMapping;
-import org.deegree.feature.persistence.sql.rules.ConstantMapping;
+import org.deegree.feature.persistence.sql.rules.SqlExpressionMapping;
 import org.deegree.feature.persistence.sql.rules.FeatureMapping;
 import org.deegree.feature.persistence.sql.rules.GeometryMapping;
 import org.deegree.feature.persistence.sql.rules.Mapping;
@@ -217,7 +217,7 @@ public abstract class DDLCreator {
             for ( Mapping childMapping : compoundMapping.getParticles() ) {
                 ddls.addAll( process( sql, table, childMapping ) );
             }
-        } else if ( mapping instanceof ConstantMapping ) {
+        } else if ( mapping instanceof SqlExpressionMapping ) {
             // skip
         } else {
             throw new RuntimeException( "Internal error. Unhandled mapping type '" + mapping.getClass() + "'" );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/expressions/Function.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/expressions/Function.java
@@ -68,14 +68,6 @@ public class Function implements MappingExpression {
 
     @Override
     public String toString() {
-        String s = functionName + "(";
-        for ( int i = 0; i < args.size(); i++ ) {
-            s += args.get( i );
-            if ( i != args.size() -1 ) {
-                s += ',';
-            }
-        }
-        s += ")";
-        return s;
+        return functionName;
     }
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
@@ -66,7 +66,7 @@ import org.deegree.feature.persistence.sql.expressions.TableJoin;
 import org.deegree.feature.persistence.sql.id.KeyPropagation;
 import org.deegree.feature.persistence.sql.id.TableDependencies;
 import org.deegree.feature.persistence.sql.rules.CompoundMapping;
-import org.deegree.feature.persistence.sql.rules.ConstantMapping;
+import org.deegree.feature.persistence.sql.rules.SqlExpressionMapping;
 import org.deegree.feature.persistence.sql.rules.FeatureMapping;
 import org.deegree.feature.persistence.sql.rules.GeometryMapping;
 import org.deegree.feature.persistence.sql.rules.Mapping;
@@ -398,7 +398,7 @@ public class InsertRowManager {
                 for ( Mapping child : ( (CompoundMapping) mapping ).getParticles() ) {
                     buildInsertRows( value, child, currentRow, additionalRows );
                 }
-            } else if ( mapping instanceof ConstantMapping ) {
+            } else if ( mapping instanceof SqlExpressionMapping ) {
                 // nothing to do
             } else {
                 LOG.warn( "Unhandled mapping type '" + mapping.getClass() + "'." );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/SqlExpressionMapping.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/SqlExpressionMapping.java
@@ -35,46 +35,37 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.feature.persistence.sql.rules;
 
-import org.deegree.feature.persistence.sql.jaxb.CustomConverterJAXB;
 import org.deegree.commons.tom.TypedObjectNode;
+import org.deegree.feature.persistence.sql.jaxb.CustomConverterJAXB;
 import org.deegree.filter.expression.ValueReference;
 
 /**
- * {@link Mapping} of a particle to a fixed value.
+ * {@link Mapping} of a particle to an SQL expression (e.g. a constant or a CASE statement).
  * 
- * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
- * @author last edited by: $Author: markus $
- * 
- * @version $Revision: $, $Date: $
+ * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
+ *
+ * @since 3.4
  */
-public class ConstantMapping<T extends TypedObjectNode> extends Mapping {
+public class SqlExpressionMapping<T extends TypedObjectNode> extends Mapping {
 
-    private final T value;
+    private final String sql;
 
     /**
-     * Creates a new {@link ConstantMapping} instance.
+     * Creates a new {@link SqlExpressionMapping} instance.
      * 
      * @param path
      *            relative xpath expression, must not be <code>null</code>
-     * @param value
-     *            the value of the particle, must not be <code>null</code>
+     * @param sql
+     *            the SQL expression, must not be <code>null</code>
      */
-    public ConstantMapping( ValueReference path, T value, CustomConverterJAXB converter ) {
+    public SqlExpressionMapping( ValueReference path, final String sql, CustomConverterJAXB converter ) {
         super( path, false, null, converter );
-        this.value = value;
+        this.sql = sql;
     }
 
-    public ConstantMapping( ValueReference path, T value ) {
+    public SqlExpressionMapping( ValueReference path, final String sql ) {
         super( path, false, null, null );
-        this.value = value;
+        this.sql = sql;
     }
 
-    /**
-     * Returns the value that the particle is mapped to.
-     * 
-     * @return the value of the particle, never <code>null</code>
-     */
-    public T getValue() {
-        return value;
-    }
 }


### PR DESCRIPTION
Prior to this patch, it was possible to use database column names or constants in the mapping attribute of primitive particles, e.g.:
```
<Primitive path="@nilReason" mapping="nil_reason"/"
```
or
```
<Primitive path="@nilReason" mapping="'unknown'"/"
```
After this patch, it's also possible to use arbitrary SQL expressions in the mapping of a primitive particle. Here's an example that maps a gml:validTime property. In this case, it either contains a TimeInstant, a TimePeriod or has attribute 'nilReason' set to 'unknown'. The attribute is set in case both the gml_validtime_gml_timeinstant and the gml_validtime_gml_timeperiod columns are NULL:

```
<Complex path="gml:validTime">
  <Primitive path="@nilReason" mapping="(CASE WHEN $0.gml_validtime_gml_timeinstant IS NULL AND $0.gml_validtime_gml_timeperiod_begin IS NULL AND $0.gml_validtime_gml_timeperiod_end IS NULL THEN 'inapplicable' ELSE NULL END)" type="text" />
  <Complex path="gml:TimeInstant">
    <Complex path="gml:timePosition">
      <Primitive path="text()" mapping="gml_validtime_gml_timeinstant" type="dateTime" />
    </Complex>
  </Complex>
  <Complex path="gml:TimePeriod">
    <Complex path="gml:beginPosition">
      <Primitive path="@indeterminatePosition" mapping="CASE WHEN gml_validtime_gml_timeperiod_begin IS NULL AND gml_validtime_gml_timeperiod_end IS NOT NULL THEN 'unknown' ELSE NULL END" type="text" />
      <Primitive path="text()" mapping="gml_validtime_gml_timeperiod_begin" type="dateTime" />
    </Complex>
    <Complex path="gml:endPosition">
      <Primitive path="@indeterminatePosition" mapping="CASE WHEN $0.gml_validtime_gml_timeperiod_end IS NULL AND $0.gml_validtime_gml_timeperiod_begin IS NOT NULL THEN 'unknown' ELSE NULL END" type="text" />
      <Primitive path="text()" mapping="gml_validtime_gml_timeperiod_end" type="dateTime" />
    </Complex>
  </Complex>
</Complex>
```
The SQL expression for determining the value of the indeterminatePosition attribute is:
```
CASE WHEN $0.gml_validtime_gml_timeperiod_begin IS NULL AND $0.gml_validtime_gml_timeperiod_end IS NOT NULL THEN 'unknown' ELSE NULL END
```
Note that column names in the expression need to be aliased with "$0.": When this expression is passed through to the SQL database, $0 is replaced with the correct table alias used in the SELECT column list or in the WhereBuilder.
