### PR TITLE
 Enhanced WFS configuration supporting the option to set a default ResolveTimeOut

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/ResolveParams.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/ResolveParams.java
@@ -51,7 +51,7 @@ public class ResolveParams {
 
     private final String resolveDepth;
 
-    private final BigInteger resolveTimeout;
+    private BigInteger resolveTimeout;
 
     public ResolveParams( ResolveMode resolve, String resolveDepth, BigInteger resolveTimeout ) {
         this.resolve = resolve;
@@ -70,4 +70,9 @@ public class ResolveParams {
     public BigInteger getTimeout() {
         return resolveTimeout;
     }
+
+    public void setTimeout( BigInteger resolveTimeout ) {
+        this.resolveTimeout = resolveTimeout;
+    }
+
 }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -917,7 +917,9 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             if ( master.getQueryMaxFeatures() != -1 ) {
                 constraints.add( new Domain( "CountDefault", "" + master.getQueryMaxFeatures() ) );
             }
-
+            if ( master.getResolveTimeOutInSeconds() != null ) {
+                constraints.add( new Domain( "ResolveTimeoutDefault", master.getResolveTimeOutInSeconds().toString() ) );
+            }
             constraints.add( new Domain( "ResolveLocalScope", "*" ) );
 
             List<String> queryExprs = new ArrayList<String>();

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -278,7 +278,9 @@ public class WebFeatureService extends AbstractOWS {
 
         queryMaxFeatures = jaxbConfig.getQueryMaxFeatures() == null ? DEFAULT_MAX_FEATURES
                                                                    : jaxbConfig.getQueryMaxFeatures().intValue();
-        resolveTimeOutInSeconds = jaxbConfig.getResolveTimeOutInSeconds();
+        resolveTimeOutInSeconds = jaxbConfig.getResolveTimeOutInSeconds() != null
+                                  && jaxbConfig.getResolveTimeOutInSeconds().intValue() > 0 ? jaxbConfig.getResolveTimeOutInSeconds()
+                                                                                           : null;
         checkAreaOfUse = jaxbConfig.isQueryCheckAreaOfUse() == null ? false : jaxbConfig.isQueryCheckAreaOfUse();
 
         service = new WfsFeatureStoreManager();

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -278,9 +278,7 @@ public class WebFeatureService extends AbstractOWS {
 
         queryMaxFeatures = jaxbConfig.getQueryMaxFeatures() == null ? DEFAULT_MAX_FEATURES
                                                                    : jaxbConfig.getQueryMaxFeatures().intValue();
-        resolveTimeOutInSeconds = jaxbConfig.getResolveTimeOutInSeconds() != null
-                                  && jaxbConfig.getResolveTimeOutInSeconds().intValue() > 0 ? jaxbConfig.getResolveTimeOutInSeconds()
-                                                                                           : null;
+        resolveTimeOutInSeconds = jaxbConfig.getResolveTimeOutInSeconds();
         checkAreaOfUse = jaxbConfig.isQueryCheckAreaOfUse() == null ? false : jaxbConfig.isQueryCheckAreaOfUse();
 
         service = new WfsFeatureStoreManager();

--- a/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
+++ b/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
@@ -54,6 +54,7 @@
         </choice>
         <element name="QueryCRS" type="string" minOccurs="1" maxOccurs="unbounded" />
         <element name="QueryMaxFeatures" type="integer" minOccurs="0" default="15000" />
+        <element name="ResolveTimeOutInSeconds" type="integer" minOccurs="0" default="60" />
         <element name="QueryCheckAreaOfUse" type="boolean" minOccurs="0" default="false" />
         <element name="StoredQuery" type="string" minOccurs="0" maxOccurs="unbounded" />
         <element ref="wfs:AbstractFormat" minOccurs="0" maxOccurs="unbounded" />

--- a/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
+++ b/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
@@ -54,7 +54,7 @@
         </choice>
         <element name="QueryCRS" type="string" minOccurs="1" maxOccurs="unbounded" />
         <element name="QueryMaxFeatures" type="integer" minOccurs="0" default="15000" />
-        <element name="ResolveTimeOutInSeconds" type="integer" minOccurs="0" default="60" />
+        <element name="ResolveTimeOutInSeconds" type="positiveInteger" minOccurs="0" />
         <element name="QueryCheckAreaOfUse" type="boolean" minOccurs="0" default="false" />
         <element name="StoredQuery" type="string" minOccurs="0" maxOccurs="unbounded" />
         <element ref="wfs:AbstractFormat" minOccurs="0" maxOccurs="unbounded" />

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -80,6 +80,8 @@ The deegree WFS config file format is defined by schema file http://schemas.deeg
 +-------------------------+-------------+---------+------------------------------------------------------------------+
 | QueryMaxFeatures        | 0..1        | Integer | Limit of features returned in a response, default: 15000         |
 +-------------------------+-------------+---------+------------------------------------------------------------------+
+| ResolveTimeOutInSeconds | 0..1        | Integer | Expiry time in seconds                                           |
++-------------------------+-------------+---------+------------------------------------------------------------------+
 | QueryCheckAreaOfUse     | 0..1        | Boolean | Check spatial query constraints against CRS area, default: false |
 +-------------------------+-------------+---------+------------------------------------------------------------------+
 | StoredQuery             | 0..n        | String  | File name of StoredQueryDefinition                               |
@@ -100,6 +102,7 @@ General options
 * ``EnableResponseBuffering``: By default, WFS responses are directly streamed to the client. This is very much recommended and even a requirement for transferring large responses efficiently. The only drawback happens if exceptions occur, after a partial response has already been transferred. In this case, the client will receive part payload and part exception report. By specifying ``false`` here, you can explicitly force buffering of the full response, before it is written to the client. Only if the full response could be generated successfully, it will be transferred. If an exception happens at any time the buffer will be discarded, and an exception report will be sent to the client. Buffering is performed in memory, but switches to a temp file in case the buffer grows bigger than 1 MiB.
 * ``QueryCRS``: Coordinate reference systems for returned geometries. This element can be specified multiple times, and the WFS will announce all CRS in the GetCapabilities response (except for WFS 1.0.0 which does not officially support using multiple coordinate reference systems). The first element always specifies the default CRS (used when no CRS parameter is present in a request).
 * ``QueryMaxFeatures``: By default, a maximum number of 15000 features will be returned for a single ``GetFeature`` request. Use this option to override this setting. A value of ``-1`` means unlimited.
+* ''ResolveTimeOutInSeconds'': Use this option to specify a default value for ResolveTimeOut, used in ``GetFeature`` request if the ResolveTimeOut option is not set.
 * ``QueryCheckAreaOfUse``: By default, spatial query constraints are not checked with regard to the area of validity of the CRS. Set this option to ``true`` to enforce this check.
 
 ^^^^^^^^^^^^


### PR DESCRIPTION
This pull requests adds a configuration option to the wfs configuration to configure the ResolveTimeOut in GetFeature, GetFetaureWithLock and GetPropertyValue request when the KVP/XML value is missing.
The configured value is exported as contraint 'ResolveTimeoutDefault' in the WFS 2.0.0 capabilities.