### PR TITLE
Support of Halos with LinePlacement for line geometries

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/HaloStroke.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/HaloStroke.java
@@ -1,0 +1,97 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2009 by:
+   Department of Geography, University of Bonn
+ and
+   lat/lon GmbH
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+----------------------------------------------------------------------------*/
+/*
+ Copyright 2006 Jerry Huxtable
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.deegree.rendering.r2d.strokes;
+
+import static java.awt.BasicStroke.CAP_BUTT;
+import static java.awt.BasicStroke.JOIN_ROUND;
+import static org.deegree.commons.utils.math.MathUtils.round;
+
+import java.awt.BasicStroke;
+import java.awt.Font;
+import java.awt.Shape;
+import java.awt.geom.GeneralPath;
+
+import org.deegree.style.styling.components.Halo;
+import org.deegree.style.styling.components.LinePlacement;
+import org.deegree.style.styling.components.UOM;
+import org.deegree.style.utils.UomCalculator;
+
+/**
+ * <code>HaloStroke</code> drawing a halo around a text.
+ * 
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class HaloStroke extends TextStroke {
+
+    private final Halo halo;
+
+    private final UOM uom;
+
+    private final UomCalculator uomCalculator;
+
+    public HaloStroke( String text, Font font, LinePlacement linePlacement, Halo halo, UOM uom,
+                       UomCalculator uomCalculator ) {
+        super( text, font, linePlacement );
+        this.halo = halo;
+        this.uom = uom;
+        this.uomCalculator = uomCalculator;
+    }
+
+    @Override
+    protected void appendShape( GeneralPath result, Shape transformedShape ) {
+        BasicStroke stroke = new BasicStroke( round( 2 * uomCalculator.considerUOM( halo.radius, uom ) ), CAP_BUTT,
+                                              JOIN_ROUND );
+
+        Shape haloShape = stroke.createStrokedShape( transformedShape );
+        result.append( haloShape, false );
+    }
+
+}

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/TextStroke.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/TextStroke.java
@@ -230,13 +230,18 @@ public class TextStroke implements Stroke {
             t.rotate( angle );
             t.translate( gap + length, lineHeight / 4 );
 
-            result.append( t.createTransformedShape( text ), false );
+            Shape transformedShape = t.createTransformedShape( text );
+            appendShape( result, transformedShape );
 
             length += gap + text.getBounds2D().getWidth();
 
             sog = wordsToRender.poll();
 
         }
+    }
+
+    protected void appendShape( GeneralPath result, Shape transformedShape ) {
+        result.append( transformedShape, false );
     }
 
     private LinkedList<String> extractWords() {
@@ -551,7 +556,9 @@ public class TextStroke implements Stroke {
             t.setToTranslation( x, y );
             t.rotate( angle );
             t.translate( -px - advance, -py + lineHeight / 4 );
-            result.append( t.createTransformedShape( glyph ), false );
+
+            appendShape( result, t.createTransformedShape( glyph ) );
+
             state.next += ( advance + state.nextAdvance );
             state.currentChar++;
             if ( linePlacement.repeat && state.currentChar >= length ) {


### PR DESCRIPTION
The follwing TextSymbolizer was not applied corerctly. Only the Halo or LinePlacement works, if both are enabled Halo was not rendered. 

``` xml
<TextSymbolizer uom="meter">
   <Label>
      <ogc:PropertyName>app:LABEL<ogc:PropertyName>
   </Label>
   <Font>
    <SvgParameter name="font-family">Arial</SvgParameter>
    <SvgParameter name="font-family">Sans-Serif</SvgParameter>
    <SvgParameter name="font-weight">bold</SvgParameter>
    <SvgParameter name="font-size">8</SvgParameter>
   </Font>
   <LabelPlacement> 
    <LinePlacement>
     <PerpendicularOffset>-10</PerpendicularOffset> 
     <IsRepeated>false</IsRepeated>
     <InitialGap>10</InitialGap> 
     <PreventUpsideDown>true</PreventUpsideDown> 
     <Center>true</Center> 
     <WordWise>false</WordWise> 
    </LinePlacement> 
   </LabelPlacement>
   <Halo>
    <Radius>5</Radius>
    <Fill>
     <SvgParameter name="fill-opacity">1</SvgParameter>
     <SvgParameter name="fill">#FFFFFF</SvgParameter>
    </Fill>
   </Halo>
  <Fill>
   <SvgParameter name="fill-opacity">1.0</SvgParameter>
   <SvgParameter name="fill">#0000FF</SvgParameter>
  </Fill>
</TextSymbolizer>
```

This fix enables support of Halos if a LinePlacement is specified. 