### PR TITLE
WFS: Omit already exported features in additional objects section

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/AbstractGmlRequestHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/AbstractGmlRequestHandler.java
@@ -159,7 +159,7 @@ abstract class AbstractGmlRequestHandler {
             Map<GMLReference<?>, GmlXlinkOptions> refToResolveState = additionalObjects.getResolveStates();
             additionalObjects.clear();
             for ( GMLReference<?> ref : nextLevelObjects ) {
-                if ( isResolvable( ref ) ) {
+                if ( isResolvable( ref ) && !isObjectAlreadySerialized( gmlStream, ref.getId() ) ) {
                     GmlXlinkOptions resolveState = refToResolveState.get( ref );
                     Feature feature = (Feature) ref;
                     if ( !wroteStartSection ) {
@@ -174,6 +174,10 @@ abstract class AbstractGmlRequestHandler {
         if ( wroteStartSection ) {
             writeAdditionalObjectsEnd( xmlStream, requestVersion );
         }
+    }
+
+    private boolean isObjectAlreadySerialized( final GMLStreamWriter gmlStream, final String id ) {
+        return gmlStream.getReferenceResolveStrategy().isObjectExported( id );
     }
 
     private void writeAdditionalObjectsStart( XMLStreamWriter xmlStream, Version requestVersion )


### PR DESCRIPTION
Prior to this patch, it was possible that circular references caused the AdditionalObjects section of a WFS 2.0.0 response to contain wfs:member elements with xlinked content, e.g.

```
<wfs:FeatureCollection...>
...
  <wfs:additionalObjects>
    ...
    <wfs:member xlink:href="#uuid.bedfbe9d-cb04-4915-9e72-3f09b2940e7b" />
   ...
  </wfs:additionalObjects>
<wfs:FeatureCollection/>
```
This is not schema-valid and also doesn't make sense: The additionalObjects section is supposed to contain "real" features, not references.