### PR TITLE
Fixed DimensionConfigBuilder to use defaultList for other dimensions

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/DimensionConfigBuilder.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/DimensionConfigBuilder.java
@@ -157,8 +157,8 @@ public class DimensionConfigBuilder {
             boolean nearest = ( type.isNearestValue() != null ) && type.isNearestValue();
             boolean multiple = ( type.isMultipleValues() != null ) && type.isMultipleValues();
             Dimension<Object> dim;
-            dim = new Dimension<Object>( type.getName(), (List<?>) parseTyped( type.getDefaultValue(), false ), false,
-                                         nearest, multiple, type.getUnits(), type.getUnitSymbol(), type.getSource(),
+            dim = new Dimension<Object>( type.getName(), (List<?>) parseTyped( defaultList, false ), false, nearest,
+                                         multiple, type.getUnits(), type.getUnitSymbol(), type.getSource(),
                                          (List<?>) parseTyped( list, false ) );
             map.put( type.getName(), dim );
         } catch ( ParseException e ) {


### PR DESCRIPTION
Setup:
 * deegree WMS is used which has a dimension configured in the layer configuration.
 * The configured dimension is not "time" or "elevation" but a custom other dimension.
 * A default value is configured for the custom other dimension.

Before this fix an error occurred during startup of deegree (or workspace reload).
Exception:
```
Could not parse layer configuration file: java.lang.String cannot be cast to java.util.List
```