### PR TITLE
Fixed bug in escaping of single quotes in PropertyIsLike filter

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/islike/PlainText.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/islike/PlainText.java
@@ -95,9 +95,13 @@ final class PlainText implements IsLikeStringPart {
             case '%':
             case '_':
             case '"':
-            case '\'':
             case '\\': {
                 sqlEscaped.append( '\\' );
+                sqlEscaped.append( currentChar );
+                break;
+            }
+            case '\'': {
+                sqlEscaped.append( '\'' );
                 sqlEscaped.append( currentChar );
                 break;
             }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/IsLikeStringTest.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/IsLikeStringTest.java
@@ -113,4 +113,17 @@ public class IsLikeStringTest extends TestCase {
         String output = specialString.toSQL();
         assertEquals( "_Paul\\_Sartre_", output );
     }
+
+    @Test
+    public void testLiteral7()
+                            throws Exception {
+        String wildCard = "%";
+        String singleChar = "*";
+        String escape = "_";
+        String inputString = "Sartre's";
+        IsLikeString specialString = new IsLikeString( inputString, wildCard, singleChar, escape );
+        String output = specialString.toSQL();
+        assertEquals( "Sartre''s", output );
+    }
+    
 }


### PR DESCRIPTION
When a PropertyIsLike filter is used in a GetFeature request, an exception is thrown if the Literal contains a single quote (').
This error results from a wrong escaping of this character: A backslash (\) is used instead of an additional single quote ('). Since postgres 9.1, in an oracle db and mysql quotes are always escaped by another quote.
This fix changes the escaping of single quotes to an additional single quote.

Example request body for testing:
```xml
<GetFeature xmlns="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gmd="http://www.isotc211.org/2005/gmd"
  xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml" xmlns:test="http://www.test.de/test"
  xmlns:iso19112="http://www.opengis.net/iso19112" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
  xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd" traverseXlinkDepth="*">
  <Query typeName="test:test">
    <ogc:Filter>
      <ogc:PropertyIsLike wildCard="*" singleChar="#" escapeChar="!">
        <ogc:PropertyName>test:test</ogc:PropertyName>
        <ogc:Literal>tes't</ogc:Literal>
      </ogc:PropertyIsLike>
    </ogc:Filter>
  </Query>
</GetFeature> 
```