### PR TITLE
Added support of metadata records describing INSPIRE Spatial Data Service in CSW

### DIFF
--- a/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/iso/parsing/ParseIdentificationInfo.java
+++ b/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/iso/parsing/ParseIdentificationInfo.java
@@ -107,11 +107,12 @@ public class ParseIdentificationInfo extends XMLAdapter {
             OMElement md_dataIdentification = getElement( root_identInfo, new XPath( "./gmd:MD_DataIdentification",
                                                                                      nsContextParseII ) );
             OMElement sv_serviceIdentification = getElement( root_identInfo,
-                                                             new XPath( "./srv:SV_ServiceIdentification",
+                                                             new XPath(
+                                                                        "./srv:SV_ServiceIdentification | ./sds:SV_ServiceIdentification",
                                                                         nsContextParseII ) );
             OMElement sv_service_OR_md_dataIdentification = getElement( root_identInfo,
                                                                         new XPath(
-                                                                                   "./srv:SV_ServiceIdentification | ./gmd:MD_DataIdentification",
+                                                                                   "./srv:SV_ServiceIdentification | ./gmd:MD_DataIdentification | ./sds:SV_ServiceIdentification",
                                                                                    nsContextParseII ) );
             /*---------------------------------------------------------------
              * 

--- a/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/iso/parsing/RecordPropertyParser.java
+++ b/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/iso/parsing/RecordPropertyParser.java
@@ -36,6 +36,8 @@
 package org.deegree.metadata.iso.parsing;
 
 import static org.deegree.commons.tom.datetime.ISO8601Converter.parseDate;
+import static org.deegree.protocol.csw.CSWConstants.SDS_NS;
+import static org.deegree.protocol.csw.CSWConstants.SDS_PREFIX;
 import static org.deegree.protocol.csw.CSWConstants.SRV_NS;
 import static org.deegree.protocol.csw.CSWConstants.SRV_PREFIX;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -88,6 +90,7 @@ public final class RecordPropertyParser extends XMLAdapter {
 
     static {
         nsContext.addNamespace( SRV_PREFIX, SRV_NS );
+        nsContext.addNamespace( SDS_PREFIX, SDS_NS );
     }
 
     public RecordPropertyParser( OMElement element ) {

--- a/deegree-core/deegree-core-metadata/src/main/java/org/deegree/protocol/csw/CSWConstants.java
+++ b/deegree-core/deegree-core-metadata/src/main/java/org/deegree/protocol/csw/CSWConstants.java
@@ -61,6 +61,7 @@ public final class CSWConstants {
     public static final String CSW_202_NS = "http://www.opengis.net/cat/csw/2.0.2";
 
     public static final String CSW_202_PREFIX = "csw";
+
     /**
      * ISO application profile <br>
      * "http://www.isotc211.org/2005/gmd"
@@ -133,6 +134,17 @@ public final class CSWConstants {
      * Common namespace prefix for elements from the ISO AP specification for the types "Service"
      */
     public static final String SRV_PREFIX = "srv";
+
+    /**
+     * Common namespace prefix for elements from the INSPIRE SDS specification.
+     */
+    public static final String SDS_PREFIX = "sds";
+
+    /**
+     * Namespace for elements from the NSPIRE SDS specification.<br>
+     * Namespace="http://inspire.ec.europa.eu/schemas/inspire_sds/1.0"
+     * */
+    public static final String SDS_NS = "http://inspire.ec.europa.eu/schemas/inspire_sds/1.0";
 
     /** Common namespace prefix for elements from the ISO AP specification */
     public static final String APISO_PREFIX = "apiso";

--- a/deegree-core/deegree-core-metadata/src/test/java/org/deegree/metadata/iso/ISORecordTest.java
+++ b/deegree-core/deegree-core-metadata/src/test/java/org/deegree/metadata/iso/ISORecordTest.java
@@ -35,7 +35,11 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.metadata.iso;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -215,4 +219,25 @@ public class ISORecordTest {
         boolean isMatching = record.eval( filter );
         assertTrue( isMatching );
     }
+
+    @Test
+    public void testInstantiationOfSpatialDataServiceRecord()
+                            throws Exception {
+        InputStream is = ISORecordTest.class.getResourceAsStream( "sds-example.xml" );
+        XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader( is );
+        ISORecord record = new ISORecord( xmlStream );
+
+        assertThat( record.getIdentifier(), is( "mysdsid1" ) );
+        assertThat( record.getType(), is( "service" ) );
+        assertThat( record.getAbstract().length, is( 1 ) );
+        assertThat( record.getAbstract()[0],
+                    containsString( "This Spatial Data Service supports various operations on the Digital Subsurface Models" ) );
+        assertThat( record.getParsedElement().getQueryableProperties().getKeywords().size(), is( 1 ) );
+        assertThat( record.getParsedElement().getQueryableProperties().getKeywords().get( 0 ).getKeywords().size(),
+                    is( 5 ) );
+        assertThat( record.getParsedElement().getQueryableProperties().getKeywords().get( 0 ).getKeywords(),
+                    hasItems( "infoCoverageAccessService", "subsurface", "geology", "Netherlands", "3D model" ) );
+        assertThat( record.getParsedElement().getQueryableProperties().getServiceType(), is( "other" ) );
+    }
+
 }

--- a/deegree-core/deegree-core-metadata/src/test/resources/org/deegree/metadata/iso/sds-example.xml
+++ b/deegree-core/deegree-core-metadata/src/test/resources/org/deegree/metadata/iso/sds-example.xml
@@ -1,0 +1,494 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2014 EUROPEAN UNION Licensed under the EUPL,
+Version 1.1  or - as soon they will be approved by the European Commission -
+subsequent versions of the EUPL (the "Licence"); You may not use this work
+except in compliance with the Licence. You may obtain a copy of the Licence
+at:
+
+http://ec.europa.eu/idabc/eupl
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the Licence is distributed on an "AS IS" basis, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+Licence for the specific language governing permissions and limitations under
+the Licence.
+
+Date: 12-03-2014
+-->
+<gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:sds="http://inspire.ec.europa.eu/schemas/inspire_sds/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://inspire.ec.europa.eu/schemas/inspire_sds/1.0 http://inspire-geoportal.ec.europa.eu/schemas/inspire/inspire_sds/1.0/inspire_sds.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>mysdsid1</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#LanguageCode" codeListValue="eng">eng</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:contact>
+    <gmd:CI_ResponsibleParty>
+      <gmd:organisationName>
+        <gco:CharacterString>TNO Geological Survey of the Netherlands</gco:CharacterString>
+      </gmd:organisationName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:address>
+            <gmd:CI_Address>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>info@dinoloket.nl</gco:CharacterString>
+              </gmd:electronicMailAddress>
+            </gmd:CI_Address>
+          </gmd:address>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:Date>2012-12-05</gco:Date>
+  </gmd:dateStamp>
+  <!--
+  <gmd:metadataStandardName>
+    <gco:CharacterString>INSPIRE Spatial Data Services Community Profile of ISO 19115:2005/19139</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+-->
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code>
+            <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/28992</gco:CharacterString>
+          </gmd:code>
+          <gmd:codeSpace>
+            <gco:CharacterString>EPSG</gco:CharacterString>
+          </gmd:codeSpace>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <sds:SV_ServiceIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Geo 3D Model service</gco:CharacterString>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2012-08-14</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>This Spatial Data Service supports various operations on the Digital Subsurface Models (Regis, DGM and GeoTop) provided by the Geological Survey of the Netherlands. There is for example an operation to create a “virtual borehole” through one of the subsurface models for any given location in the Netherlands. The result can either be returned as Xml data or as a graphical representation. There is also supported for creating a VerticalSection a depthSection and many others. All operations and returned values are in the EPSG:28992 (RDNew)  coordinate reference system. The models have a resolution of 100x100 meters horizontally and have varying vertical resolutions. </gco:CharacterString>
+      </gmd:abstract>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:organisationName>
+            <gco:CharacterString>Geological Survey of the Netherlands</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>info@dinoloket.nl</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>infoCoverageAccessService</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>subsurface</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>geology</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>Netherlands</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>3D model</gco:CharacterString>
+          </gmd:keyword>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>Creative Commons Free Culture.</gco:CharacterString>
+          </gmd:useLimitation>
+        </gmd:MD_Constraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints>
+          <gmd:useLimitation>
+            <gmx:Anchor xlink:href="http://creativecommons.org/licenses/by/3.0/deed.nl">Creative Commons - Attribution 3.0 Unported</gmx:Anchor>
+          </gmd:useLimitation>
+        </gmd:MD_Constraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
+          </gmd:accessConstraints>
+          <gmd:otherConstraints>
+            <gco:CharacterString>no limitations</gco:CharacterString>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <srv:serviceType>
+        <gco:LocalName>other</gco:LocalName>
+      </srv:serviceType>
+      <srv:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>3.047</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>50.670</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>7.276</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>53.612</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </srv:extent>
+      <!--Added with respect to base example-->
+      <srv:extent>
+        <gmd:EX_Extent>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimeInstant gml:id="id1">
+                  <gml:timePosition>2012</gml:timePosition>
+                </gml:TimeInstant>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </srv:extent>
+      <srv:couplingType gco:nilReason="missing"/>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>sampleColumn</gco:CharacterString>
+          </srv:operationName>
+          <srv:DCP>
+            <srv:DCPList codeList="http://someurl#DCPList" codeListValue="HTTPGet"/>
+          </srv:DCP>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName>
+                  <gco:CharacterString>model</gco:CharacterString>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName>
+                      <gco:CharacterString>CharacterString</gco:CharacterString>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:direction>
+                <srv:SV_ParameterDirection>in</srv:SV_ParameterDirection>
+              </srv:direction>
+              <srv:optionality>
+                <gco:CharacterString>required</gco:CharacterString>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>false</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>string</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName>
+                  <gco:CharacterString>xCoordinate</gco:CharacterString>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName>
+                      <gco:CharacterString>CharacterString</gco:CharacterString>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:direction>
+                <srv:SV_ParameterDirection>in</srv:SV_ParameterDirection>
+              </srv:direction>
+              <srv:optionality>
+                <gco:CharacterString>required</gco:CharacterString>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>false</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>double</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName>
+                  <gco:CharacterString>yCoordinate</gco:CharacterString>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName>
+                      <gco:CharacterString>CharacterString</gco:CharacterString>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:direction>
+                <srv:SV_ParameterDirection>in</srv:SV_ParameterDirection>
+              </srv:direction>
+              <srv:optionality>
+                <gco:CharacterString>required</gco:CharacterString>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>false</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>double</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName>
+                  <gco:CharacterString>resolution</gco:CharacterString>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName>
+                      <gco:CharacterString>CharacterString</gco:CharacterString>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:direction>
+                <srv:SV_ParameterDirection>in</srv:SV_ParameterDirection>
+              </srv:direction>
+              <srv:optionality>
+                <gco:CharacterString>required</gco:CharacterString>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>false</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>int</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:parameters>
+            <srv:SV_Parameter>
+              <srv:name>
+                <gco:aName>
+                  <gco:CharacterString>coordinateSystem</gco:CharacterString>
+                </gco:aName>
+                <gco:attributeType>
+                  <gco:TypeName>
+                    <gco:aName>
+                      <gco:CharacterString>CharacterString</gco:CharacterString>
+                    </gco:aName>
+                  </gco:TypeName>
+                </gco:attributeType>
+              </srv:name>
+              <srv:direction>
+                <srv:SV_ParameterDirection>in</srv:SV_ParameterDirection>
+              </srv:direction>
+              <srv:optionality>
+                <gco:CharacterString>optional</gco:CharacterString>
+              </srv:optionality>
+              <srv:repeatability>
+                <gco:Boolean>false</gco:Boolean>
+              </srv:repeatability>
+              <srv:valueType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>AvailableCoordinateSystemType</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </srv:valueType>
+            </srv:SV_Parameter>
+          </srv:parameters>
+          <srv:connectPoint>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://www.dinoservices.nl:80/geo3dmodelwebservices-1/Geo3DModelService</gmd:URL>
+              </gmd:linkage>
+            </gmd:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:operatesOn xlink:href="http://www.dinoservices.nl"/>
+      <sds:qualityOfService>
+        <sds:SV_QualityOfService>
+          <sds:criterion>
+            <sds:SV_QualityOfServiceCriteria>performance</sds:SV_QualityOfServiceCriteria>
+          </sds:criterion>
+          <sds:unit>
+            <gco:CharacterString>seconds</gco:CharacterString>
+          </sds:unit>
+          <sds:value>
+            <gco:CharacterString>1.457</gco:CharacterString>
+          </sds:value>
+          <sds:measurementDescription>
+            <gco:CharacterString>Average response time in seconds</gco:CharacterString>
+          </sds:measurementDescription>
+        </sds:SV_QualityOfService>
+        <sds:SV_QualityOfService>
+          <sds:criterion>
+            <sds:SV_QualityOfServiceCriteria>availability</sds:SV_QualityOfServiceCriteria>
+          </sds:criterion>
+          <sds:unit>
+            <gco:CharacterString>percentage of time</gco:CharacterString>
+          </sds:unit>
+          <sds:value>
+            <gco:CharacterString>99.0</gco:CharacterString>
+          </sds:value>
+          <sds:measurementDescription>
+            <gco:CharacterString>Availability on yearly basis, expressed as percentage of time</gco:CharacterString>
+          </sds:measurementDescription>
+        </sds:SV_QualityOfService>
+        <sds:SV_QualityOfService>
+          <sds:criterion>
+            <sds:SV_QualityOfServiceCriteria>capacity</sds:SV_QualityOfServiceCriteria>
+          </sds:criterion>
+          <sds:unit>
+            <gco:CharacterString>number of requests per second</gco:CharacterString>
+          </sds:unit>
+          <sds:value>
+            <gco:CharacterString>20</gco:CharacterString>
+          </sds:value>
+          <sds:measurementDescription>
+            <gco:CharacterString>Maximum number of simultaneous requests per second meeting the performance criteria</gco:CharacterString>
+          </sds:measurementDescription>
+        </sds:SV_QualityOfService>
+      </sds:qualityOfService>
+      <sds:category>invocable</sds:category>
+    </sds:SV_ServiceIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://www.dinoservices.nl/geo3dmodelwebservices-1/Geo3DModelService</gmd:URL>
+              </gmd:linkage>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://inspire.ec.europa.eu/draft-schemas/resources/Codelist/gmxCodelist.xml#INSPIRE_CI_OnLineFunctionCode" codeListValue="accessPoint-selfDescribing">accessPoint- selfDescribing</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://link-to/get-service-metadata</gmd:URL>
+              </gmd:linkage>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://inspire.ec.europa.eu/draft-schemas/resources/Codelist/gmxCodelist.xml#INSPIRE_CI_OnLineFunctionCode" codeListValue="providesServiceMetadata">providesServiceMetadata</gmd:CI_OnLineFunctionCode>
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="service">service</gmd:MD_ScopeCode>
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:report>
+        <gmd:DQ_DomainConsistency xsi:type="gmd:DQ_DomainConsistency_Type">
+          <gmd:result>
+            <gmd:DQ_ConformanceResult xsi:type="gmd:DQ_ConformanceResult_Type">
+              <gmd:specification>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>invocable</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:date>
+                    <gmd:CI_Date>
+                      <gmd:date>
+                        <gco:Date>2010-12-08</gco:Date>
+                      </gmd:date>
+                      <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                      </gmd:dateType>
+                    </gmd:CI_Date>
+                  </gmd:date>
+                </gmd:CI_Citation>
+              </gmd:specification>
+              <gmd:explanation>
+                <gco:CharacterString>See the referenced specification</gco:CharacterString>
+              </gmd:explanation>
+              <gmd:pass>
+                <gco:Boolean>true</gco:Boolean>
+              </gmd:pass>
+            </gmd:DQ_ConformanceResult>
+          </gmd:result>
+        </gmd:DQ_DomainConsistency>
+      </gmd:report>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</gmd:MD_Metadata>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOMetadataStore.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOMetadataStore.java
@@ -188,6 +188,7 @@ public class ISOMetadataStore implements MetadataStore<ISORecord> {
                 // TODO: namespace bindings configured by the user!?
                 NamespaceBindings namespaceContext = CommonNamespaces.getNamespaceContext();
                 namespaceContext.addNamespace( CSWConstants.SRV_PREFIX, CSWConstants.SRV_NS );
+                namespaceContext.addNamespace( CSWConstants.SDS_PREFIX, CSWConstants.SDS_NS );
                 XPath xpath = new XPath( qp.getXpath(), namespaceContext );
                 List<Name> name = qp.getName();
                 List<QName> names = new ArrayList<QName>();
@@ -314,11 +315,11 @@ public class ISOMetadataStore implements MetadataStore<ISORecord> {
     public ResourceMetadata<? extends Resource> getMetadata() {
         return metadata;
     }
-    
+
     private QueryService getReadOnlySqlService()
                             throws MetadataStoreException {
         ServiceManager serviceManager = ServiceManagerProvider.getInstance().getServiceManager();
         return serviceManager.getQueryService( dialect, queryables );
     }
-    
+
 }

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/FIInspector.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/FIInspector.java
@@ -35,6 +35,8 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.metadata.iso.persistence.inspectors;
 
+import static org.deegree.protocol.csw.CSWConstants.SDS_NS;
+import static org.deegree.protocol.csw.CSWConstants.SDS_PREFIX;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.sql.Connection;
@@ -80,6 +82,7 @@ public class FIInspector implements RecordInspector<ISORecord> {
         nsContext.addNamespace( "srv", "http://www.isotc211.org/2005/srv" );
         nsContext.addNamespace( "gmd", "http://www.isotc211.org/2005/gmd" );
         nsContext.addNamespace( "gco", "http://www.isotc211.org/2005/gco" );
+        nsContext.addNamespace( SDS_PREFIX, SDS_NS );
     }
 
     /**
@@ -146,13 +149,12 @@ public class FIInspector implements RecordInspector<ISORecord> {
                                                              new XPath( "./gmd:fileIdentifier/gco:CharacterString",
                                                                         nsContext ) );
 
-        OMElement sv_service_OR_md_dataIdentification = a.getElement( rootEl,
-                                                                      new XPath(
-                                                                                 "./gmd:identificationInfo/srv:SV_ServiceIdentification | ./gmd:identificationInfo/gmd:MD_DataIdentification",
-                                                                                 nsContext ) );
-        String dataIdentificationId = sv_service_OR_md_dataIdentification.getAttributeValue( new QName( "id" ) );
-        String dataIdentificationUuId = sv_service_OR_md_dataIdentification.getAttributeValue( new QName( "uuid" ) );
-        List<OMElement> identifier = a.getElements( sv_service_OR_md_dataIdentification,
+        String identificationInfoXPathExpr = "./gmd:identificationInfo/srv:SV_ServiceIdentification | ./gmd:identificationInfo/gmd:MD_DataIdentification"
+                                             + " | ./gmd:identificationInfo/sds:SV_ServiceIdentification";
+        OMElement identificationInfo = a.getElement( rootEl, new XPath( identificationInfoXPathExpr, nsContext ) );
+        String dataIdentificationId = identificationInfo.getAttributeValue( new QName( "id" ) );
+        String dataIdentificationUuId = identificationInfo.getAttributeValue( new QName( "uuid" ) );
+        List<OMElement> identifier = a.getElements( identificationInfo,
                                                     new XPath( "./gmd:citation/gmd:CI_Citation/gmd:identifier",
                                                                nsContext ) );
         List<String> resourceIdentifierList = new ArrayList<String>();

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/TransactionHandler.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/TransactionHandler.java
@@ -196,7 +196,7 @@ public class TransactionHandler {
                 String msg = "Transaction operation '" + currentHandle + "' failed: " + e.getMessage();
                 throw new OWSException( msg, OWSException.NO_APPLICABLE_CODE );
             }
-            throw new OWSException( e.getMessage(), OWSException.NO_APPLICABLE_CODE );
+            throw new OWSException( e.getMessage(), e, OWSException.NO_APPLICABLE_CODE );
         }
 
         writer.writeStartElement( CSW_202_NS, "totalInserted" );


### PR DESCRIPTION
This pull requests adds the support of metadata records describing INSPIRE Spatial Data Service (TG for INSPIRE Spatial Data Services, v 3.1: ​​http://inspire.ec.europa.eu/documents/Spatial_Data_Services/TG_for_INSPIRE_SDS_3_1.pdf).

Metadata records describing INSPIRE Spatial Data Service as specified in ​http://inspire-geoportal.ec.europa.eu/schemas/inspire/inspire_sds/1.0/ can be inserted, removed and requested.