### PR TITLE
Fixed SQL-Statement generated for resultType="hits" where column names are not unique

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -670,6 +670,8 @@ public class SQLFeatureStore implements FeatureStore {
                 } else {
                     sql.append( "COUNT(*) FROM (SELECT DISTINCT " );
 
+                    String ftTableAlias = wb.getAliasManager().getRootTableAlias();
+                    
                     FIDMapping fidMapping = ftMapping.getFidMapping();
                     List<Pair<SQLIdentifier, BaseType>> fidCols = fidMapping.getColumns();
                     boolean first = true;
@@ -679,12 +681,11 @@ public class SQLFeatureStore implements FeatureStore {
                         } else {
                             first = false;
                         }
-                        sql.append( fidCol.first );
+                        sql.append( ftTableAlias ).append( '.' ).append( fidCol.first );
                     }
 
                     sql.append( " FROM " );
 
-                    String ftTableAlias = wb.getAliasManager().getRootTableAlias();
 
                     // pure relational query
                     sql.append( ftMapping.getFtTable() );


### PR DESCRIPTION
This bug fix allows !GetFeature-requests with resultType="hits" in a SQLFeatureStore configuration with multiple tables where two or more tables have columns with the same name.
The alias of the root table is added in the select clause, to avoid SQLExceptions.   