### PR TITLE
Updated dependencies for which security vulnerabilities have been reported

### DIFF
--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -60,6 +60,10 @@
       <artifactId>FastInfoset</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
     </dependency>

--- a/deegree-spring/pom.xml
+++ b/deegree-spring/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<deegree.module.status>ok</deegree.module.status>
-		<spring.version>3.2.3.RELEASE</spring.version>
+		<spring.version>3.2.15.RELEASE</spring.version>
 	</properties>
 
 	<dependencies>

--- a/deegree-workspaces/deegree-workspace-wps-jrxml/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wps-jrxml/pom.xml
@@ -54,6 +54,12 @@
     <dependency>
       <groupId>net.sf.jasperreports</groupId>
       <artifactId>jasperreports</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.lowagie</groupId>
+          <artifactId>itext</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>xalan</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -511,17 +511,17 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
+        <version>1.7.13</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.5</version>
+        <version>1.7.13</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>1.7.5</version>
+        <version>1.7.13</version>
       </dependency>
       <!-- 3d -->
       <dependency>
@@ -569,7 +569,7 @@
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-impl</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15</version>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.woodstox</groupId>
@@ -584,7 +584,7 @@
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-api</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -606,7 +606,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.6</version>
         <exclusions>
           <exclusion>
             <groupId>dom4j</groupId>
@@ -851,7 +851,7 @@
       <dependency>
         <groupId>com.lowagie</groupId>
         <artifactId>itext</artifactId>
-        <version>4.2.2</version>
+        <version>4.2.1</version>
       </dependency>
       <!-- CITE -->
       <dependency>
@@ -973,12 +973,12 @@
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>
         <artifactId>imageio-ext-utilities</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.9</version>
       </dependency>
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>
         <artifactId>imageio-ext-tiff</artifactId>
-        <version>1.1.7</version>
+        <version>1.1.9</version>
         <exclusions>
           <exclusion>
             <groupId>javax.media</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -341,14 +341,19 @@
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito</artifactId>
-        <version>1.6.2</version>
+        <version>1.6.3</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>3.20.0-GA</version>
       </dependency>
       <dependency>
         <groupId>org.xmlmatchers</groupId>
@@ -402,13 +407,12 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3</version>
+        <version>1.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.2.3</version>
-        <scope>compile</scope>
+        <version>4.3.6</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -635,7 +639,7 @@
       <dependency>
         <groupId>xalan</groupId>
         <artifactId>xalan</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -847,7 +851,7 @@
       <dependency>
         <groupId>com.lowagie</groupId>
         <artifactId>itext</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.2</version>
       </dependency>
       <!-- CITE -->
       <dependency>
@@ -1167,6 +1171,18 @@
           <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>1.3.1</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
The following direct or transitive dependencies had security vulnerabilities as documented by the  [Open Web Application Security Project (OWASP)] (https://www.owasp.org/index.php/Main_Page):
 * org.springframework:spring-context:3.2.3.RELEASE
 * org.apache.httpcomponents: httpclient: 4.2.3
 * xalan: xalan:2.7.1
 * com.lowagie: itext: 4.2.0
 * org.powermock:powermock-module-junit4:1.6.2 used outdated org.javassist: javassist

This PR updates all those dependencies and adds the maven ```dependency-check-maven```plugin to create the report. 