### PR TITLE
Fixes inconsistencies between styles in Capabilities and GetLegendGraphic response

### DIFF
--- a/deegree-core/deegree-core-layer/pom.xml
+++ b/deegree-core/deegree-core-layer/pom.xml
@@ -64,7 +64,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>    
+    </dependency>  
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>          
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr-runtime</artifactId>

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -68,9 +68,12 @@ import org.slf4j.Logger;
  * 
  * @version $Revision: $, $Date: $
  */
-public class ConfigUtils {
+public final class ConfigUtils {
 
     private static final Logger LOG = getLogger( ConfigUtils.class );
+
+    private ConfigUtils() {
+    }
 
     public static Pair<Map<String, Style>, Map<String, Style>> parseStyles( DeegreeWorkspace workspace,
                                                                             String layerName, List<StyleRefType> styles ) {
@@ -135,43 +138,43 @@ public class ConfigUtils {
             if ( isDefault && !styleMap.containsKey( "default" ) ) {
                 styleMap.put( "default", st );
             }
-            if ( s.getLegendGraphic() != null ) {
-                LegendGraphic g = s.getLegendGraphic();
+            if ( hasLegendGraphic( s ) || hasLegendStyle( s ) ) {
+                if ( hasLegendGraphic( s ) ) {
+                    LegendGraphic g = s.getLegendGraphic();
 
-                URL url = null;
-                try {
-                    url = new URL( g.getValue() );
-                    if ( url.toURI().isAbsolute() ) {
-                        st.setLegendURL( url );
+                    URL url = null;
+                    try {
+                        url = new URL( g.getValue() );
+                        if ( url.toURI().isAbsolute() ) {
+                            st.setLegendURL( url );
+                        }
+                        st.setPrefersGetLegendGraphicUrl( g.isOutputGetLegendGraphicUrl() );
+                    } catch ( Exception e ) {
+                        LOG.debug( "LegendGraphic was not an absolute URL." );
+                        LOG.trace( "Stack trace:", e );
                     }
-                    st.setPrefersGetLegendGraphicUrl( g.isOutputGetLegendGraphicUrl() );
-                } catch ( Exception e ) {
-                    LOG.debug( "LegendGraphic was not an absolute URL." );
-                    LOG.trace( "Stack trace:", e );
-                }
 
-                if ( url == null ) {
-                    File file = workspace.getLocation();
-                    file = new File( file, "styles" );
-                    file = new File( file, id + ".xml" );
-                    file = new File( file.toURI().resolve( g.getValue() ) );
-                    if ( file.exists() ) {
-                        st.setLegendFile( file );
-                    } else {
-                        LOG.warn( "LegendGraphic {} could not be resolved to a legend.", g.getValue() );
+                    if ( url == null ) {
+                        File file = workspace.getLocation();
+                        file = new File( file, "styles" );
+                        file = new File( file, id + ".xml" );
+                        file = new File( file.toURI().resolve( g.getValue() ) );
+                        if ( file.exists() ) {
+                            st.setLegendFile( file );
+                        } else {
+                            LOG.warn( "LegendGraphic {} could not be resolved to a legend.", g.getValue() );
+                        }
                     }
-                }
-            } else {
-                LegendStyle ls = s.getLegendStyle();
-                if ( ls != null ) {
+                } else if ( hasLegendStyle( s ) ) {
+                    LegendStyle ls = s.getLegendStyle();
                     st = store.getStyle( ls.getLayerNameRef(), ls.getStyleNameRef() );
                     st = st.copy();
                     st.setName( name );
                 }
-            }
-            legendStyleMap.put( name, st );
-            if ( defaultLegendStyle == null ) {
-                defaultLegendStyle = st;
+                legendStyleMap.put( name, st );
+                if ( defaultLegendStyle == null ) {
+                    defaultLegendStyle = st;
+                }
             }
         }
         return new Pair<Style, Style>( defaultStyle, defaultLegendStyle );
@@ -237,6 +240,14 @@ public class ConfigUtils {
 
     public static Map<String, Dimension<?>> parseDimensions( String layerName, List<DimensionType> dimensions ) {
         return DimensionConfigBuilder.parseDimensions( layerName, dimensions );
+    }
+
+    private static boolean hasLegendGraphic( org.deegree.layer.persistence.base.jaxb.StyleRefType.Style s ) {
+        return s.getLegendGraphic() != null;
+    }
+
+    private static boolean hasLegendStyle( org.deegree.layer.persistence.base.jaxb.StyleRefType.Style s ) {
+        return s.getLegendStyle() != null;
     }
 
 }

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -168,10 +168,10 @@ public class ConfigUtils {
                     st = st.copy();
                     st.setName( name );
                 }
-                legendStyleMap.put( name, st );
-                if ( defaultLegendStyle == null ) {
-                    defaultLegendStyle = st;
-                }
+            }
+            legendStyleMap.put( name, st );
+            if ( defaultLegendStyle == null ) {
+                defaultLegendStyle = st;
             }
         }
         return new Pair<Style, Style>( defaultStyle, defaultLegendStyle );

--- a/deegree-core/deegree-core-layer/src/test/java/org/deegree/layer/config/ConfigUtilsTest.java
+++ b/deegree-core/deegree-core-layer/src/test/java/org/deegree/layer/config/ConfigUtilsTest.java
@@ -1,0 +1,201 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.layer.config;
+
+import static java.util.Collections.singletonList;
+import static org.deegree.layer.config.ConfigUtils.parseStyles;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.stream.StreamSource;
+
+import org.deegree.commons.config.DeegreeWorkspace;
+import org.deegree.commons.utils.Pair;
+import org.deegree.layer.persistence.base.jaxb.StyleRefType;
+import org.deegree.style.persistence.StyleStore;
+import org.deegree.style.persistence.StyleStoreManager;
+import org.deegree.style.se.unevaluated.Style;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ * @author last edited by: $Author: lyn $
+ * 
+ * @version $Revision: $, $Date: $
+ */
+public class ConfigUtilsTest {
+
+    @Test
+    public void testParseStyles_EqualDefaultAndSimple()
+                            throws Exception {
+        StyleStore store = mockStyleStoreWithThreeStyles_EqualDefaultAndSimple();
+        DeegreeWorkspace workspace = mockWorkspace( store );
+
+        List<StyleRefType> styles = singletonList( readStyleRef( "styleRefs_EqualDefaultAndSimple.xml" ) );
+
+        Pair<Map<String, Style>, Map<String, Style>> selectedStyles = parseStyles( workspace, "layer", styles );
+
+        Map<String, Style> styleMap = selectedStyles.getFirst();
+        Map<String, Style> legendStyleMap = selectedStyles.getSecond();
+
+        assertThat( styleMap.size(), is( 3 ) );
+        assertThat( legendStyleMap.size(), is( 3 ) );
+
+        Style defaultLegendStyle = legendStyleMap.get( "default" );
+        assertThat( defaultLegendStyle.getName(), is( "default" ) );
+        assertThat( defaultLegendStyle.getLegendURL(), is( new URL( "http://test.de/legende.png" ) ) );
+    }
+
+    @Test
+    public void testParseStyles_DifferentDefaultAndSimple()
+                            throws Exception {
+        StyleStore store = mockStyleStoreWithThreeStyles_DifferentDefaultAndSimple();
+        DeegreeWorkspace workspace = mockWorkspace( store );
+
+        List<StyleRefType> styles = singletonList( readStyleRef( "styleRefs_DifferentDefaultAndSimple.xml" ) );
+
+        Pair<Map<String, Style>, Map<String, Style>> selectedStyles = parseStyles( workspace, "layer", styles );
+
+        Map<String, Style> styleMap = selectedStyles.getFirst();
+        Map<String, Style> legendStyleMap = selectedStyles.getSecond();
+
+        assertThat( styleMap.size(), is( 3 ) );
+        assertThat( legendStyleMap.size(), is( 3 ) );
+
+        Style defaultLegendStyle = legendStyleMap.get( "default" );
+        assertThat( defaultLegendStyle.getName(), is( "default" ) );
+        assertThat( defaultLegendStyle.getLegendURL(), is( new URL( "http://test.de/legende2.png" ) ) );
+    }
+
+    @Test
+    public void testParseStyles_OnlyOneWithLegendStyle()
+                            throws Exception {
+        StyleStore store = mockStyleStoreWithThreeStyles_DifferentDefaultAndSimple();
+        DeegreeWorkspace workspace = mockWorkspace( store );
+
+        List<StyleRefType> styles = singletonList( readStyleRef( "styleRefs_OnlyOneWithLegendStyle.xml" ) );
+
+        Pair<Map<String, Style>, Map<String, Style>> selectedStyles = parseStyles( workspace, "layer", styles );
+
+        Map<String, Style> styleMap = selectedStyles.getFirst();
+        Map<String, Style> legendStyleMap = selectedStyles.getSecond();
+
+        assertThat( styleMap.size(), is( 3 ) );
+        assertThat( legendStyleMap.size(), is( 2 ) );
+
+        Style defaultLegendStyle = legendStyleMap.get( "default" );
+        assertThat( defaultLegendStyle.getName(), is( "legendStyle" ) );
+        assertThat( defaultLegendStyle.getLegendURL(), nullValue() );
+    }
+
+    @Test
+    public void testParseStyless_DefaultWithoutLegendStyle()
+                            throws Exception {
+        StyleStore store = mockStyleStoreWithThreeStyles_DifferentDefaultAndSimple();
+        DeegreeWorkspace workspace = mockWorkspace( store );
+
+        List<StyleRefType> styles = singletonList( readStyleRef( "styleRefs_DefaultWithoutLegendStyle.xml" ) );
+
+        Pair<Map<String, Style>, Map<String, Style>> selectedStyles = parseStyles( workspace, "layer", styles );
+
+        Map<String, Style> styleMap = selectedStyles.getFirst();
+        Map<String, Style> legendStyleMap = selectedStyles.getSecond();
+
+        assertThat( styleMap.size(), is( 3 ) );
+        assertThat( legendStyleMap.size(), is( 3 ) );
+
+        Style defaultLegendStyle = legendStyleMap.get( "default" );
+        assertThat( defaultLegendStyle.getName(), is( "simpleStyle" ) );
+        assertThat( defaultLegendStyle.getLegendURL(), is( new URL( "http://test.de/legende.png" ) ) );
+    }
+
+    private StyleStore mockStyleStoreWithThreeStyles_EqualDefaultAndSimple() {
+        StyleStore mockedStyleStore = mock( StyleStore.class );
+        addStyle( mockedStyleStore, "simpleStyle", "layer", "simpleStyle" );
+        addStyle( mockedStyleStore, "default", "layer", "simpleStyle" );
+        addStyle( mockedStyleStore, "legendStyle", "layer", "legende" );
+        return mockedStyleStore;
+    }
+
+    private StyleStore mockStyleStoreWithThreeStyles_DifferentDefaultAndSimple() {
+        StyleStore mockedStyleStore = mock( StyleStore.class );
+        addStyle( mockedStyleStore, "simpleStyle", "layer", "simpleStyle1" );
+        addStyle( mockedStyleStore, "default", "layer", "simpleStyle2" );
+        addStyle( mockedStyleStore, "legendStyle", "layer", "legende" );
+        return mockedStyleStore;
+    }
+
+    private void addStyle( StyleStore mockedStyleStore, String styleName, String layerNameRef, String styleNameRef ) {
+        Style simpleStyle = mockStyle( styleName );
+        when( mockedStyleStore.getStyle( layerNameRef, styleNameRef ) ).thenReturn( simpleStyle );
+    }
+
+    private Style mockStyle( String styleName ) {
+        Style style = new Style();
+        Style spiedStyle = spy( style );
+        when( spiedStyle.getName() ).thenReturn( styleName );
+        return spiedStyle;
+    }
+
+    private StyleRefType readStyleRef( String name )
+                            throws JAXBException {
+        JAXBContext jaxbContext = JAXBContext.newInstance( StyleRefType.class );
+        Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+        InputStream resourceAsStream = ConfigUtilsTest.class.getResourceAsStream( name );
+        return (StyleRefType) unmarshaller.unmarshal( new StreamSource( resourceAsStream ), StyleRefType.class ).getValue();
+    }
+
+    private DeegreeWorkspace mockWorkspace( StyleStore store ) {
+        DeegreeWorkspace mockedWorkspace = mock( DeegreeWorkspace.class );
+        StyleStoreManager mockedStyleStoreManager = mock( StyleStoreManager.class );
+        when( mockedStyleStoreManager.get( "sldStoreId" ) ).thenReturn( store );
+        when( mockedWorkspace.getSubsystemManager( StyleStoreManager.class ) ).thenReturn( mockedStyleStoreManager );
+        return mockedWorkspace;
+    }
+    
+}

--- a/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_DefaultWithoutLegendStyle.xml
+++ b/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_DefaultWithoutLegendStyle.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<StyleRef xmlns="http://www.deegree.org/layers/base">
+  <StyleStoreId>sldStoreId</StyleStoreId>
+  <Style>
+    <StyleName>simpleStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle1</StyleNameRef>
+    <LegendGraphic outputGetLegendGraphicUrl="false">http://test.de/legende.png</LegendGraphic>
+  </Style>
+  <Style>
+    <StyleName>default</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle2</StyleNameRef>
+  </Style>
+  <Style>
+    <StyleName>legendStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>legende</StyleNameRef>
+    <LegendStyle>
+      <LayerNameRef>layer</LayerNameRef>
+      <StyleNameRef>legende</StyleNameRef>
+    </LegendStyle>
+  </Style>
+</StyleRef>

--- a/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_DifferentDefaultAndSimple.xml
+++ b/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_DifferentDefaultAndSimple.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<StyleRef xmlns="http://www.deegree.org/layers/base">
+  <StyleStoreId>sldStoreId</StyleStoreId>
+  <Style>
+    <StyleName>simpleStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle1</StyleNameRef>
+    <LegendGraphic outputGetLegendGraphicUrl="false">http://test.de/legende1.png</LegendGraphic>
+  </Style>
+  <Style>
+    <StyleName>default</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle2</StyleNameRef>
+    <LegendGraphic outputGetLegendGraphicUrl="false">http://test.de/legende2.png</LegendGraphic>
+  </Style>
+  <Style>
+    <StyleName>legendStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>legende</StyleNameRef>
+    <LegendStyle>
+      <LayerNameRef>layer</LayerNameRef>
+      <StyleNameRef>legende</StyleNameRef>
+    </LegendStyle>
+  </Style>
+</StyleRef>

--- a/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_EqualDefaultAndSimple.xml
+++ b/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_EqualDefaultAndSimple.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<StyleRef xmlns="http://www.deegree.org/layers/base">
+  <StyleStoreId>sldStoreId</StyleStoreId>
+  <Style>
+    <StyleName>simpleStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle</StyleNameRef>
+    <LegendGraphic outputGetLegendGraphicUrl="false">http://test.de/legende.png</LegendGraphic>
+  </Style>
+  <Style>
+    <StyleName>default</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle</StyleNameRef>
+    <LegendGraphic outputGetLegendGraphicUrl="false">http://test.de/legende.png</LegendGraphic>
+  </Style>
+  <Style>
+    <StyleName>legendStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>legende</StyleNameRef>
+    <LegendStyle>
+      <LayerNameRef>layer</LayerNameRef>
+      <StyleNameRef>legende</StyleNameRef>
+    </LegendStyle>
+  </Style>
+</StyleRef>

--- a/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_OnlyOneWithLegendStyle.xml
+++ b/deegree-core/deegree-core-layer/src/test/resources/org/deegree/layer/config/styleRefs_OnlyOneWithLegendStyle.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<StyleRef xmlns="http://www.deegree.org/layers/base">
+  <StyleStoreId>sldStoreId</StyleStoreId>
+  <Style>
+    <StyleName>simpleStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle1</StyleNameRef>
+  </Style>
+  <Style>
+    <StyleName>default</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>simpleStyle2</StyleNameRef>
+  </Style>
+  <Style>
+    <StyleName>legendStyle</StyleName>
+    <LayerNameRef>layer</LayerNameRef>
+    <StyleNameRef>legende</StyleNameRef>
+    <LegendStyle>
+      <LayerNameRef>layer</LayerNameRef>
+      <StyleNameRef>legende</StyleNameRef>
+    </LegendStyle>
+  </Style>
+</StyleRef>


### PR DESCRIPTION
Following scenario explains the inconsistency between Capabilities and GetLegendGraphic response:

Styles section of Capabilities:
```xml
<Style>
  <Name>style</Name>
  <Title>style</Title>
  <LegendURL width="150" height="234">
    <Format>image/png</Format>
    <OnlineResource xlink:type="simple" xlink:href="style.png"/>
  </LegendURL>
</Style>
<Style>
  <Name>default</Name>
  <Title>default</Title>
  <LegendURL width="204" height="189">
    <Format>image/png</Format>
    <OnlineResource xlink:type="simple" xlink:href="style.png"/>
  </LegendURL>
</Style>
<Style>
  <Name>legend_style</Name>
  <Title>legend_style</Title>
  <LegendURL width="204" height="189">
    <Format>image/png</Format>
    <OnlineResource xlink:type="simple" xlink:href="http://localhost:8080/services/wms?request=GetLegendGraphic&amp;version=1.3.0&amp;service=WMS&amp;layer=test&amp;style=legend_style&amp;format=image/png"/>
  </LegendURL>
</Style>
```

Following requests are sent (just the style parameter differs):
[1] ​http://localhost:8080/services?request=GetLegendGraphic&version=1.1.1&service=WMS&format=image/png&layer=test&style=style
[2] ​http://localhost:8080/services?request=GetLegendGraphic&version=1.1.1&service=WMS&format=image/png&layer=test&style=default
[3] ​http://localhost:8080/services?request=GetLegendGraphic&version=1.1.1&service=WMS&format=image/png&layer=test&style=legend_style
[4] ​http://localhost:8080/services?request=GetLegendGraphic&version=1.1.1&service=WMS&format=image/png&layer=test&styles=

[1] returns style.png and [2], [3] and [4] a generated legend (http://localhost:8080/services/wms?request=GetLegendGraphic&amp;version=1.3.0&amp;service=WMS&amp;layer=test&amp;style=legend_style&amp;format=image/png).

The responses [1] and [3] return the expected style. Response [2] and [4] should return the style.png but they answer with a generated legend.

This behaviour is a result of the fact that in the code there exist a styleMap and a legendStyleMap. The styleMap contains all configured styles and is used for the generation of the Capabilities. On the other hand, the legendStyleMap just contains styles which contain a configured LegendStyle (styles with a LegendGraphic are not considered). This can also cause that the default style of the Capabilities is not added to the legendStyleMap.
When GetLegendGraphic is requested the legendStyleMap is used first and if no style is found the styleMap is used. So, if the default or no style is requested, the first style of the legendStyleMap is used. This is inconsistent to the capabilities document.

This fix adds all styles to the legendStyleMap to ensure consistency to the styles section of the Capabilities document.