### PR TITLE
Fixed NPE in WFS and WMS Capabilities request with SOAP, corrected ContentType of response and added NamespaceBinding to DescribeFeatureType response

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -341,7 +341,6 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
         FilterCapabilitiesExporter.export100( writer );
 
         writer.writeEndElement();
-        writer.writeEndDocument();
     }
 
     private void exportCapability100()
@@ -760,7 +759,6 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
         FilterCapabilitiesExporter.export110( writer );
 
         writer.writeEndElement();
-        writer.writeEndDocument();
     }
 
     private void writeOutputFormats110( XMLStreamWriter writer )
@@ -1062,7 +1060,6 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
         }
 
         writer.writeEndElement();
-        writer.writeEndDocument();
     }
 
     private void addOperation( WFSRequestType wfsRequestType, List<DCP> getAndPost, List<DCP> post, List<DCP> get,

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -960,7 +960,6 @@ public class WebFeatureService extends AbstractOWS {
         Version requestVersion = null;
         try {
             if ( soapDoc.getVersion() instanceof SOAP11Version ) {
-                response.setContentType( "application/soap+xml" );
                 XMLStreamWriter xmlWriter = response.getXMLWriter();
                 String soapEnvNS = "http://schemas.xmlsoap.org/soap/envelope/";
                 String xsiNS = "http://www.w3.org/2001/XMLSchema-instance";
@@ -1086,6 +1085,7 @@ public class WebFeatureService extends AbstractOWS {
             }
 
             endSOAPResponse( response );
+            response.setContentType( "application/soap+xml" );
 
         } catch ( OWSException e ) {
             LOG.debug( e.getMessage(), e );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
@@ -220,9 +220,11 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
         if ( VERSION_200.equals( request.getVersion() ) ) {
             writer.setPrefix( WFS_PREFIX, WFS_200_NS );
             writer.writeStartElement( WFS_200_NS, "DescribeFeatureTypeResponse" );
+            writer.writeNamespace( WFS_PREFIX, WFS_200_NS );
         } else {
             writer.setPrefix( WFS_PREFIX, WFS_NS );
             writer.writeStartElement( WFS_NS, "DescribeFeatureTypeResponse" );
+            writer.writeNamespace( WFS_PREFIX, WFS_NS );
         }
 
         doDescribeFeatureType( request, version, schemaWriter );

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities111XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities111XMLAdapter.java
@@ -139,7 +139,6 @@ public class Capabilities111XMLAdapter extends XMLAdapter {
         writeCapability( writer );
 
         writer.writeEndElement();
-        writer.writeEndDocument();
     }
 
     private void writeCapability( XMLStreamWriter writer )

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
@@ -161,7 +161,6 @@ public class Capabilities130XMLAdapter {
         writeCapability( writer );
 
         writer.writeEndElement();
-        writer.writeEndDocument();
     }
 
     private void writeExtendedCapabilities( XMLStreamWriter writer ) {


### PR DESCRIPTION
In the CapabilitiesHandler the export of the Capabilities was finished with writer.writeEndDocument(), this leads to a NPE if the SOAP tags are closed later.

Request:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
  <soapenv:Body>
    <wfs:GetCapabilities xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" service="WFS" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd" />
  </soapenv:Body>
</soapenv:Envelope>
```
Response:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="2.0.0">
  <ows:Exception exceptionCode="InvalidRequest">
    <ows:ExceptionText>java.lang.NullPointerException</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```

Stacktrace with configured logging: log4j.logger.org.deegree.services=TRACE:
```
[22:31:19] TRACE: [WebFeatureService] Stack trace:
java.lang.NullPointerException
	at java.lang.System.arraycopy(Native Method)
	at java.lang.String.getChars(String.java:826)
	at com.ctc.wstx.sw.BufferingXmlWriter.writeRaw(BufferingXmlWriter.java:298)
	at com.ctc.wstx.sw.BaseStreamWriter.writeCharacters(BaseStreamWriter.java:440)
	at org.deegree.commons.xml.stax.IndentingXMLStreamWriter.writeIndent(IndentingXMLStreamWriter.java:285)
	at org.deegree.commons.xml.stax.IndentingXMLStreamWriter.unindent(IndentingXMLStreamWriter.java:262)
	at org.deegree.commons.xml.stax.IndentingXMLStreamWriter.writeEndElement(IndentingXMLStreamWriter.java:254)
	at org.deegree.services.controller.AbstractOWS.endSOAPResponse(AbstractOWS.java:230)
	at org.deegree.services.wfs.WebFeatureService.doSOAP(WebFeatureService.java:925)
	at org.deegree.services.controller.OGCFrontController.dispatchSOAPRequest(OGCFrontController.java:1017)
	at org.deegree.services.controller.OGCFrontController.doPost(OGCFrontController.java:499)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:637)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:717)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:290)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
	at org.deegree.client.core.filter.InputFileFilter.doFilter(InputFileFilter.java:75)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:233)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:191)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:470)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:127)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:102)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:109)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:298)
	at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:857)
	at org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:588)
	at org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:489)
	at java.lang.Thread.run(Thread.java:744)
```

The fix removes the writer.writeEndDocument() in the CapabilitiesHandler of the WMS and WFS. This is not required cause all open elements are closed manually.

In addition, the ContentType of GetCapabilities and GetFeature responses of SOAP requests was changed from "text/xml;charset=UTF-8" and "application/gml+xml; version=3.2;charset=UTF-8" to "application/soap+xml".

Further, the NamespaceBinding for wfs was added to the DescribeFeatureType response.