### PR TITLE
Implemented Temporal Operators After, Before und During for WFS 2.0.0

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/temporal/Before.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/temporal/Before.java
@@ -36,11 +36,11 @@
 package org.deegree.filter.temporal;
 
 import org.deegree.filter.Expression;
-import org.deegree.filter.FilterEvaluationException;
-import org.deegree.filter.XPathEvaluator;
+import org.deegree.time.operator.BeforeOperator;
+import org.deegree.time.primitive.TimeGeometricPrimitive;
 
 /**
- * {@link TemporalOperator} that...
+ * {@link TemporalOperator} that evaluates Before.
  * 
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
@@ -62,8 +62,8 @@ public class Before extends TemporalOperator {
     }
 
     @Override
-    public <T> boolean evaluate( T obj, XPathEvaluator<T> xpathEvaluator )
-                            throws FilterEvaluationException {
-        throw new UnsupportedOperationException( "Evaluation of operator " + getSubType() + " is not implemented yet." );
+    protected boolean evaluate( TimeGeometricPrimitive t1, TimeGeometricPrimitive t2 ) {
+        return new BeforeOperator().evaluate( t1, t2 );
     }
+
 }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/temporal/During.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/temporal/During.java
@@ -36,11 +36,11 @@
 package org.deegree.filter.temporal;
 
 import org.deegree.filter.Expression;
-import org.deegree.filter.FilterEvaluationException;
-import org.deegree.filter.XPathEvaluator;
+import org.deegree.time.operator.LaxDuring;
+import org.deegree.time.primitive.TimeGeometricPrimitive;
 
 /**
- * {@link TemporalOperator} that...
+ * {@link TemporalOperator} that evaluates During.
  * 
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author$
@@ -62,8 +62,8 @@ public class During extends TemporalOperator {
     }
 
     @Override
-    public <T> boolean evaluate( T obj, XPathEvaluator<T> xpathEvaluator )
-                            throws FilterEvaluationException {
-        throw new UnsupportedOperationException( "Evaluation of operator " + getSubType() + " is not implemented yet." );
+    protected boolean evaluate( TimeGeometricPrimitive t1, TimeGeometricPrimitive t2 ) {
+        return new LaxDuring().evaluate( t1, t2 );
     }
+
 }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/FilterCapabilitiesExporter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/FilterCapabilitiesExporter.java
@@ -145,7 +145,7 @@ public class FilterCapabilitiesExporter {
         exportIdCapabilities200( writer );
         exportScalarCapabilities200( writer );
         exportSpatialCapabilities200( writer );
-        // exportTemporalCapabilities200( writer );
+        exportTemporalCapabilities200( writer );
         exportFunctions200( writer );
         exportExtendedCapabilities200( writer );
 
@@ -281,34 +281,34 @@ public class FilterCapabilitiesExporter {
         writer.writeAttribute( "name", name );
     }
 
-    // private static void exportTemporalCapabilities200( XMLStreamWriter writer )
-    // throws XMLStreamException {
-    // writer.writeStartElement( FES_20_NS, "Temporal_Capabilities" );
-    // writer.writeStartElement( FES_20_NS, "TemporalOperands" );
-    // writer.writeNamespace( "gml", CommonNamespaces.GMLNS );
-    // writer.writeNamespace( "gml32", CommonNamespaces.GMLNS );
-    // exportTemporalOperand( writer, "gml:TimeInstant" );
-    // exportTemporalOperand( writer, "gml:TimePeriod" );
-    // exportTemporalOperand( writer, "gml32:TimeInstant" );
-    // exportTemporalOperand( writer, "gml32:TimePeriod" );
-    // writer.writeEndElement();
-    // writer.writeStartElement( FES_20_NS, "TemporalOperators" );
-    // exportTemporalOperator( writer, "After" );
-    // exportTemporalOperator( writer, "Before" );
-    // exportTemporalOperator( writer, "Begins" );
-    // exportTemporalOperator( writer, "BegunBy" );
-    // exportTemporalOperator( writer, "TContains" );
-    // exportTemporalOperator( writer, "During" );
-    // exportTemporalOperator( writer, "TEquals" );
-    // exportTemporalOperator( writer, "TOverlaps" );
-    // exportTemporalOperator( writer, "Meets" );
-    // exportTemporalOperator( writer, "OverlappedBy" );
-    // exportTemporalOperator( writer, "MetBy" );
-    // exportTemporalOperator( writer, "Ends" );
-    // exportTemporalOperator( writer, "EndedBy" );
-    // writer.writeEndElement();
-    // writer.writeEndElement();
-    // }
+    private static void exportTemporalCapabilities200( XMLStreamWriter writer )
+                            throws XMLStreamException {
+        writer.writeStartElement( FES_20_NS, "Temporal_Capabilities" );
+        writer.writeStartElement( FES_20_NS, "TemporalOperands" );
+        writer.writeNamespace( "gml", CommonNamespaces.GMLNS );
+        writer.writeNamespace( "gml32", CommonNamespaces.GMLNS );
+        exportTemporalOperand( writer, "gml:TimeInstant" );
+        exportTemporalOperand( writer, "gml:TimePeriod" );
+        exportTemporalOperand( writer, "gml32:TimeInstant" );
+        exportTemporalOperand( writer, "gml32:TimePeriod" );
+        writer.writeEndElement();
+        writer.writeStartElement( FES_20_NS, "TemporalOperators" );
+        exportTemporalOperator( writer, "After" );
+        exportTemporalOperator( writer, "Before" );
+        exportTemporalOperator( writer, "Begins" );
+        exportTemporalOperator( writer, "BegunBy" );
+        exportTemporalOperator( writer, "TContains" );
+        exportTemporalOperator( writer, "During" );
+        exportTemporalOperator( writer, "TEquals" );
+        exportTemporalOperator( writer, "TOverlaps" );
+        exportTemporalOperator( writer, "Meets" );
+        exportTemporalOperator( writer, "OverlappedBy" );
+        exportTemporalOperator( writer, "MetBy" );
+        exportTemporalOperator( writer, "Ends" );
+        exportTemporalOperator( writer, "EndedBy" );
+        writer.writeEndElement();
+        writer.writeEndElement();
+    }
 
     private static void exportTemporalOperand( XMLStreamWriter writer, String name )
                             throws XMLStreamException {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/FilterCapabilitiesExporter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/FilterCapabilitiesExporter.java
@@ -295,17 +295,17 @@ public class FilterCapabilitiesExporter {
         writer.writeStartElement( FES_20_NS, "TemporalOperators" );
         exportTemporalOperator( writer, "After" );
         exportTemporalOperator( writer, "Before" );
-        exportTemporalOperator( writer, "Begins" );
-        exportTemporalOperator( writer, "BegunBy" );
-        exportTemporalOperator( writer, "TContains" );
+        // exportTemporalOperator( writer, "Begins" );
+        // exportTemporalOperator( writer, "BegunBy" );
+        // exportTemporalOperator( writer, "TContains" );
         exportTemporalOperator( writer, "During" );
         exportTemporalOperator( writer, "TEquals" );
-        exportTemporalOperator( writer, "TOverlaps" );
-        exportTemporalOperator( writer, "Meets" );
-        exportTemporalOperator( writer, "OverlappedBy" );
-        exportTemporalOperator( writer, "MetBy" );
-        exportTemporalOperator( writer, "Ends" );
-        exportTemporalOperator( writer, "EndedBy" );
+        // exportTemporalOperator( writer, "TOverlaps" );
+        // exportTemporalOperator( writer, "Meets" );
+        // exportTemporalOperator( writer, "OverlappedBy" );
+        // exportTemporalOperator( writer, "MetBy" );
+        // exportTemporalOperator( writer, "Ends" );
+        // exportTemporalOperator( writer, "EndedBy" );
         writer.writeEndElement();
         writer.writeEndElement();
     }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/FilterCapabilitiesExporter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/FilterCapabilitiesExporter.java
@@ -163,8 +163,8 @@ public class FilterCapabilitiesExporter {
         exportConstraint200( writer, "ImplementsStandardFilter", true );
         exportConstraint200( writer, "ImplementsMinSpatialFilter", true );
         exportConstraint200( writer, "ImplementsSpatialFilter", true );
-        exportConstraint200( writer, "ImplementsMinTemporalFilter", false );
-        exportConstraint200( writer, "ImplementsTemporalFilter", false );
+        exportConstraint200( writer, "ImplementsMinTemporalFilter", true );
+        exportConstraint200( writer, "ImplementsTemporalFilter", true );
         exportConstraint200( writer, "ImplementsVersionNav", false );
         exportConstraint200( writer, "ImplementsSorting", true );
         exportConstraint200( writer, "ImplementsExtendedOperators", false );

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/time/operator/AfterOperator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/time/operator/AfterOperator.java
@@ -1,7 +1,7 @@
 //$HeadURL$
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
- Copyright (C) 2001-2011 by:
+ Copyright (C) 2001-2015 by:
  - Department of Geography, University of Bonn -
  and
  - lat/lon GmbH -
@@ -33,37 +33,42 @@
 
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
-package org.deegree.filter.temporal;
+package org.deegree.time.operator;
 
-import org.deegree.filter.Expression;
-import org.deegree.time.operator.AfterOperator;
+import static org.deegree.time.operator.TimeCompareUtils.compareBeginWithEnd;
+
 import org.deegree.time.primitive.TimeGeometricPrimitive;
 
 /**
- * {@link TemporalOperator} that evaluates After.
+ * Time operator to evaluate 'After'.
  * 
- * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
- * @author last edited by: $Author$
- * 
- * @version $Revision$, $Date$
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
  */
