### PR TITLE
Enhancement allowing to set more than one MetadataURL for each Layer/FeatureType

### DIFF
--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/OWSMetadataProvider.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/OWSMetadataProvider.java
@@ -106,4 +106,13 @@ public interface OWSMetadataProvider extends Resource {
      */
     DatasetMetadata getDatasetMetadata( QName name );
 
+    /**
+     * Returns a list of data metadata for the specified dataset.
+     * 
+     * @param name
+     *            for layers, a qname with only a local name is used, for feature types its qname
+     * @return metadata, may be empty but never <code>null</code> (no metadata available)
+     */
+    List<DatasetMetadata> getAllDatasetMetadata( QName name );
+    
 }

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOWSMetadataProvider.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOWSMetadataProvider.java
@@ -40,6 +40,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.services.metadata.provider;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +73,7 @@ public class DefaultOWSMetadataProvider implements OWSMetadataProvider {
 
     private final List<DatasetMetadata> datasetMetadata;
 
-    private final Map<QName, DatasetMetadata> datasetNameToMetadata = new HashMap<QName, DatasetMetadata>();
+    private final Map<QName, List<DatasetMetadata>> datasetNameToMetadata = new HashMap<QName, List<DatasetMetadata>>();
 
     private final Map<String, List<OMElement>> extendedCapabilities;
 
@@ -90,7 +91,10 @@ public class DefaultOWSMetadataProvider implements OWSMetadataProvider {
             this.datasetMetadata = Collections.emptyList();
         }
         for ( DatasetMetadata dsMd : this.datasetMetadata ) {
-            this.datasetNameToMetadata.put( dsMd.getQName(), dsMd );
+            QName dsMdName = dsMd.getQName();
+            if ( !this.datasetNameToMetadata.containsKey( dsMdName ) )
+                this.datasetNameToMetadata.put( dsMdName, new ArrayList<DatasetMetadata>() );
+            this.datasetNameToMetadata.get( dsMdName ).add( dsMd );
         }
         this.authorities = authorities;
     }
