### PR TITLE
Fixed handling of GetFeatureWithLock requests and resultType 'hits' (according the WFS 2.0.0 specification)

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -125,6 +125,7 @@ import org.deegree.protocol.wfs.describefeaturetype.DescribeFeatureType;
 import org.deegree.protocol.wfs.describefeaturetype.kvp.DescribeFeatureTypeKVPAdapter;
 import org.deegree.protocol.wfs.describefeaturetype.xml.DescribeFeatureTypeXMLAdapter;
 import org.deegree.protocol.wfs.getfeature.GetFeature;
+import org.deegree.protocol.wfs.getfeature.ResultType;
 import org.deegree.protocol.wfs.getfeature.kvp.GetFeatureKVPAdapter;
 import org.deegree.protocol.wfs.getfeature.xml.GetFeatureXMLAdapter;
 import org.deegree.protocol.wfs.getfeaturewithlock.GetFeatureWithLock;
@@ -896,6 +897,7 @@ public class WebFeatureService extends AbstractOWS {
                 GetFeatureWithLockXMLAdapter getFeatureWithLockAdapter = new GetFeatureWithLockXMLAdapter();
                 getFeatureWithLockAdapter.setRootElement( new XMLAdapter( xmlStream ).getRootElement() );
                 GetFeatureWithLock getFeatureWithLock = getFeatureWithLockAdapter.parse();
+                checkGetFeatureWithLockRequest( getFeatureWithLock );
                 updateResolveTimeOut( getFeatureWithLock.getResolveParams() );
                 format = determineFormat( requestVersion, getFeatureWithLock.getPresentationParams().getOutputFormat(),
                                           "outputFormat" );
@@ -1389,6 +1391,11 @@ public class WebFeatureService extends AbstractOWS {
                                     OWSException.INVALID_PARAMETER_VALUE );
         }
         return version;
+    }
+
+    private void checkGetFeatureWithLockRequest( GetFeatureWithLock getFeatureWithLock ) {
+        if ( getFeatureWithLock.getPresentationParams().getResultType() == ResultType.HITS )
+            throw new InvalidParameterValueException( "ResultType 'hits' is not specified in GetFeatureWithLock requests!" );
     }
 
 }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -59,6 +59,7 @@ import static org.deegree.protocol.wfs.WFSRequestType.GetPropertyValue;
 import static org.deegree.protocol.wfs.WFSRequestType.ListStoredQueries;
 import static org.deegree.protocol.wfs.WFSRequestType.LockFeature;
 import static org.deegree.protocol.wfs.WFSRequestType.Transaction;
+import static org.deegree.protocol.wfs.getfeature.ResultType.HITS;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -125,7 +126,6 @@ import org.deegree.protocol.wfs.describefeaturetype.DescribeFeatureType;
 import org.deegree.protocol.wfs.describefeaturetype.kvp.DescribeFeatureTypeKVPAdapter;
 import org.deegree.protocol.wfs.describefeaturetype.xml.DescribeFeatureTypeXMLAdapter;
 import org.deegree.protocol.wfs.getfeature.GetFeature;
-import org.deegree.protocol.wfs.getfeature.ResultType;
 import org.deegree.protocol.wfs.getfeature.kvp.GetFeatureKVPAdapter;
 import org.deegree.protocol.wfs.getfeature.xml.GetFeatureXMLAdapter;
 import org.deegree.protocol.wfs.getfeaturewithlock.GetFeatureWithLock;
@@ -897,7 +897,7 @@ public class WebFeatureService extends AbstractOWS {
                 GetFeatureWithLockXMLAdapter getFeatureWithLockAdapter = new GetFeatureWithLockXMLAdapter();
                 getFeatureWithLockAdapter.setRootElement( new XMLAdapter( xmlStream ).getRootElement() );
                 GetFeatureWithLock getFeatureWithLock = getFeatureWithLockAdapter.parse();
-                checkGetFeatureWithLockRequest( getFeatureWithLock );
+                checkGetFeatureWithLockRequest( requestVersion, getFeatureWithLock );
                 updateResolveTimeOut( getFeatureWithLock.getResolveParams() );
                 format = determineFormat( requestVersion, getFeatureWithLock.getPresentationParams().getOutputFormat(),
                                           "outputFormat" );
@@ -1393,9 +1393,11 @@ public class WebFeatureService extends AbstractOWS {
         return version;
     }
 
-    private void checkGetFeatureWithLockRequest( GetFeatureWithLock getFeatureWithLock ) {
-        if ( getFeatureWithLock.getPresentationParams().getResultType() == ResultType.HITS )
-            throw new InvalidParameterValueException( "ResultType 'hits' is not specified in GetFeatureWithLock requests!" );
+    private void checkGetFeatureWithLockRequest( Version requestVersion, GetFeatureWithLock getFeatureWithLock ) {
+        if ( VERSION_200.equals( requestVersion )
+             && HITS.equals( getFeatureWithLock.getPresentationParams().getResultType() ) )
+            throw new InvalidParameterValueException(
+                                                      "ResultType 'hits' is not allowed in GetFeatureWithLock requests!" );
     }
 
 }


### PR DESCRIPTION
In the WFS 2.0.0 the resultType parameter of GetFeatureWithLock requests is specified as follows (13.2.4.3
resultType parameter, p. 78):
```
The only valid value for the resultType attribute for a GetFeatureWithLock request shall 
be "results". If a client specifies a value of "hits" the server shall raise an 
InvalidParameterValue exception (see 7.5).
```
This pull requests fixes deegree WFS 2.0.0 to behave as specified and tested by the WFS 2.0.0 cite Testsuite (org.opengis.cite.iso19142.locking.GetFeatureWithLockTests, lockQueryResults_hits()).