-public class After extends TemporalOperator {
+public class AfterOperator {
 
     /**
-     * Creates a new instance of {@link After}.
+     * Evaluates if self is after other or not. TimeInstant and TimePeriods are allowed and handled as followed:
      * 
-     * @param param1
-     *            first temporal expression (time instant or period), must not be <code>null</code>
-     * @param param2
-     *            second temporal expression (time instant or period), must not be <code>null</code>
+     * <ul>
+     * <li>self.position > other.position</li>
+     * <li>self.position > other.end.position</li>
+     * <li>self.begin.position > other.position</li>
+     * <li>self.begin.position > other.end.position</li>
+     * </ul>
+     * 
+     * @param self
+     *            may be <code>null</code> (evaluation results in <code>false</code>)
+     * @param other
+     *            may be <code>null</code> (evaluation results in <code>false</code>)
+     * @return <code>true</code> if self is temporal after other, <code>false</code> if self is before or equal to other
+     *         or self and/or other are <code>null</code>
      */
-    public After( Expression param1, Expression param2 ) {
-        super( param1, param2 );
-    }
+    public boolean evaluate( final TimeGeometricPrimitive self, final TimeGeometricPrimitive other ) {
+        if ( self == null || other == null )
+            return false;
 
-    @Override
-    protected boolean evaluate( final TimeGeometricPrimitive t1, final TimeGeometricPrimitive t2 ) {
-        return new AfterOperator().evaluate( t1, t2 );
+        int compareBeginWithEnd = compareBeginWithEnd( self, other );
+        return compareBeginWithEnd > 0;
     }
 
 }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/time/operator/BeforeOperator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/time/operator/BeforeOperator.java
@@ -1,0 +1,73 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.time.operator;
+
+import static org.deegree.time.operator.TimeCompareUtils.compareEndWithBegin;
+
+import org.deegree.time.primitive.TimeGeometricPrimitive;
+
+/**
+ * Time operator to evaluate 'Before'.
+ * 
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class BeforeOperator {
+
+    /**
+     * Evaluates if self is before other or not. TimeInstant and TimePeriods are allowed and handled as followed:
+     * 
+     * <ul>
+     * <li>self.position < other.position</li>
+     * <li>self.position < other.begin.position</li>
+     * <li>self.end.position < other.position</li>
+     * <li>self.end.position < other.begin.position</li>
+     * </ul>
+     * 
+     * @param self
+     *            may be <code>null</code> (evaluation results in <code>false</code>)
+     * @param other
+     *            may be <code>null</code> (evaluation results in <code>false</code>)
+     * @return <code>true</code> if self is temporal before other, <code>false</code> if self is after or equal to other
+     *         or self and/or other are <code>null</code>
+     */
+    public boolean evaluate( final TimeGeometricPrimitive self, final TimeGeometricPrimitive other ) {
+        if ( self == null || other == null )
+            return false;
+        int compareBeginWithEnd = compareEndWithBegin( self, other );
+        return compareBeginWithEnd < 0;
+    }
+
+}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/time/operator/TimeCompareUtils.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/time/operator/TimeCompareUtils.java
@@ -60,6 +60,26 @@ public class TimeCompareUtils {
         return compared;
     }
 
+    /**
+     * Compares the end of a with the begin of b.
+     * 
+     * @param a
+     *            never <code>null</code>
+     * @param b
+     *            never <code>null</code>
+     * @return -1 if the end of a is before the begin of b; 0 if a and b are the equal or a and/or b are UNKNOWN; 1 if
+     *         the end of a is after the begin of b
+     * @throws NullPointerException
+     *             if a and/or b is <code>null</code>
+     */
+    public static int compareEndWithBegin( final TimeGeometricPrimitive a, final TimeGeometricPrimitive b ) {
+        final Temporal endA = new TemporalConverter().convert( end( a ) );
+        final Temporal beginB = new TemporalConverter().convert( begin( b ) );
+        if ( endA == null || beginB == null )
+            return 0;
+        return endA.compareTo( beginB );
+    }
+
     public static TimePosition begin( final TimeGeometricPrimitive t ) {
         if ( t instanceof TimeInstant ) {
             return ( (TimeInstant) t ).getPosition();

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/AfterOperatorTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/AfterOperatorTest.java
@@ -85,19 +85,23 @@ public class AfterOperatorTest {
     public void evaluateInstantPeriod() {
         assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:00" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
         assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
-                                     period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ) ) );
-        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
-                                     period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ) ) );
-        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
-                                     period( "2014-01-01T00:00:00", "2014-01-01T00:00:03" ) ) );
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:03" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
 