@@ -128,15 +132,34 @@ public class DefaultOWSMetadataProvider implements OWSMetadataProvider {
 
     @Override
     public DatasetMetadata getDatasetMetadata( QName name ) {
-        DatasetMetadata md = datasetNameToMetadata.get( name );
-        if ( md == null ) {
-            for ( Entry<QName, DatasetMetadata> e : datasetNameToMetadata.entrySet() ) {
+        List<DatasetMetadata> md = datasetNameToMetadata.get( name );
+        if ( md == null || md.isEmpty() ) {
+            for ( Entry<QName, List<DatasetMetadata>> e : datasetNameToMetadata.entrySet() ) {
                 if ( e.getKey().getLocalPart().equalsIgnoreCase( name.getLocalPart() ) ) {
-                    return e.getValue();
+                    List<DatasetMetadata> dsMd = e.getValue();
+                    if ( !dsMd.isEmpty() )
+                        return dsMd.get( 0 );
                 }
             }
+            return null;
         }
-        return md;
+        return md.get( 0 );
+    }
+
+    @Override
+    public List<DatasetMetadata> getAllDatasetMetadata( QName name ) {
+        List<DatasetMetadata> datasetMetadata = new ArrayList<DatasetMetadata>();
+        List<DatasetMetadata> mds = datasetNameToMetadata.get( name );
+        if ( mds == null || mds.isEmpty() ) {
+            for ( Entry<QName, List<DatasetMetadata>> e : datasetNameToMetadata.entrySet() ) {
+                if ( e.getKey().getLocalPart().equalsIgnoreCase( name.getLocalPart() ) ) {
+                    datasetMetadata.addAll( e.getValue() );
+                }
+            }
+        } else {
+            datasetMetadata.addAll( mds );
+        }
+        return datasetMetadata;
     }
 
     @Override

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/metadata/provider/DefaultOWSMetadataProviderTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/metadata/provider/DefaultOWSMetadataProviderTest.java
@@ -45,13 +45,10 @@ import java.util.List;
 import javax.xml.namespace.QName;
 
 import org.deegree.commons.ows.metadata.DatasetMetadata;
-import org.deegree.commons.ows.metadata.MetadataUrl;
-import org.deegree.commons.ows.metadata.layer.Attribution;
-import org.deegree.commons.ows.metadata.layer.ExternalIdentifier;
-import org.deegree.commons.ows.metadata.layer.UrlWithFormat;
 import org.deegree.commons.tom.ows.CodeType;
 import org.deegree.commons.tom.ows.LanguageString;
 import org.deegree.commons.utils.Pair;
+import org.deegree.commons.utils.StringPair;
 import org.junit.Test;
 
 /**
@@ -94,25 +91,17 @@ public class DefaultOWSMetadataProviderTest {
     private DefaultOWSMetadataProvider createProvider() {
         List<DatasetMetadata> datasetMetadata = new ArrayList<DatasetMetadata>();
         datasetMetadata.add( createDatasetMetadata( "name1", "http:/url.org/1" ) );
-        datasetMetadata.add( createDatasetMetadata( "name1", "http:/url.org/2", "http:/url.org/3" ) );
-        datasetMetadata.add( createDatasetMetadata( "name2", "http:/url.org/4" ) );
-        return new DefaultOWSMetadataProvider( null, null, null, datasetMetadata, null, null );
+        datasetMetadata.add( createDatasetMetadata( "name1", "http:/url.org/2" ) );
+        datasetMetadata.add( createDatasetMetadata( "name2", "http:/url.org/3" ) );
+        return new DefaultOWSMetadataProvider( null, null, null, datasetMetadata, null );
     }
 
-    private DatasetMetadata createDatasetMetadata( String name, String... urls ) {
+    private DatasetMetadata createDatasetMetadata( String name, String url ) {
         List<LanguageString> titles = new ArrayList<LanguageString>();
         List<LanguageString> abstracts = new ArrayList<LanguageString>();
         List<Pair<List<LanguageString>, CodeType>> keywords = new ArrayList<Pair<List<LanguageString>, CodeType>>();
-        List<MetadataUrl> metadataUrls = new ArrayList<MetadataUrl>();
-        List<ExternalIdentifier> externalIds = new ArrayList<ExternalIdentifier>();
-        List<UrlWithFormat> dataUrls = new ArrayList<UrlWithFormat>();
-        List<UrlWithFormat> featureListUrls = new ArrayList<UrlWithFormat>();
-        Attribution attribution = null;
-        for ( String url : urls ) {
-            metadataUrls.add( new MetadataUrl( url, "ISO19115:2003", "application/xml" ) );
-        }
-        return new DatasetMetadata( new QName( name ), titles, abstracts, keywords, metadataUrls, externalIds,
-                                    dataUrls, featureListUrls, attribution );
+        List<StringPair> externalIds = new ArrayList<StringPair>();
+        return new DatasetMetadata( new QName( name ), titles, abstracts, keywords, url, externalIds );
     }
 
 }

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/metadata/provider/DefaultOWSMetadataProviderTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/metadata/provider/DefaultOWSMetadataProviderTest.java
@@ -1,0 +1,118 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.services.metadata.provider;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import org.deegree.commons.ows.metadata.DatasetMetadata;
+import org.deegree.commons.ows.metadata.MetadataUrl;
+import org.deegree.commons.ows.metadata.layer.Attribution;
+import org.deegree.commons.ows.metadata.layer.ExternalIdentifier;
+import org.deegree.commons.ows.metadata.layer.UrlWithFormat;
+import org.deegree.commons.tom.ows.CodeType;
+import org.deegree.commons.tom.ows.LanguageString;
+import org.deegree.commons.utils.Pair;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DefaultOWSMetadataProvider}.
+ * 
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class DefaultOWSMetadataProviderTest {
+
+    @Test
+    public void testGetDatasetMetadata()
+                            throws Exception {
+        DefaultOWSMetadataProvider metadataProvider = createProvider();
+
+        List<DatasetMetadata> datasetMetadata = metadataProvider.getDatasetMetadata();
+
+        assertThat( datasetMetadata.size(), is( 3 ) );
+    }
+
+    @Test
+    public void testGetDatasetMetadataByName()
+                            throws Exception {
+        DefaultOWSMetadataProvider metadataProvider = createProvider();
+
+        DatasetMetadata datasetMetadata = metadataProvider.getDatasetMetadata( new QName( "name1" ) );
+
+        assertThat( datasetMetadata, is( notNullValue() ) );
+    }
+
+    @Test
+    public void testGetAllDatasetMetadataByName()
+                            throws Exception {
+        DefaultOWSMetadataProvider metadataProvider = createProvider();
+
+        List<DatasetMetadata> datasetMetadata = metadataProvider.getAllDatasetMetadata( new QName( "name1" ) );
+
+        assertThat( datasetMetadata.size(), is( 2 ) );
+    }
+
+    private DefaultOWSMetadataProvider createProvider() {
+        List<DatasetMetadata> datasetMetadata = new ArrayList<DatasetMetadata>();
+        datasetMetadata.add( createDatasetMetadata( "name1", "http:/url.org/1" ) );
+        datasetMetadata.add( createDatasetMetadata( "name1", "http:/url.org/2", "http:/url.org/3" ) );
+        datasetMetadata.add( createDatasetMetadata( "name2", "http:/url.org/4" ) );
+        return new DefaultOWSMetadataProvider( null, null, null, datasetMetadata, null, null );
+    }
+
+    private DatasetMetadata createDatasetMetadata( String name, String... urls ) {
+        List<LanguageString> titles = new ArrayList<LanguageString>();
+        List<LanguageString> abstracts = new ArrayList<LanguageString>();
+        List<Pair<List<LanguageString>, CodeType>> keywords = new ArrayList<Pair<List<LanguageString>, CodeType>>();
+        List<MetadataUrl> metadataUrls = new ArrayList<MetadataUrl>();
+        List<ExternalIdentifier> externalIds = new ArrayList<ExternalIdentifier>();
+        List<UrlWithFormat> dataUrls = new ArrayList<UrlWithFormat>();
+        List<UrlWithFormat> featureListUrls = new ArrayList<UrlWithFormat>();
+        Attribution attribution = null;
+        for ( String url : urls ) {
+            metadataUrls.add( new MetadataUrl( url, "ISO19115:2003", "application/xml" ) );
+        }
+        return new DatasetMetadata( new QName( name ), titles, abstracts, keywords, metadataUrls, externalIds,
+                                    dataUrls, featureListUrls, attribution );
+    }
+
+}

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -687,13 +687,16 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
                 // TODO Operations
 
                 // wfs:MetadataURL (minOccurs=0, maxOccurs=unbounded)
-                String metadataUrl = ftMd != null ? ftMd.getUrl() : null;
-                if ( metadataUrl != null ) {
-                    writer.writeStartElement( WFS_NS, "MetadataURL" );
-                    writer.writeAttribute( "type", "19139" );
-                    writer.writeAttribute( "format", "text/xml" );
-                    writer.writeCharacters( metadataUrl );
-                    writer.writeEndElement();
+                List<DatasetMetadata> ftMds = mdProvider.getAllDatasetMetadata( ftName );
+                if ( ftMds != null ) {
+                    for ( DatasetMetadata datasetMetadata : ftMds ) {
+                        String metadataUrl = datasetMetadata.getUrl();
+                        writer.writeStartElement( WFS_NS, "MetadataURL" );
+                        writer.writeAttribute( "type", "19139" );
+                        writer.writeAttribute( "format", "text/xml" );
+                        writer.writeCharacters( metadataUrl );
+                        writer.writeEndElement();
+                    }
                 }
 
                 writer.writeEndElement();

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -313,13 +313,18 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             }
 
             // wfs:MetadataURL (minOccurs=0, maxOccurs=unbounded)
-            String metadataUrl = ftMd != null ? ftMd.getUrl() : null;
-            if ( metadataUrl != null ) {
-                writer.writeStartElement( WFS_NS, "MetadataURL" );
-                writer.writeAttribute( "type", "TC211" );
-                writer.writeAttribute( "format", "XML" );
-                writer.writeCharacters( metadataUrl );
-                writer.writeEndElement();
+            List<DatasetMetadata> ftMds = mdProvider.getAllDatasetMetadata( ftName );
+            if ( ftMds != null ) {
+                for ( DatasetMetadata datasetMetadata : ftMds ) {
+                    String metadataUrl = datasetMetadata.getUrl();
+                    if ( metadataUrl != null ) {
+                        writer.writeStartElement( WFS_NS, "MetadataURL" );
+                        writer.writeAttribute( "type", "TC211" );
+                        writer.writeAttribute( "format", "XML" );
+                        writer.writeCharacters( metadataUrl );
+                        writer.writeEndElement();
+                    }
+                }
             }
 
             writer.writeEndElement();
@@ -810,10 +815,10 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
                 constraints.add( new Domain( "AutomaticDataLocking", "TRUE" ) );
                 constraints.add( new Domain( "PreservesSiblingOrder", "TRUE" ) );
                 operations.add( new Operation( Transaction.name(), post, null, constraints, null ) );
-                
+
                 // GetFeatureWithLock
                 operations.add( new Operation( GetFeatureWithLock.name(), getAndPost, null, null, null ) );
-                
+
                 // LockFeature
                 operations.add( new Operation( LockFeature.name(), getAndPost, null, null, null ) );
             }
@@ -853,7 +858,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             } else {
                 constraints.add( new Domain( "ImplementsTransactionalWFS", "FALSE" ) );
                 constraints.add( new Domain( "ImplementsLockingWFS", "FALSE" ) );
-            }            
+            }
             constraints.add( new Domain( "KVPEncoding", "TRUE" ) );
             constraints.add( new Domain( "XMLEncoding", "TRUE" ) );
             constraints.add( new Domain( "SOAPEncoding", "FALSE" ) );
@@ -994,10 +999,15 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
                 writer.writeEndElement();
 
                 // wfs:MetadataURL (minOccurs=0, maxOccurs=unbounded)
-                String metadataUrl = ftMd != null ? ftMd.getUrl() : null;
-                if ( metadataUrl != null ) {
-                    writer.writeEmptyElement( WFS_200_NS, "MetadataURL" );
-                    writer.writeAttribute( XLN_NS, "href", metadataUrl );
+                List<DatasetMetadata> ftMds = mdProvider.getAllDatasetMetadata( ftName );
+                if ( ftMds != null ) {
+                    for ( DatasetMetadata datasetMetadata : ftMds ) {
+                        String metadataUrl = datasetMetadata.getUrl();
+                        if ( metadataUrl != null ) {
+                            writer.writeEmptyElement( WFS_200_NS, "MetadataURL" );
+                            writer.writeAttribute( XLN_NS, "href", metadataUrl );
+                        }
+                    }
                 }
 
                 writer.writeEndElement();

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities111XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities111XMLAdapter.java
@@ -104,7 +104,7 @@ public class Capabilities111XMLAdapter extends XMLAdapter {
         this.service = service;
         this.controller = controller;
         metadataWriter = new WmsCapabilities111MetadataWriter( identification, provider, getUrl, postUrl, controller );
-        themeWriter = new WmsCapabilities111ThemeWriter( controller, getUrl, this );
+        themeWriter = new WmsCapabilities111ThemeWriter( controller, getUrl, this, metadata );
     }
 
     /**

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities111ThemeWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities111ThemeWriter.java
@@ -212,16 +212,17 @@ class WmsCapabilities111ThemeWriter {
         if ( md != null ) {
             for ( StringPair ext : md.getExternalUrls() ) {
                 String url = auths.get( ext.first );
-                writer.writeStartElement( WMSNS, "AuthorityURL" );
+                writer.writeStartElement( "AuthorityURL" );
                 writer.writeAttribute( "name", ext.first );
-                writer.writeStartElement( WMSNS, "OnlineResource" );
+                writer.writeStartElement( "OnlineResource" );
+                writer.writeNamespace( XLINK_PREFIX, XLNNS );
                 writer.writeAttribute( XLNNS, "type", "simple" );
                 writer.writeAttribute( XLNNS, "href", url );
                 writer.writeEndElement();
                 writer.writeEndElement();
             }
             for ( StringPair ext : md.getExternalUrls() ) {
-                writer.writeStartElement( WMSNS, "Identifier" );
+                writer.writeStartElement( "Identifier" );
                 writer.writeAttribute( "authority", ext.first );
                 writer.writeCharacters( ext.second );
                 writer.writeEndElement();
@@ -238,7 +239,7 @@ class WmsCapabilities111ThemeWriter {
     private void writeMetadataUrl( XMLStreamWriter writer, String url )
                             throws XMLStreamException {
         writer.writeStartElement( "MetadataURL" );
-        writer.writeAttribute( "type", "ISO19115:2003" );
+        writer.writeAttribute( "type", "TC211" );
         writeElement( writer, "Format", "application/xml" );
         writer.writeStartElement( "OnlineResource" );
         writer.writeNamespace( XLINK_PREFIX, XLNNS );

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities130ThemeWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/WmsCapabilities130ThemeWriter.java
@@ -226,8 +226,11 @@ class WmsCapabilities130ThemeWriter {
                 writer.writeEndElement();
             }
 
-            String url = md.getUrl();
-            writeMetadataUrl( writer, url );
+            List<DatasetMetadata> mds = metadata.getAllDatasetMetadata( new QName( name ) );
+            for ( DatasetMetadata datasetMetadata : mds ) {
+                String url = datasetMetadata.getUrl();
+                writeMetadataUrl( writer, url );
+            }
         }
     }
 


### PR DESCRIPTION
Currently, just one metadataUrl is set for each Layer/FeatureType in the capabilities document of the WMS and WFS, even if multiple metadataUrls are configured for a Layer/FeatureType (if this is the case, just the last one is written in the capabilities document).
This fix allows to configure multiple metadataUrls for a single Layer/FeatureType and returns them in the capabilities response. The fix has been tested for WMS 1.3.0, WMS 1.1.1, WFS 1.1.0 and WFS 2.0.0.

In addition, two general adjustments were done:
 * Previously, the WFS just returned FeatureTypes with metadataUrls in the capabilities document if metadataUrls were set. This behaviour was changed and now always all FeatureTypes are returned (even if metadataUrls are set).
 * Previously, the metadataUrls of the first layer were also set in top level layer (e.g. root layer) in the capabilities document of the WMS. This behaviour was changed and now top level layer do not get the metadataUrls of the first child layer anymore.

This pull request was also created for the master (#536).