### PR TITLE
Added new WFS 1.1.0 endpoint to utah demo passing all CITE WFS 1.1.0 basic profile tests

### DIFF
--- a/deegree-workspaces/deegree-workspace-utah/src/main/workspace/services/wfs110.xml
+++ b/deegree-workspaces/deegree-workspace-utah/src/main/workspace/services/wfs110.xml
@@ -1,0 +1,25 @@
+<deegreeWFS configVersion="3.1.0" xmlns="http://www.deegree.org/services/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.deegree.org/services/wfs http://schemas.deegree.org/services/wfs/3.1.0/wfs_configuration.xsd">
+  <SupportedVersions>
+    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
+  </SupportedVersions>
+  <!-- [0..n] FeatureStoreId: If ommited all featurestores will be published as feature types  -->
+  <!--  
+  <FeatureStoreId>MyStore1</FeatureStoreId>
+  <FeatureStoreId>MyStore2</FeatureStoreId>
+   -->
+  <EnableTransactions>false</EnableTransactions>
+  <QueryCRS>EPSG:26912</QueryCRS>
+  <QueryCRS>EPSG:4326</QueryCRS>
+  <QueryMaxFeatures>-1</QueryMaxFeatures>
+  
+  <GMLFormat gmlVersion="GML_31">
+    <MimeType>text/xml; subtype=gml/3.1.1</MimeType>
+    <GenerateBoundedByForFeatures>true</GenerateBoundedByForFeatures>
+    <GetFeatureResponse>
+      <DisableStreaming>true</DisableStreaming>
+    </GetFeatureResponse>
+  </GMLFormat>
+  
+</deegreeWFS>

--- a/deegree-workspaces/deegree-workspace-utah/src/main/workspace/services/wfs110_metadata.xml
+++ b/deegree-workspaces/deegree-workspace-utah/src/main/workspace/services/wfs110_metadata.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deegreeServicesMetadata configVersion="3.0.0" xmlns="http://www.deegree.org/services/metadata"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/services/metadata/3.0.0/metadata.xsd">
+  <!--
+    General service information for all services. Used in the GetCapabilities
+    responses.
+  -->
+
+  <ServiceIdentification>
+    <Title>deegree 3 Utah Demo WFS</Title>
+    <Abstract>WFS demonstration with Utah data</Abstract>
+  </ServiceIdentification>
+
+  <ServiceProvider>
+    <ProviderName>lat/lon GmbH</ProviderName>
+    <ProviderSite>http://www.lat-lon.de</ProviderSite>
+    <ServiceContact>
+      <IndividualName>Andreas Schmitz</IndividualName>
+      <PositionName>Software developer</PositionName>
+      <Phone>0228/18496-0</Phone>
+      <Facsimile>0228/18496-29</Facsimile>
+      <ElectronicMailAddress>info@lat-lon.de</ElectronicMailAddress>
+      <Address>
+        <DeliveryPoint>Aennchenstr. 19</DeliveryPoint>
+        <City>Bonn</City>
+        <AdministrativeArea>NRW</AdministrativeArea>
+        <PostalCode>53177</PostalCode>
+        <Country>Germany</Country>
+      </Address>
+      <OnlineResource>http://www.deegree.org</OnlineResource>
+      <HoursOfService>24x7</HoursOfService>
+      <ContactInstructions>Do not hesitate to call</ContactInstructions>
+      <Role>PointOfContact</Role>
+    </ServiceContact>
+  </ServiceProvider>
+
+</deegreeServicesMetadata>


### PR DESCRIPTION
A new WFS 1.1.0 endpoint was added to the utah demo workspace, which passes all CITE WFS 1.1.0 basic profile tests. This new testsuite is data-agnostic and can be found at http://cite.opengeospatial.org/teamengine/about/wfs/1.1.0/site/.