### PR TITLE
Fixes bug in ConnectionProviderManager: Removed deregistration of drivers from DriverManager

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/DriverWrapper.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/DriverWrapper.java
@@ -94,6 +94,11 @@ public class DriverWrapper implements Driver {
         return d.jdbcCompliant();
     }
 
+    @Override
+    public String toString() {
+        return "Wrapped: " + d.toString();
+    }
+
     public Logger getParentLogger()
                             throws SQLFeatureNotSupportedException {
         Logger logger = null;

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/DriverWrapper.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/DriverWrapper.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
  */
 public class DriverWrapper implements Driver {
 
-    private Driver d;
+    private final Driver d;
 
     public DriverWrapper( Driver d ) {
         this.d = d;
@@ -97,6 +97,10 @@ public class DriverWrapper implements Driver {
     @Override
     public String toString() {
         return "Wrapped: " + d.toString();
+    }
+
+    public Driver getWrappedDriver() {
+        return d;
     }
 
     public Logger getParentLogger()

--- a/deegree-core/deegree-core-db/src/main/java/org/deegree/db/ConnectionProviderManager.java
+++ b/deegree-core/deegree-core-db/src/main/java/org/deegree/db/ConnectionProviderManager.java
@@ -107,6 +107,7 @@ public class ConnectionProviderManager extends DefaultResourceManager<Connection
         while ( enumer.hasMoreElements() ) {
             Driver d = enumer.nextElement();
             try {
+                LOG.info( "Try to deregister driver " + d );
                 deregisterDriver( d );
             } catch ( SQLException e ) {
                 LOG.debug( "Unable to deregister driver: {}", e.getLocalizedMessage() );
@@ -124,13 +125,17 @@ public class ConnectionProviderManager extends DefaultResourceManager<Connection
             ListIterator<?> iter = list.listIterator();
             while ( iter.hasNext() ) {
                 Object o = iter.next();
+                LOG.debug( "Candidate to deregister: Driver " + o + " with classloader "
+                           + o.getClass().getClassLoader() );
                 if ( o.getClass().getClassLoader() == workspace.getModuleClassLoader()
                      || o.getClass().getClassLoader() == null ) {
+                    LOG.debug( "   ... will be removed" + o );
                     // iter.remove not supported by used list
                     toRemove.add( o );
                 }
             }
             for ( Object o : toRemove ) {
+                LOG.info( "Deregister driver " + o );
                 list.remove( o );
             }
         } catch ( Exception ex ) {


### PR DESCRIPTION
In the scenario described as follows an SQLException occurs. Two deegree-webservice instances with jdbc connection(A and B) are running in one tomcat. A is undeployed or stopped via tomcat manager, B is requested where the processing of the requests requires a database connection.

Exception:
```
org.springframework.transaction.CannotCreateTransactionException: 
Could not open JDBC Connection for transaction; 
nested exception is java.sql.SQLException: No suitable driver found for ....
 ```
The fix removes the part of the shutdown method in the ConnectionProviderManager where all drivers are registered from java.sql.DriverManager via reflections. As far as I understand this should remove all drivers loaded with the module classloader of the workspace. But the field  *registeredDrivers* of the java.sql.DriverManager contains instances of DriverInfo (an inner class of the DriverManager). The check if the classloader is same as the module classloader comes never true, but the null check does (as drivers are loaded in bootstrap class loader, which can be represented by null). This leads to the removing of **all** drivers overall deegree-webservices instances.