### PR TITLE
Use X-Forwarded-Host from header as HTTP GET and POST DCP URL if available

### DIFF
--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -91,7 +91,15 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-    </dependency>     
+    </dependency>   
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -255,7 +255,7 @@ public class OGCFrontController extends HttpServlet {
      * @return URL, never <code>null</code> (without trailing slash or question mark)
      */
     public static String getHttpPostURL() {
-        return getContext().getServiceUrl();
+        return getHttpURL();
     }
 
     /**
@@ -271,7 +271,7 @@ public class OGCFrontController extends HttpServlet {
      * @return URL (for GET requests), never <code>null</code> (with trailing question mark)
      */
     public static String getHttpGetURL() {
-        return getContext().getServiceUrl() + "?";
+        return getHttpURL() + "?";
     }
 
     /**
@@ -1571,6 +1571,14 @@ public class OGCFrontController extends HttpServlet {
         if ( requestWatchdog != null ) {
             requestWatchdog.unwatchCurrentThread();
         }
+    }
+
+    private static String getHttpURL() {
+        RequestContext context = getContext();
+        String xForwardedHost = context.getXForwardedHost();
+        if ( xForwardedHost != null && xForwardedHost != "" )
+            return xForwardedHost;
+        return context.getServiceUrl();
     }
 
 }

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -1603,7 +1603,7 @@ public class OGCFrontController extends HttpServlet {
         if ( port != null )
             urlBuilder.append( ":" ).append( port );
         if ( path != null && !"".equals( path ) )
-            urlBuilder.append( "/" ).append( path );
+            urlBuilder.append( path );
         return urlBuilder.toString();
     }
 

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/RequestContext.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/RequestContext.java
@@ -72,7 +72,11 @@ public class RequestContext {
 
     private final String userAgent;
 
+    private final String xForwardedPort;
+
     private final String xForwardedHost;
+
+    private final String xForwardedProto;
 
     /**
      * @param request
@@ -93,7 +97,9 @@ public class RequestContext {
         requestedEndpointUrl = request.getRequestURL().toString();
         webappBaseUrl = deriveWebappBaseUrl( requestedEndpointUrl, request );
         userAgent = request.getHeader( "user-agent" );
+        xForwardedPort = request.getHeader( "X-Forwarded-Port" );
         xForwardedHost = request.getHeader( "X-Forwarded-Host" );
+        xForwardedProto = request.getHeader( "X-Forwarded-Proto" );
         if ( LOG.isDebugEnabled() ) {
             LOG.debug( "Request URL: " + requestedEndpointUrl );
             LOG.debug( "Webapp base URL (derived from request): " + webappBaseUrl );
@@ -167,10 +173,24 @@ public class RequestContext {
     }
 
     /**
+     * @return the request's 'X-Forwarded-Proto' header, can be <code>null</code>
+     */
+    public String getXForwardedProto() {
+        return xForwardedProto;
+    }
+
+    /**
      * @return the request's 'X-Forwarded-Host' header, can be <code>null</code>
      */
     public String getXForwardedHost() {
         return xForwardedHost;
+    }
+
+    /**
+     * @return the request's 'X-Forwarded-Port' header, can be <code>null</code>
+     */
+    public String getXForwardedPort() {
+        return xForwardedPort;
     }
 
     @Override

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/RequestContext.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/RequestContext.java
@@ -72,6 +72,8 @@ public class RequestContext {
 
     private final String userAgent;
 
+    private final String xForwardedHost;
+
     /**
      * @param request
      *            request for which the context will be created, must not be <code>null</code>
@@ -91,6 +93,7 @@ public class RequestContext {
         requestedEndpointUrl = request.getRequestURL().toString();
         webappBaseUrl = deriveWebappBaseUrl( requestedEndpointUrl, request );
         userAgent = request.getHeader( "user-agent" );
+        xForwardedHost = request.getHeader( "X-Forwarded-Host" );
         if ( LOG.isDebugEnabled() ) {
             LOG.debug( "Request URL: " + requestedEndpointUrl );
             LOG.debug( "Webapp base URL (derived from request): " + webappBaseUrl );
@@ -161,6 +164,13 @@ public class RequestContext {
      */
     public String getUserAgent() {
         return userAgent;
+    }
+
+    /**
+     * @return the request's 'X-Forwarded-Host' header, can be <code>null</code>
+     */
+    public String getXForwardedHost() {
+        return xForwardedHost;
     }
 
     @Override

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/OGCFrontControllerTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/OGCFrontControllerTest.java
@@ -1,0 +1,168 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ Department of Geography, University of Bonn
+ and
+ lat/lon GmbH
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.services.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+import java.net.URL;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(OGCFrontController.class)
+public class OGCFrontControllerTest {
+
+    @Test
+    public void testGetHttpPostURLWithServiceUrl()
+                            throws Exception {
+        String serviceUrl = "http://myservice.de/deegree-webservices/test";
+        RequestContext mockedContext = mockContext( serviceUrl );
+
+        prepareOGCFrontController( mockedContext );
+
+        String httpPostURL = OGCFrontController.getHttpPostURL();
+
+        assertThat( httpPostURL, is( serviceUrl ) );
+    }
+
+    @Test
+    public void testGetHttpPostURLWithXForwardedHost()
+                            throws Exception {
+        String serviceUrl = "http://myservice.de/deegree-webservices/test";
+        String xForwardedHost = "xForwardedHost.de";
+        RequestContext mockedContext = mockContext( serviceUrl, xForwardedHost );
+
+        prepareOGCFrontController( mockedContext );
+
+        String httpPostURL = OGCFrontController.getHttpPostURL();
+
+        assertThat( httpPostURL, is( "http://xForwardedHost.de/deegree-webservices/test" ) );
+    }
+
+    @Test
+    public void testGetHttpPostURLWithXForwardedHostAndPortAddPort()
+                            throws Exception {
+        String serviceUrl = "http://myservice.de/deegree-webservices/test";
+        String xForwardedHost = "xForwardedHost.de";
+        String xForwardedPort = "8089";
+        RequestContext mockedContext = mockContext( serviceUrl, xForwardedHost, xForwardedPort );
+
+        prepareOGCFrontController( mockedContext );
+
+        String httpPostURL = OGCFrontController.getHttpPostURL();
+
+        assertThat( httpPostURL, is( "http://xForwardedHost.de:8089/deegree-webservices/test" ) );
+    }
+
+    @Test
+    public void testGetHttpPostURLWithXForwardedHostAndPortReplacePort()
+                            throws Exception {
+        String serviceUrl = "http://myservice.de:9090/deegree-webservices/test";
+        String xForwardedHost = "xForwardedHost.de";
+        String xForwardedPort = "8089";
+        RequestContext mockedContext = mockContext( serviceUrl, xForwardedHost, xForwardedPort );
+
+        prepareOGCFrontController( mockedContext );
+
+        String httpPostURL = OGCFrontController.getHttpPostURL();
+
+        assertThat( httpPostURL, is( "http://xForwardedHost.de:8089/deegree-webservices/test" ) );
+    }
+
+    @Test
+    public void testGetHttpPostURLWithXForwardedHostAndPortAndProtocolReplaceProto()
+                            throws Exception {
+        String serviceUrl = "http://myservice.de:9090/deegree-webservices/test";
+        String xForwardedHost = "xForwardedHost.de";
+        String xForwardedPort = "8089";
+        String xForwardedProto = "https";
+        RequestContext mockedContext = mockContext( serviceUrl, xForwardedHost, xForwardedPort, xForwardedProto );
+
+        prepareOGCFrontController( mockedContext );
+
+        String httpPostURL = OGCFrontController.getHttpPostURL();
+
+        assertThat( httpPostURL, is( "https://xForwardedHost.de:8089/deegree-webservices/test" ) );
+    }
+
+    private void prepareOGCFrontController( RequestContext mockedContext )
+                            throws Exception {
+        mockStatic( OGCFrontController.class );
+        PowerMockito.when( OGCFrontController.getHttpPostURL() ).thenCallRealMethod();
+        PowerMockito.when( OGCFrontController.class, "getHttpURL" ).thenCallRealMethod();
+        PowerMockito.when( OGCFrontController.class, "buildUrlFromForwardedHeader", eq( mockedContext ),
+                           any( URL.class ) ).thenCallRealMethod();
+        PowerMockito.when( OGCFrontController.class, "parseProtocol", anyString(), any( URL.class ) ).thenCallRealMethod();
+        PowerMockito.when( OGCFrontController.class, "parsePort", anyString(), any( URL.class ) ).thenCallRealMethod();
+        PowerMockito.when( OGCFrontController.getContext() ).thenReturn( mockedContext );
+    }
+
+    private RequestContext mockContext( String serviceUrl ) {
+        return mockContext( serviceUrl, null );
+    }
+
+    private RequestContext mockContext( String serviceUrl, String xForwardedHost ) {
+        return mockContext( serviceUrl, xForwardedHost, null );
+    }
+
+    private RequestContext mockContext( String serviceUrl, String xForwardedHost, String xForwardedPort ) {
+        return mockContext( serviceUrl, xForwardedHost, xForwardedPort, null );
+    }
+
+    private RequestContext mockContext( String serviceUrl, String xForwardedHost, String xForwardedPort,
+                                        String xForwardedProto ) {
+        RequestContext context = mock( RequestContext.class );
+        when( context.getServiceUrl() ).thenReturn( serviceUrl );
+        when( context.getXForwardedHost() ).thenReturn( xForwardedHost );
+        when( context.getXForwardedPort() ).thenReturn( xForwardedPort );
+        when( context.getXForwardedProto() ).thenReturn( xForwardedProto );
+        return context;
+    }
+}

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -1088,6 +1088,15 @@ For this example, deegree would report ``http://www.mygeoportal.com/ows`` as ser
 
 The URL configured by ``Resources`` relates to the reported URL of the ``resources`` servlet, which allows to access parts of the active deegree workspace via HTTP. Currently, this is only used in WFS DescribeFeatureType responses that access GML application schema directories.
 
+The URLs changed by this configuration option are overwritten by the URL specified by the X-Forwarded-Host, X-Forwarded-Port and X-Forwarded-Proto header values.
+For example via a request to ``http://realnameofdeegreemachine:8080/deegree-webservices/services/inspire-wfs-ad`` and the specified header values
+
+ * X-Forwarded-Host = www.mysecondgeoportal.com
+ * X-Forwarded-Port = 8088
+ * X-Forwarded-Proto = https
+
+deegree would report ``https://www.mysecondgeoportal.com:8088/deegree-webservices/services/inspire-wfs-ad``. The URL path is kept as in the request URL. Host, port and protocol are replaced by the values from the header. If X-Forwarded-Port or X-Forwarded-Proto are missing the values are taken from the request URL, deegree would report ``http://www.mysecondgeoportal.com/deegree-webservices/services/inspire-wfs-ad``. This behaviour is usefull when the deegree webservice can be requested via different URLs.
+
 ^^^^^^^^^^^^^^^^
 Request timeouts
 ^^^^^^^^^^^^^^^^

--- a/pom.xml
+++ b/pom.xml
@@ -329,13 +329,25 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.9.5</version>
+        <version>1.10.19</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>1.6.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>1.6.2</version>
         <scope>test</scope>
       </dependency>
       <!-- apache commons -->


### PR DESCRIPTION
This enhancement enables following functionality:
If an incoming request contains the header "X-Forwarded-Host", the DCP URLs in the capabilities document are replaced by the value of the header. If the header is not present, the old mechanism is used.
The enhancement allows, for example, that a deegree service which can be accessed by multiple URLs returns the correct DCP URLs if the "X-Forwarded-Host" header is set.