### PR TITLE
Fixed exception code if unknown FeatureType is inserted by WFS 2.0.0 transaction

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/ows/exception/OWSException.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/ows/exception/OWSException.java
@@ -60,16 +60,22 @@ public class OWSException extends Exception {
      * a required parameter is missing
      */
     public static final String MISSING_PARAMETER_VALUE = "MissingParameterValue";
-    
+
     /**
      * Server processing failed
      */
     public static final String OPERATION_PROCESSING_FAILED = "OperationProcessingFailed";
-            
+
     /**
      * the parameter value is invalid
      */
     public static final String INVALID_PARAMETER_VALUE = "InvalidParameterValue";
+
+    /**
+     * A Transaction (see Clause 15) has attempted to insert or change the value of a data component in a way that
+     * violates the schema of the feature. (WFS 2.0.0, Table 3 - WFS exception codes)
+     */
+    public static final String INVALID_VALUE = "InvalidValue";
 
     /**
      * the parameter value of the format parameter is invalid
@@ -132,7 +138,7 @@ public class OWSException extends Exception {
      * exception code for all not known exceptions
      */
     public static final String NO_APPLICABLE_CODE = "NoApplicableCode";
-        
+
     private final String exceptionCode;
 
     private final String locator;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -407,6 +407,14 @@ class TransactionHandler {
             for ( String newFid : newFids ) {
                 inserted.add( newFid, insert.getHandle() );
             }
+        } catch ( XMLParsingException e ) {
+            String exceptionCode = INVALID_PARAMETER_VALUE;
+            if ( VERSION_200.equals( request.getVersion() ) ) {
+                exceptionCode = OWSException.INVALID_VALUE;
+            }
+            LOG.debug( e.getMessage(), e );
+            String msg = "Cannot perform insert operation: " + e.getMessage();
+            throw new OWSException( msg, exceptionCode );
         } catch ( Exception e ) {
             LOG.debug( e.getMessage(), e );
             String msg = "Cannot perform insert operation: " + e.getMessage();


### PR DESCRIPTION
An InvalidValues exception should be thrown by WFS 2.0.0  transaction if unknown FeatureType is inserted:
 * WFS 2.0.0 Specification, Table 3 - WFS exception codes, P.16:
  * InvalidValue: "A Transaction (see Clause 15) has attempted to insert or change the value of a data component in a way that violates the schema of the feature."

This fix changes the exception code to "InvalidValues" if an unknown FeatureType is inserted by WFS 2.0.0 transaction.