### PR TITLE
Enhanced WMS to configure the UpdateSequence in the service configuration

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -96,19 +96,13 @@ public class MapService {
 
     private static final Logger LOG = getLogger( MapService.class );
 
-    /**
-     * 
-     */
     public StyleRegistry registry;
 
     MapOptionsMaps layerOptions = new MapOptionsMaps();
 
     MapOptions defaultLayerOptions;
 
-    /**
-     * The current update sequence.
-     */
-    public int updateSequence = 0; // TODO how to restore this after restart?
+    private int updateSequence; // TODO how to restore this after restart?
 
     private List<Theme> themes;
 
@@ -123,7 +117,9 @@ public class MapService {
      * @param adapter
      * @throws MalformedURLException
      */
-    public MapService( ServiceConfigurationType conf, Workspace workspace ) throws MalformedURLException {
+    public MapService( ServiceConfigurationType conf, Workspace workspace, int updateSequence )
+                            throws MalformedURLException {
+        this.updateSequence = updateSequence;
         this.registry = new StyleRegistry();
 
         MapServiceBuilder builder = new MapServiceBuilder( conf );
@@ -292,11 +288,11 @@ public class MapService {
                      || l.getMetadata().getScaleDenominators().second < scale ) {
                     continue;
                 }
-                
-                if (!l.getMetadata().isQueryable()) {
+
+                if ( !l.getMetadata().isQueryable() ) {
                     continue;
                 }
-                
+
                 list.add( l.infoQuery( query, headers ) );
             }
         }
@@ -373,7 +369,8 @@ public class MapService {
         return getLegendHandler.getLegendSize( style );
     }
 
-    public BufferedImage getLegend( GetLegendGraphic req ) throws OWSException {
+    public BufferedImage getLegend( GetLegendGraphic req )
+                            throws OWSException {
         return getLegendHandler.getLegend( req );
     }
 
@@ -396,6 +393,13 @@ public class MapService {
      */
     public int getGlobalMaxFeatures() {
         return defaultLayerOptions.getMaxFeatures();
+    }
+
+    /**
+     * @return the current update sequence
+     */
+    public int getCurrentUpdateSequence() {
+        return updateSequence;
     }
 
 }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -311,7 +311,9 @@ public class WMSController extends AbstractOWS {
             }
 
             ServiceConfigurationType sc = conf.getServiceConfiguration();
-            service = new MapService( sc, workspace );
+            int capabilitiesVersion = conf.getCapabilitiesVersion() != null ? conf.getCapabilitiesVersion().intValue()
+                                                                           : 0;
+            service = new MapService( sc, workspace, capabilitiesVersion );
 
             // after the service knows what layers are available:
             handleMetadata( conf.getMetadataURLTemplate(), conf.getMetadataStoreId() );

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -311,8 +311,7 @@ public class WMSController extends AbstractOWS {
             }
 
             ServiceConfigurationType sc = conf.getServiceConfiguration();
-            int capabilitiesVersion = conf.getCapabilitiesVersion() != null ? conf.getCapabilitiesVersion().intValue()
-                                                                           : 0;
+            int capabilitiesVersion = conf.getUpdateSequence() != null ? conf.getUpdateSequence().intValue() : 0;
             service = new MapService( sc, workspace, capabilitiesVersion );
 
             // after the service knows what layers are available:

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSControllerBase.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSControllerBase.java
@@ -103,11 +103,11 @@ public abstract class WMSControllerBase implements Controller {
         if ( updateSequence != null && updateSequence.trim().length() > 0 ) {
             try {
                 int seq = parseInt( updateSequence );
-                if ( seq > service.updateSequence ) {
+                if ( seq > service.getCurrentUpdateSequence() ) {
                     throw new OWSException( get( "WMS.INVALID_UPDATE_SEQUENCE", updateSequence ),
                                             OWSException.INVALID_UPDATE_SEQUENCE );
                 }
-                if ( seq == service.updateSequence ) {
+                if ( seq == service.getCurrentUpdateSequence() ) {
                     throw new OWSException( get( "WMS.CURRENT_UPDATE_SEQUENCE" ), OWSException.CURRENT_UPDATE_SEQUENCE );
                 }
             } catch ( NumberFormatException e ) {

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities111XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities111XMLAdapter.java
@@ -137,7 +137,7 @@ public class Capabilities111XMLAdapter extends XMLAdapter {
                          + "\" [<!ELEMENT VendorSpecificCapabilities EMPTY>]>\n" );
         writer.writeStartElement( "WMT_MS_Capabilities" );
         writer.writeAttribute( "version", "1.1.1" );
-        writer.writeAttribute( "updateSequence", "" + service.updateSequence );
+        writer.writeAttribute( "updateSequence", "" + service.getCurrentUpdateSequence() );
 
         metadataWriter.writeService( writer );
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
@@ -147,7 +147,7 @@ public class Capabilities130XMLAdapter {
         writer.setDefaultNamespace( WMSNS );
         writer.writeStartElement( WMSNS, "WMS_Capabilities" );
         writer.writeAttribute( "version", "1.3.0" );
-        writer.writeAttribute( "updateSequence", "" + service.updateSequence );
+        writer.writeAttribute( "updateSequence", "" + service.getCurrentUpdateSequence() );
         writer.writeDefaultNamespace( WMSNS );
         writer.writeNamespace( "xsi", XSINS );
         writer.writeNamespace( "xlink", XLNNS );

--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
@@ -21,7 +21,7 @@
             </sequence>
           </complexType>
         </element>
-        <element name="CapabilitiesVersion" type="integer" minOccurs="0" />
+        <element name="UpdateSequence" type="integer" minOccurs="0" />
         <!-- if set, it will be checked upon startup if metadata ids for layers actually exist -->
         <element name="MetadataStoreId" type="string" minOccurs="0" />
         <!-- if set, this template will be used for generating MetadataURL elements for layers (default is to use an internal 

--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
@@ -21,6 +21,7 @@
             </sequence>
           </complexType>
         </element>
+        <element name="CapabilitiesVersion" type="integer" minOccurs="0" />
         <!-- if set, it will be checked upon startup if metadata ids for layers actually exist -->
         <element name="MetadataStoreId" type="string" minOccurs="0" />
         <!-- if set, this template will be used for generating MetadataURL elements for layers (default is to use an internal 

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -375,6 +375,8 @@ The following table shows what top level options are available.
 +==========================+==============+=========+==============================================================================+
 | SupportedVersions        | 0..1         | Complex | Limits active OGC protocol versions                                          |
 +--------------------------+--------------+---------+------------------------------------------------------------------------------+
+| UpdateSequence           | 0..1         | Integer | Current update sequence, default: 0                                          |
++--------------------------+--------------+---------+------------------------------------------------------------------------------+
 | MetadataStoreId          | 0..1         | String  | Configures a metadata store to check if metadata ids for layers exist        |
 +--------------------------+--------------+---------+------------------------------------------------------------------------------+
 | MetadataURLTemplate      | 0..1         | String  | Template for generating URLs to feature type metadata                        |


### PR DESCRIPTION
This pull requests allows the user to set the sequence manually in the service configuration. In the following example the UpdateSequence was configured to 10, in the Capabilities this version is returned. If the configuration option is missing 0 is assumed and exported in the capabilities (old behaviour) 

Example:
```xml
<wms:deegreeWMS xmlns:wms="http://www.deegree.org/services/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dgws="http://www.deegree.org/webservices" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.2.0" xsi:schemaLocation="http://www.deegree.org/services/wms http://schemas.deegree.org/services/wms/3.2.0/wms_configuration.xsd">
    <wms:SupportedVersions>
        <wms:Version>1.3.0</wms:Version>
    </wms:SupportedVersions>
    <wms:UpdateSequence>10</wms:UpdateSequence>
...
```