### PR TITLE
correctly merge envelopes of multiple gdal files

### DIFF
--- a/deegree-layers/deegree-layers-gdal/src/main/java/org/deegree/layer/persistence/gdal/GdalLayerStoreBuilder.java
+++ b/deegree-layers/deegree-layers-gdal/src/main/java/org/deegree/layer/persistence/gdal/GdalLayerStoreBuilder.java
@@ -130,7 +130,7 @@ class GdalLayerStoreBuilder implements ResourceBuilder<LayerStore> {
                     if ( env == null ) {
                         env = gdalSettings.getDatasetPool().getEnvelope( file );
                     } else {
-                        env.merge( gdalSettings.getDatasetPool().getEnvelope( file ) );
+                        env = env.merge( gdalSettings.getDatasetPool().getEnvelope( file ) );
                     }
                 }
             } catch ( Exception e ) {


### PR DESCRIPTION
When multiple GDAL files are configured to be used as single GDAL layer a new envelope enclosing all  those files is supposed to be calculated. This calculation was not implemented correctly resulting in an incorrect layer envelope.

