### PR TITLE
Fix NPE in GML feature writer

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -737,7 +737,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             ObjectPropertyType gmlPropertyDecl = schemaInfoset.getGMLPropertyDecl( elDecl, elName, 0, 1, null );
             if ( gmlPropertyDecl instanceof FeaturePropertyType ) {
                 List<TypedObjectNode> children = xmlContent.getChildren();
-                if ( children.size() == 1 && children.get( 0 ) instanceof Feature ) {
+                if ( children != null && children.size() == 1 && children.get( 0 ) instanceof Feature ) {
                     LOG.debug( "Exporting as nested feature property." );
                     exportFeatureProperty( (FeaturePropertyType) gmlPropertyDecl, (Feature) children.get( 0 ),
                                            resolveState );


### PR DESCRIPTION
GMLFeatureWriter: sometimes in our test the children of the ElementNode was null throwing a NullPointerException. Thus, we added a guard to it.

Please note that the integration tests are already broken on the deegree:master.