### PR TITLE
Fixed bug in StoredQuery filter when GmlFormats are configured

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -207,6 +207,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                     xmlStream.writeAttribute( "lockId", lock.getId() );
                 }
             }
+            prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
         } else if ( request.getVersion().equals( VERSION_110 ) ) {
             if ( responseContainerEl != null ) {
                 xmlStream.setPrefix( responseContainerEl.getPrefix(), responseContainerEl.getNamespaceURI() );
@@ -221,6 +222,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                 }
                 xmlStream.writeAttribute( "timeStamp", getTimestamp() );
             }
+            prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
         } else if ( request.getVersion().equals( VERSION_200 ) && ( !isGetFeatureById ) ) {
             xmlStream.setPrefix( "wfs", WFS_200_NS );
             xmlStream.writeStartElement( WFS_200_NS, "FeatureCollection" );
@@ -229,8 +231,8 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
             if ( lock != null ) {
                 xmlStream.writeAttribute( "lockId", lock.getId() );
             }
+            prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
         }
-        prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
 
         if ( !isGetFeatureById ) {
             // ensure that namespace for feature member elements is bound


### PR DESCRIPTION
When a StoredQuery filter is used in a GetFeature request and GmlFormats are configured following erroneous response is returned:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="2.0.0">
  <ows:Exception exceptionCode="NoApplicableCode">
    <ows:ExceptionText>Trying to write a namespace declaration when there is no open start element.</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```
The namespace bindings of GmlFormats are added, although no FeatureCollection element was opened. This error was fixed in this pull request.