### PR TITLE
WFS: Evaluate CRS in BBOX parameter for version 2.0.0 KVP-queries

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/OWSCommonKVPAdapter.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/OWSCommonKVPAdapter.java
@@ -35,6 +35,9 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.protocol.ows;
 
+import static java.lang.Double.parseDouble;
+import static org.deegree.cs.persistence.CRSManager.getCRSRef;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,19 +66,26 @@ public class OWSCommonKVPAdapter {
      *            crs to use when not explicitly encoded, may be <code>null</code>
      * @return decoded {@link Envelope}, never <code>null</code>
      */
-    public static Envelope parseBBox( String bboxStr, ICRS defaultCrs ) {
-
-        String[] coordList = bboxStr.split( "," );
-
-        int n = coordList.length / 2;
-        List<Double> lowerCorner = new ArrayList<Double>( n );
+    public static Envelope parseBBox( final String bboxStr, final ICRS defaultCrs ) {
+        final String[] tokens = bboxStr.split( "," );
+        final int n = tokens.length / 2;
+        final List<Double> lowerCorner = new ArrayList<Double>( n );
         for ( int i = 0; i < n; i++ ) {
-            lowerCorner.add( Double.parseDouble( coordList[i] ) );
+            lowerCorner.add( parseDouble( tokens[i] ) );
         }
-        List<Double> upperCorner = new ArrayList<Double>( n );
+        final List<Double> upperCorner = new ArrayList<Double>( n );
         for ( int i = n; i < 2 * n; i++ ) {
-            upperCorner.add( Double.parseDouble( coordList[i] ) );
+            upperCorner.add( parseDouble( tokens[i] ) );
         }
-        return geomFac.createEnvelope( lowerCorner, upperCorner, defaultCrs );
+        final ICRS bboxCrs = getEncodedCrs( tokens );
+        final ICRS crs = bboxCrs != null ? bboxCrs : defaultCrs;
+        return geomFac.createEnvelope( lowerCorner, upperCorner, crs );
+    }
+
+    private static ICRS getEncodedCrs( final String[] tokens ) {
+        if ( tokens.length % 2 == 1 ) {
+            return getCRSRef( tokens[tokens.length - 1] );
+        }
+        return null;
     }
 }

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/getfeature/kvp/GetFeatureKVPAdapterTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/getfeature/kvp/GetFeatureKVPAdapterTest.java
@@ -46,6 +46,7 @@ import javax.xml.namespace.QName;
 import junit.framework.TestCase;
 
 import org.deegree.commons.utils.kvp.KVPUtils;
+import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.filter.Filter;
 import org.deegree.filter.Operator;
@@ -987,6 +988,15 @@ public class GetFeatureKVPAdapterTest extends TestCase {
     public void test200Example17()
                             throws Exception {
         GetFeature request = parse( "wfs200/example17.kvp" );
+    }
+
+    @Test
+    public void test200ExampleBboxExplicitCrs()
+                            throws Exception {
+        final GetFeature request = parse( "wfs200/example_bbox_explicit_crs.kvp" );
+        final BBoxQuery query = (BBoxQuery) request.getQueries().get( 0 );
+        final ICRS crs = query.getBBox().getCoordinateSystem();
+        assertEquals( "EPSG:4326", crs.getAlias() );
     }
 
     private GetFeature parse( String resource )

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/resources/org/deegree/protocol/wfs/getfeature/kvp/wfs200/example_bbox_explicit_crs.kvp
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/resources/org/deegree/protocol/wfs/getfeature/kvp/wfs200/example_bbox_explicit_crs.kvp
@@ -1,0 +1,6 @@
+service=WFS
+version=2.0.0
+request=GetFeature
+typeNames=DominantVegetation
+bbox=-180,-90,180,90,EPSG:4326
+resultType=hits


### PR DESCRIPTION
Fixes #539.

Prior to this patch, the WFS would ignore the CRS information in KVP-encoded 2.0.0 BBOX-queries, always assuming the configured default CRS.

Example: The following request would not return the number of expected features (1248), but zero:

http://demo.deegree.org/utah-workspace/services?service=WFS&version=2.0.0&request=GetFeature&typeNames=DominantVegetation&bbox=-180,-90,180,90,EPSG:4326&resultType=hits

After this patch, the WFS respects the CRS information in the BBOX parameter and the example request returns 1248 (all features, as BBOX covers the earth).

Unit-Test included.