-        assertTrue( after.evaluate( instant( "2014-01-01T00:00:03" ),
-                                    period( "2014-01-01T00:00:00", "2014-01-01T00:00:02" ) ) );
+        assertTrue( after.evaluate( instant( "2014-01-01T00:00:04" ),
+                                    period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
     }
 
     @Test
     public void evaluatePeriodInstant() {
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ),
+                                     instant( "2014-01-01T00:00:01" ) ) );
         assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
                                      instant( "2014-01-01T00:00:01" ) ) );
         assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
@@ -113,8 +117,11 @@ public class AfterOperatorTest {
 
     @Test
     public void evaluatePeriodPeriod() {
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ) );
         assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ) );
+
         assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
                                      period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ) ) );
         assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/AfterOperatorTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/AfterOperatorTest.java
@@ -1,0 +1,150 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.time.operator;
+
+import static java.util.Collections.emptyList;
+import static org.deegree.time.position.IndeterminateValue.UNKNOWN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.time.position.TimePosition;
+import org.deegree.time.primitive.GenericTimeInstant;
+import org.deegree.time.primitive.GenericTimePeriod;
+import org.deegree.time.primitive.RelatedTime;
+import org.deegree.time.primitive.TimeInstant;
+import org.deegree.time.primitive.TimePeriod;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class AfterOperatorTest {
+
+    private final AfterOperator after = new AfterOperator();
+
+    @Test
+    public void evaluateInstantInstant() {
+        assertFalse( after.evaluate( instant( "2014-01-01" ), instant( "2014-01-01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01.000" ), instant( "2014-01-01T00:00:01.000" ) ) );
+
+        assertFalse( after.evaluate( instant( "2014-01-01" ), instant( "2015-01-01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:02" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01.000" ), instant( "2014-01-01T00:00:01.001" ) ) );
+        assertFalse( after.evaluate( null, null ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( instant( "INDETERMINATE" ), instant( "INDETERMINATE" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:02" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ), instant( "INDETERMINATE" ) ) );
+        assertFalse( after.evaluate( instant( "INDETERMINATE" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ), null ) );
+        assertFalse( after.evaluate( null, instant( "2014-01-01T00:00:01" ) ) );
+
+        assertTrue( after.evaluate( instant( "2015-01-01" ), instant( "2014-01-01" ) ) );
+        assertTrue( after.evaluate( instant( "2014-01-01T00:00:02" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertTrue( after.evaluate( instant( "2014-01-01T00:00:01.001" ), instant( "2014-01-01T00:00:01.000" ) ) );
+    }
+
+    @Test
+    public void evaluateInstantPeriod() {
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
+                                     period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
+                                     period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ) ) );
+        assertFalse( after.evaluate( instant( "2014-01-01T00:00:01" ),
+                                     period( "2014-01-01T00:00:00", "2014-01-01T00:00:03" ) ) );
+
+        assertTrue( after.evaluate( instant( "2014-01-01T00:00:03" ),
+                                    period( "2014-01-01T00:00:00", "2014-01-01T00:00:02" ) ) );
+    }
+
+    @Test
+    public void evaluatePeriodInstant() {
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                     instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                     instant( "2014-01-01T00:00:02" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                     instant( "2014-01-01T00:00:03" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                     instant( "2014-01-01T00:00:04" ) ) );
+
+        assertTrue( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                    instant( "2014-01-01T00:00:00" ) ) );
+    }
+
+    @Test
+    public void evaluatePeriodPeriod() {
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:04" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:02", "2014-01-01T00:00:04" ) ) );
+        assertFalse( after.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:03", "2014-01-01T00:00:04" ) ) );
+
+        assertTrue( after.evaluate( period( "2014-01-01T00:00:03", "2014-01-01T00:00:04" ),
+                                    period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ) );
+    }
+
+    private TimeInstant instant( final String s ) {
+        final List<Property> props = emptyList();
+        final List<RelatedTime> relatedTimes = emptyList();
+        TimePosition pos = null;
+        if ( "INDETERMINATE".equals( s ) ) {
+            pos = new TimePosition( null, null, UNKNOWN, "" );
+        } else {
+            pos = new TimePosition( null, null, null, s );
+        }
+        return new GenericTimeInstant( null, props, relatedTimes, null, pos );
+    }
+
+    private TimePeriod period( final String t1, final String t2 ) {
+        final TimeInstant begin = instant( t1 );
+        final TimeInstant end = instant( t2 );
+        final List<Property> props = emptyList();
+        final List<RelatedTime> relatedTimes = emptyList();
+        return new GenericTimePeriod( null, props, relatedTimes, null, begin, end );
+    }
+}

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/BeforeOperatorTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/BeforeOperatorTest.java
@@ -1,0 +1,158 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.time.operator;
+
+import static java.util.Collections.emptyList;
+import static org.deegree.time.position.IndeterminateValue.UNKNOWN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.time.position.TimePosition;
+import org.deegree.time.primitive.GenericTimeInstant;
+import org.deegree.time.primitive.GenericTimePeriod;
+import org.deegree.time.primitive.RelatedTime;
+import org.deegree.time.primitive.TimeInstant;
+import org.deegree.time.primitive.TimePeriod;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class BeforeOperatorTest {
+
+    private final BeforeOperator before = new BeforeOperator();
+
+    @Test
+    public void evaluateInstantInstant() {
+        assertFalse( before.evaluate( instant( "2014-01-01" ), instant( "2014-01-01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01.000" ), instant( "2014-01-01T00:00:01.000" ) ) );
+
+        assertFalse( before.evaluate( instant( "2015-01-01" ), instant( "2014-01-01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:02" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01.001" ), instant( "2014-01-01T00:00:01.000" ) ) );
+        assertFalse( before.evaluate( null, null ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "INDETERMINATE" ), instant( "INDETERMINATE" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:02" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "INDETERMINATE" ), instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01" ), instant( "INDETERMINATE" ) ) );
+        assertFalse( before.evaluate( null, instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01" ), null ) );
+
+        assertTrue( before.evaluate( instant( "2014-01-01" ), instant( "2015-01-01" ) ) );
+        assertTrue( before.evaluate( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:02" ) ) );
+        assertTrue( before.evaluate( instant( "2014-01-01T00:00:01.000" ), instant( "2014-01-01T00:00:01.001" ) ) );
+    }
+
+    @Test
+    public void evaluateInstantPeriod() {
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:01" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:02" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:03" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+        assertFalse( before.evaluate( instant( "2014-01-01T00:00:04" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+
+        assertTrue( before.evaluate( instant( "2014-01-01T00:00:00" ),
+                                     period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ) );
+    }
+
+    @Test
+    public void evaluatePeriodInstant() {
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ),
+                                      instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                      instant( "2014-01-01T00:00:00" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                      instant( "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                      instant( "2014-01-01T00:00:02" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                      instant( "2014-01-01T00:00:03" ) ) );
+
+        assertTrue( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                     instant( "2014-01-01T00:00:04" ) ) );
+    }
+
+    @Test
+    public void evaluatePeriodPeriod() {
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ) );
+
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                      period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                      period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                      period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ) ) );
+        assertFalse( before.evaluate( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                      period( "2014-01-01T00:00:03", "2014-01-01T00:00:03" ) ) );
+
+        assertTrue( before.evaluate( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                     period( "2014-01-01T00:00:03", "2014-01-01T00:00:04" ) ) );
+    }
+
+    private TimeInstant instant( final String s ) {
+        final List<Property> props = emptyList();
+        final List<RelatedTime> relatedTimes = emptyList();
+        TimePosition pos = null;
+        if ( "INDETERMINATE".equals( s ) ) {
+            pos = new TimePosition( null, null, UNKNOWN, "" );
+        } else {
+            pos = new TimePosition( null, null, null, s );
+        }
+        return new GenericTimeInstant( null, props, relatedTimes, null, pos );
+    }
+
+    private TimePeriod period( final String t1, final String t2 ) {
+        final TimeInstant begin = instant( t1 );
+        final TimeInstant end = instant( t2 );
+        final List<Property> props = emptyList();
+        final List<RelatedTime> relatedTimes = emptyList();
+        return new GenericTimePeriod( null, props, relatedTimes, null, begin, end );
+    }
+
+}

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/TimeCompareUtilsTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/time/operator/TimeCompareUtilsTest.java
@@ -1,0 +1,169 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.time.operator;
+
+import static java.util.Collections.emptyList;
+import static org.deegree.time.operator.TimeCompareUtils.compareEndWithBegin;
+import static org.deegree.time.position.IndeterminateValue.UNKNOWN;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.time.position.TimePosition;
+import org.deegree.time.primitive.GenericTimeInstant;
+import org.deegree.time.primitive.GenericTimePeriod;
+import org.deegree.time.primitive.RelatedTime;
+import org.deegree.time.primitive.TimeInstant;
+import org.deegree.time.primitive.TimePeriod;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class TimeCompareUtilsTest {
+
+    @Test(expected = NullPointerException.class)
+    public void evaluateInstantInstant_BothNull() {
+        compareEndWithBegin( null, null );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void evaluateInstantInstant_FirstNull() {
+        compareEndWithBegin( null, instant( "2014-01-01" ) );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void evaluateInstantInstant_SecondNull() {
+        compareEndWithBegin( instant( "2014-01-01" ), null );
+    }
+
+    @Test
+    public void evaluateInstantInstant() {
+        assertThat( compareEndWithBegin( instant( "2014-01-01" ), instant( "2014-01-01" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:01" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01.000" ), instant( "2014-01-01T00:00:01.000" ) ),
+                    is( 0 ) );
+        assertThat( compareEndWithBegin( instant( "INDETERMINATE" ), instant( "INDETERMINATE" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( instant( "INDETERMINATE" ), instant( "2014-01-01T00:00:01" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01" ), instant( "INDETERMINATE" ) ), is( 0 ) );
+
+        assertThat( compareEndWithBegin( instant( "2015-01-01" ), instant( "2014-01-01" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:02" ), instant( "2014-01-01T00:00:01" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01.001" ), instant( "2014-01-01T00:00:01.000" ) ),
+                    is( 1 ) );
+
+        assertThat( compareEndWithBegin( instant( "2014-01-01" ), instant( "2015-01-01" ) ), is( -1 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01" ), instant( "2014-01-01T00:00:02" ) ), is( -1 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01.000" ), instant( "2014-01-01T00:00:01.001" ) ),
+                    is( -1 ) );
+    }
+
+    @Test
+    public void evaluateInstantPeriod() {
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:01" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ), is( 0 ) );
+
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:02" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:03" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:04" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ), is( 1 ) );
+
+        assertThat( compareEndWithBegin( instant( "2014-01-01T00:00:00" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ) ), is( -1 ) );
+    }
+
+    @Test
+    public void evaluatePeriodInstant() {
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ),
+                                         instant( "2014-01-01T00:00:01" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                         instant( "2014-01-01T00:00:03" ) ), is( 0 ) );
+
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                         instant( "2014-01-01T00:00:02" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                         instant( "2014-01-01T00:00:01" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                         instant( "2014-01-01T00:00:00" ) ), is( 1 ) );
+
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:03" ),
+                                         instant( "2014-01-01T00:00:04" ) ), is( -1 ) );
+    }
+
+    @Test
+    public void evaluatePeriodPeriod() {
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:01" ) ), is( 0 ) );
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ), is( 0 ) );
+
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                         period( "2014-01-01T00:00:00", "2014-01-01T00:00:01" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                         period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ) ), is( 1 ) );
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ),
+                                         period( "2014-01-01T00:00:02", "2014-01-01T00:00:03" ) ), is( 1 ) );
+
+        assertThat( compareEndWithBegin( period( "2014-01-01T00:00:01", "2014-01-01T00:00:02" ),
+                                         period( "2014-01-01T00:00:03", "2014-01-01T00:00:04" ) ), is( -1 ) );
+    }
+
+    private TimeInstant instant( final String s ) {
+        final List<Property> props = emptyList();
+        final List<RelatedTime> relatedTimes = emptyList();
+        TimePosition pos = null;
+        if ( "INDETERMINATE".equals( s ) ) {
+            pos = new TimePosition( null, null, UNKNOWN, "" );
+        } else {
+            pos = new TimePosition( null, null, null, s );
+        }
+        return new GenericTimeInstant( null, props, relatedTimes, null, pos );
+    }
+
+    private TimePeriod period( final String t1, final String t2 ) {
+        final TimeInstant begin = instant( t1 );
+        final TimeInstant end = instant( t2 );
+        final List<Property> props = emptyList();
+        final List<RelatedTime> relatedTimes = emptyList();
+        return new GenericTimePeriod( null, props, relatedTimes, null, begin, end );
+    }
+}


### PR DESCRIPTION
Implemented the temporal operators "After", "Before" and "During" for WFS 2.0.0.

Temporal operators can be used to filter GetFeature requests.

The support of those operators is described in the capabilities and the constraints "ImplementsMinTemporalFilter" and "ImplementsTemporalFilter" are set to true.