### PR TITLE
Fixed BBOX of first layer in WMS capabilities

### DIFF
--- a/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/metadata/SpatialMetadataTest.java
+++ b/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/metadata/SpatialMetadataTest.java
@@ -1,0 +1,179 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.geometry.metadata;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.exceptions.UnknownCRSException;
+import org.deegree.cs.persistence.CRSManager;
+import org.deegree.geometry.Envelope;
+import org.deegree.geometry.SimpleGeometryFactory;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class SpatialMetadataTest {
+
+    private static final SimpleGeometryFactory GEOM_FACTORY = new SimpleGeometryFactory();
+
+    @Test
+    public void testMerge_Null()
+                            throws Exception {
+        SpatialMetadata spatialMetadata = new SpatialMetadata( firstEnvelope(), firstCrsList() );
+
+        SpatialMetadata merged = spatialMetadata.merge( null );
+
+        assertThat( merged.getEnvelope(), isEnvelope( firstEnvelope() ) );
+        assertThat( merged.getCoordinateSystems(), is( firstCrsList() ) );
+    }
+
+    @Test
+    public void testMerge_EnvelopeNullInSource()
+                            throws Exception {
+        SpatialMetadata spatialMetadata = new SpatialMetadata( null, firstCrsList() );
+
+        SpatialMetadata merged = spatialMetadata.merge( new SpatialMetadata( firstEnvelope(), firstCrsList() ) );
+
+        assertThat( merged.getEnvelope(), isEnvelope( firstEnvelope() ) );
+        assertThat( merged.getCoordinateSystems(), is( firstCrsList() ) );
+    }
+
+    @Test
+    public void testMerge_CrsNullInSource()
+                            throws Exception {
+        SpatialMetadata spatialMetadata = new SpatialMetadata( firstEnvelope(), null );
+
+        SpatialMetadata merged = spatialMetadata.merge( new SpatialMetadata( firstEnvelope(), firstCrsList() ) );
+
+        assertThat( merged.getEnvelope(), isEnvelope( firstEnvelope() ) );
+        assertThat( merged.getCoordinateSystems(), is( firstCrsList() ) );
+    }
+
+    @Test
+    public void testMerge_EnvelopesDifferent()
+                            throws Exception {
+        SpatialMetadata spatialMetadata = new SpatialMetadata( firstEnvelope(), firstCrsList() );
+
+        SpatialMetadata merged = spatialMetadata.merge( new SpatialMetadata( secondEnvelope(), firstCrsList() ) );
+
+        assertThat( merged.getEnvelope(), isEnvelope( firstEnvelope().merge( secondEnvelope() ) ) );
+        assertThat( merged.getCoordinateSystems(), is( firstCrsList() ) );
+    }
+
+    @Test
+    public void testMerge_CrsListDifferent()
+                            throws Exception {
+        SpatialMetadata spatialMetadata = new SpatialMetadata( firstEnvelope(), firstCrsList() );
+
+        SpatialMetadata merged = spatialMetadata.merge( new SpatialMetadata( firstEnvelope(), secondCrsList() ) );
+
+        assertThat( merged.getEnvelope(), isEnvelope( firstEnvelope() ) );
+        assertThat( merged.getCoordinateSystems(), hasItems( firstCrsList().toArray( new ICRS[] {} ) ) );
+        assertThat( merged.getCoordinateSystems(), hasItems( secondCrsList().toArray( new ICRS[] {} ) ) );
+    }
+
+    @Test
+    public void testMerge_CheckMergedAreUntouched()
+                            throws Exception {
+        SpatialMetadata spatialMetadata = new SpatialMetadata( firstEnvelope(), firstCrsList() );
+        SpatialMetadata spatialMetadataToMerge = new SpatialMetadata( secondEnvelope(), secondCrsList() );
+        SpatialMetadata merged = spatialMetadata.merge( spatialMetadataToMerge );
+
+        assertThat( spatialMetadata.getEnvelope(), isEnvelope( firstEnvelope() ) );
+        assertThat( spatialMetadata.getCoordinateSystems(), is( firstCrsList() ) );
+
+        assertThat( spatialMetadataToMerge.getEnvelope(), isEnvelope( secondEnvelope() ) );
+        assertThat( spatialMetadataToMerge.getCoordinateSystems(), is( secondCrsList() ) );
+
+        assertThat( merged.getEnvelope(), isEnvelope( firstEnvelope().merge( secondEnvelope() ) ) );
+        assertThat( merged.getCoordinateSystems(), hasItems( firstCrsList().toArray( new ICRS[] {} ) ) );
+        assertThat( merged.getCoordinateSystems(), hasItems( secondCrsList().toArray( new ICRS[] {} ) ) );
+    }
+
+    private Envelope firstEnvelope()
+                            throws UnknownCRSException {
+        return GEOM_FACTORY.createEnvelope( 10, 53, 11, 54, CRSManager.lookup( "EPSG:4326" ) );
+    }
+
+    private Envelope secondEnvelope()
+                            throws UnknownCRSException {
+        return GEOM_FACTORY.createEnvelope( 10, 52, 11, 54, CRSManager.lookup( "EPSG:4326" ) );
+    }
+
+    private List<ICRS> firstCrsList()
+                            throws UnknownCRSException {
+        return asCrsList( "EPSG:4326", "EPSG:25833" );
+    }
+
+    private List<ICRS> secondCrsList()
+                            throws UnknownCRSException {
+        return asCrsList( "EPSG:900913" );
+    }
+
+    private List<ICRS> asCrsList( String... crsNames )
+                            throws UnknownCRSException {
+        List<ICRS> crs = new ArrayList<ICRS>();
+        for ( String crsName : crsNames ) {
+            crs.add( CRSManager.lookup( crsName ) );
+        }
+        return crs;
+    }
+
+    private Matcher<Envelope> isEnvelope( final Envelope envelope ) {
+        return new BaseMatcher<Envelope>() {
+            @Override
+            public boolean matches( Object item ) {
+                Envelope itemEnvelope = (Envelope) item;
+                return itemEnvelope.equals( envelope );
+            }
+
+            @Override
+            public void describeTo( Description description ) {
+                description.appendText( "Expected: " + envelope );
+            }
+        };
+    }
+}

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/metadata/LayerMetadata.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/metadata/LayerMetadata.java
@@ -89,7 +89,7 @@ public class LayerMetadata {
     private List<Pair<String, String>> authorities = new ArrayList<Pair<String, String>>();
 
     private boolean requestable = true;
-    
+
     public LayerMetadata( String name, Description description, SpatialMetadata spatialMetadata ) {
         this.name = name;
         this.description = description;
@@ -172,8 +172,8 @@ public class LayerMetadata {
         if ( mapOptions == null ) {
             return true;
         }
-        
-        //TRICKY assume that, the service is query able by default (<0) 
+
+        // TRICKY assume that, the service is query able by default (<0)
         return mapOptions.getFeatureInfoRadius() != 0;
     }
 
@@ -214,35 +214,6 @@ public class LayerMetadata {
         this.spatialMetadata = spatialMetadata;
     }
 
-    private void mergeDescription( Description desc ) {
-        if ( desc != null ) {
-            if ( description.getTitles() == null || description.getTitles().isEmpty() ) {
-                description.setTitles( desc.getTitles() );
-            }
-            if ( description.getAbstracts() == null || description.getAbstracts().isEmpty() ) {
-                description.setAbstracts( desc.getAbstracts() );
-            }
-            if ( description.getKeywords() == null || description.getKeywords().isEmpty() ) {
-                description.setKeywords( desc.getKeywords() );
-            }
-        }
-    }
-
-    private void mergeSpatialMetadata( SpatialMetadata smd ) {
-        if ( smd != null ) {
-            if ( spatialMetadata.getCoordinateSystems() == null || spatialMetadata.getCoordinateSystems().isEmpty() ) {
-                spatialMetadata.setCoordinateSystems( smd.getCoordinateSystems() );
-            }
-            if ( spatialMetadata.getEnvelope() == null ) {
-                spatialMetadata.setEnvelope( smd.getEnvelope() );
-            } else {
-                if ( smd.getEnvelope() != null ) {
-                    spatialMetadata.setEnvelope( spatialMetadata.getEnvelope().merge( smd.getEnvelope() ) );
-                }
-            }
-        }
-    }
-
     /**
      * Copies any fields from md which are currently not set (applies to description and spatial metadata only).
      * 
@@ -257,10 +228,12 @@ public class LayerMetadata {
         } else {
             mergeDescription( md.getDescription() );
         }
-        if ( spatialMetadata == null ) {
-            spatialMetadata = md.getSpatialMetadata();
-        } else {
-            mergeSpatialMetadata( md.getSpatialMetadata() );
+        if ( spatialMetadata == null && md.getSpatialMetadata() != null ) {
+            spatialMetadata = new SpatialMetadata( md.getSpatialMetadata() );
+        } else if ( spatialMetadata != null && md.getSpatialMetadata() == null ) {
+            spatialMetadata = new SpatialMetadata( spatialMetadata );
+        } else if ( spatialMetadata != null && md.getSpatialMetadata() != null ) {
+            spatialMetadata = this.spatialMetadata.merge( md.getSpatialMetadata() );
         }
     }
 
@@ -397,6 +370,25 @@ public class LayerMetadata {
      */
     public void setAuthorities( List<Pair<String, String>> authorities ) {
         this.authorities = authorities;
+    }
+
+    private void mergeDescription( Description desc ) {
+        if ( desc != null ) {
+            if ( description.getTitles() == null || description.getTitles().isEmpty() ) {
+                description.setTitles( desc.getTitles() );
+            }
+            if ( description.getAbstracts() == null || description.getAbstracts().isEmpty() ) {
+                description.setAbstracts( desc.getAbstracts() );
+            }
+            if ( description.getKeywords() == null || description.getKeywords().isEmpty() ) {
+                description.setKeywords( desc.getKeywords() );
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "LayerMetadata [description=" + description + ", spatialMetadata=" + spatialMetadata + ", ...]";
     }
 
 }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
@@ -61,7 +61,6 @@ import org.deegree.commons.utils.Pair;
 import org.deegree.commons.xml.stax.XMLStreamUtils;
 import org.deegree.geometry.metadata.SpatialMetadata;
 import org.deegree.layer.dims.Dimension;
-import org.deegree.layer.metadata.LayerMetadata;
 import org.deegree.protocol.wms.WMSConstants;
 import org.deegree.services.metadata.OWSMetadataProvider;
 import org.deegree.services.wms.MapService;
@@ -208,18 +207,13 @@ public class Capabilities130XMLAdapter {
             writeElement( writer, WMSNS, "Title", "Root" );
 
             // TODO think about a push approach instead of a pull approach
-            LayerMetadata lmd = null;
+            SpatialMetadata smd = new SpatialMetadata( null, null );
             for ( Theme t : themes ) {
                 for ( org.deegree.layer.Layer l : Themes.getAllLayers( t ) ) {
-                    if ( lmd == null ) {
-                        lmd = l.getMetadata();
-                    } else {
-                        lmd.merge( l.getMetadata() );
-                    }
+                    smd.merge( l.getMetadata().getSpatialMetadata() );
                 }
             }
-            if ( lmd != null ) {
-                SpatialMetadata smd = lmd.getSpatialMetadata();
+            if ( smd != null ) {
                 writeSrsAndEnvelope( writer, smd.getCoordinateSystems(), smd.getEnvelope() );
             }
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataMerger.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataMerger.java
@@ -61,13 +61,13 @@ import org.deegree.theme.Themes;
  * @since 3.3
  */
 class LayerMetadataMerger {
-    
+
     private static final int QUERYABLE_DEFAULT_MASK = 1;
-    
+
     private static final int QUERYABLE_DISABLED_MASK = 2;
-    
+
     private static final int QUERYABLE_ENABLED_MASK = 4;
-    
+
     /**
      * Returns the combined layer metadata for the given theme/sublayers.
      *
@@ -79,31 +79,26 @@ class LayerMetadataMerger {
      */
     LayerMetadata merge( final Theme theme ) {
         final LayerMetadata themeMetadata = theme.getLayerMetadata();
-        LayerMetadata layerMetadata = null;
-        
+        LayerMetadata layerMetadata = new LayerMetadata( null, null, null );
+
         int queryable = 0;
-        
+
         for ( final Layer l : Themes.getAllLayers( theme ) ) {
             queryable |= analyseQueryable( l.getMetadata() );
-            
-            if ( layerMetadata == null ) {
-                layerMetadata = l.getMetadata();
-            } else {
-                layerMetadata.merge( l.getMetadata() );
-            }
+            layerMetadata.merge( l.getMetadata() );
         }
         themeMetadata.merge( layerMetadata );
-        
+
         if ( themeMetadata.getMapOptions() == null ) {
             themeMetadata.setMapOptions( new MapOptions( null, null, null, -1, -1 ) );
         }
-        
+
         if ( queryable == QUERYABLE_DISABLED_MASK ) {
             themeMetadata.getMapOptions().setFeatureInfoRadius( 0 );
         } else {
             themeMetadata.getMapOptions().setFeatureInfoRadius( -1 );
         }
-            
+
         return themeMetadata;
     }
 
@@ -144,9 +139,9 @@ class LayerMetadataMerger {
     private int analyseQueryable( LayerMetadata m ) {
         if ( m.getMapOptions() == null )
             return QUERYABLE_DEFAULT_MASK;
-        
+
         int r = m.getMapOptions().getFeatureInfoRadius();
-        
+
         if ( r < 0 )
             return QUERYABLE_DEFAULT_MASK;
         else if ( r == 0 )


### PR DESCRIPTION
Previously, the BBOX of the first requestable layer was identical to the BBOX of the root layer.

This pull request fixes this issue and now the first layer has its own, (according to the data) correct BBOX.