### PR TITLE
Improve tilestore-merge to paint canvas background in white

### DIFF
--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/java/org/deegree/tile/persistence/merge/MergingTile.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/java/org/deegree/tile/persistence/merge/MergingTile.java
@@ -109,8 +109,13 @@ class MergingTile implements Tile {
         try {
             BufferedImage img = getAsImage();
             if ( img.getTransparency() != BufferedImage.OPAQUE ) {
-                BufferedImage noTransparency = new BufferedImage( img.getWidth(), img.getHeight(), TYPE_3BYTE_BGR );
+                final int width = img.getWidth();
+                final int height = img.getHeight();
+                
+                BufferedImage noTransparency = new BufferedImage( width, height, TYPE_3BYTE_BGR );
                 Graphics g = noTransparency.getGraphics();
+                g.setColor( Color.WHITE );
+                g.fillRect( 0, 0, width, height );
                 g.drawImage( img, 0, 0, null );
                 img = noTransparency;
             }


### PR DESCRIPTION
When the 'upstream' tilestores are providing tiles with an alpha layer we have to remove this alpha layer before we create a jpeg file from the merged buffered image. Currently the case where we have no color data for certain pixels (= all tilestores provide a fully transparent pixel) is not explicitly handled resulting in unexpected black pixels. This pull requests suggests to explicitly paint the canvas white and subsequently paint the merged tile on top of that.