### PR TITLE
Removed catch (Throwable) in OracleSqlDialect to improve error handling and logging on (rework)

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
@@ -117,8 +117,7 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
         try {
             return new SDOGeometryConverter().toGeometry( (STRUCT) sqlValue, crs );
         } catch ( Throwable t ) {
-            LOG.trace( t.getMessage(), t );
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(t);
         }
     }
 
@@ -142,8 +141,7 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
                 stmt.setObject( paramIndex, struct );
             }
         } catch ( Throwable t ) {
-            t.printStackTrace();
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(t);
         }
     }
 


### PR DESCRIPTION
The caught throwable in the OracleGeometryConverter are now thrown as Stack of a new IllegalArgument Exception.
This was made to:
 * Arrive the same goal as #430 to allow a better logging including original Exception information
 * Keep the same Code workflow (throw IllegalArgumentException)