### PR TITLE
GML-Writer: Encode decimal values faithfully

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -62,7 +62,6 @@ import org.deegree.commons.tom.gml.property.Property;
 import org.deegree.commons.tom.gml.property.PropertyType;
 import org.deegree.commons.tom.ows.CodeType;
 import org.deegree.commons.tom.ows.StringOrRef;
-import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.uom.Length;
 import org.deegree.commons.uom.Measure;
@@ -318,12 +317,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
                 PrimitiveValue pValue = (PrimitiveValue) value;
                 writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
                 if ( pValue != null ) {
-                    // TODO
-                    if ( pValue.getType().getBaseType() == BaseType.DECIMAL ) {
-                        writer.writeCharacters( pValue.getValue().toString() );
-                    } else {
-                        writer.writeCharacters( pValue.getAsText() );
-                    }
+                    writer.writeCharacters( pValue.getAsText() );
                 }
                 writer.writeEndElement();
             }

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
@@ -36,7 +36,7 @@
 
 package org.deegree.gml.feature;
 
-import static junit.framework.Assert.assertEquals;
+import static org.deegree.commons.tom.primitive.BaseType.DECIMAL;
 import static org.deegree.commons.xml.CommonNamespaces.GML3_2_NS;
 import static org.deegree.filter.MatchAction.ALL;
 import static org.deegree.gml.GMLInputFactory.createGMLStreamReader;
@@ -44,6 +44,7 @@ import static org.deegree.gml.GMLOutputFactory.createGMLStreamWriter;
 import static org.deegree.gml.GMLVersion.GML_2;
 import static org.deegree.gml.GMLVersion.GML_31;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -54,6 +55,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -61,6 +63,10 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.axiom.om.OMElement;
 import org.deegree.commons.tom.ReferenceResolvingException;
+import org.deegree.commons.tom.TypedObjectNode;
+import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.commons.tom.gml.property.PropertyType;
+import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.xml.NamespaceBindings;
 import org.deegree.commons.xml.XMLAdapter;
@@ -72,7 +78,9 @@ import org.deegree.cs.exceptions.TransformationException;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.feature.Feature;
 import org.deegree.feature.FeatureCollection;
+import org.deegree.feature.property.GenericProperty;
 import org.deegree.feature.types.AppSchema;
+import org.deegree.feature.types.property.SimplePropertyType;
 import org.deegree.filter.Filter;
 import org.deegree.filter.OperatorFilter;
 import org.deegree.filter.comparison.PropertyIsEqualTo;
@@ -387,4 +395,25 @@ public class GMLFeatureWriterTest {
         assertTrue( memoryWriter.toString().contains( "rsts206" ) );
         assertFalse( memoryWriter.toString().contains( "rsts207" ) );
     }
+    
+    @Test
+    public void testDecimalPropertyEncodedFaithfully()
+                            throws XMLStreamException, UnknownCRSException, TransformationException {
+        final String formattedInputValue = "0.00000009";
+        final XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
+        outputFactory.setProperty( "javax.xml.stream.isRepairingNamespaces", new Boolean( true ) );
+        final XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
+        final XMLStreamWriter writer = memoryWriter.getXMLStreamWriter();
+        final GMLStreamWriter exporter = createGMLStreamWriter( GML_2, writer );
+        final GMLFeatureWriter featureWriter = exporter.getFeatureWriter();
+        final PropertyType decimalPt = new SimplePropertyType( new QName( "property" ), 1, 1, DECIMAL, null, null );
+        final PrimitiveType pt = new PrimitiveType( DECIMAL );
+        final TypedObjectNode value = new PrimitiveValue( formattedInputValue, pt );
+        final Property prop = new GenericProperty( decimalPt, value );
+        featureWriter.export( prop );
+        writer.flush();
+        writer.close();
+        assertEquals( "<property>0.00000009</property>\n", memoryWriter.toString() );
+    }
+
 }


### PR DESCRIPTION
The GML subsystem tries to preserve original text representations whenever possible, e.g. if a numeric value of "0.10" is read, it should be exported as "0.10" and not as "0.1". I removed a forced reencoding via toString() for the case of decimal values. It had the effect that an xs:decimal value of "0.00000009" was re-encoded as "9E-8". This is not only a violation of the faithful encoding principle, but also invalid according to schema type xs:decimal.

Test case included.