### PR TITLE
Improved positioning from labels of lines

### DIFF
--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/components/LinePlacement.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/components/LinePlacement.java
@@ -104,11 +104,13 @@ public class LinePlacement implements Copyable<LinePlacement> {
         copy.perpendicularOffset = perpendicularOffset;
         copy.perpendicularOffsetType = perpendicularOffsetType.copy();
         copy.repeat = repeat;
+        copy.center = center;
         copy.initialGap = initialGap;
         copy.gap = gap;
         copy.isAligned = isAligned;
         copy.generalizeLine = generalizeLine;
         copy.preventUpsideDown = preventUpsideDown;
+        copy.wordWise = wordWise;
         return copy;
     }
 


### PR DESCRIPTION
Before it was not possible to position a label to a line centered, when using a function for the distance between line and label within perpendicular offset for the label.

With these changes it is possible!