### PR TITLE
Enhanced Filter200XmlDecoder to throw an Exception if a Literal with gml-Geometry subelement is parsed

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/Filter200XMLDecoder.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/Filter200XMLDecoder.java
@@ -70,6 +70,7 @@ import org.deegree.commons.tom.genericxml.GenericXMLElement;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.uom.Measure;
 import org.deegree.commons.utils.ArrayUtils;
+import org.deegree.commons.xml.CommonNamespaces;
 import org.deegree.commons.xml.NamespaceBindings;
 import org.deegree.commons.xml.XMLParsingException;
 import org.deegree.commons.xml.XPathUtils;
@@ -782,6 +783,7 @@ public class Filter200XMLDecoder {
         while ( xmlStream.next() != END_ELEMENT ) {
             int eventType = xmlStream.getEventType();
             if ( eventType == START_ELEMENT ) {
+                checkIfCurrentStartElementIsGmlGeometry( xmlStream );
                 children.add( parseElement( xmlStream ) );
             } else if ( eventType == CHARACTERS || eventType == CDATA ) {
                 children.add( new PrimitiveValue( xmlStream.getText() ) );
@@ -1166,6 +1168,17 @@ public class Filter200XMLDecoder {
         } catch ( Throwable t ) {
             t.printStackTrace();
             throw new XMLParsingException( xmlStream, t.getMessage() );
+        }
+    }
+
+    private static void checkIfCurrentStartElementIsGmlGeometry( XMLStreamReader xmlStream )
+                            throws XMLStreamException {
+        String ns = xmlStream.getNamespaceURI();
+        if ( CommonNamespaces.GMLNS.equals( ns ) || CommonNamespaces.GML3_2_NS.equals( ns ) ) {
+            GMLGeometryReader gmlReader = GMLGeometryVersionHelper.getGeometryReader( xmlStream.getName(), xmlStream );
+            boolean isGeometryElement = gmlReader.isGeometryOrEnvelopeElement( xmlStream );
+            if ( isGeometryElement )
+                throw new XMLParsingException( xmlStream, "Geometry elements as Literal child are not supported!" );
         }
     }
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/filter/xml/Filter200XMLDecoderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/filter/xml/Filter200XMLDecoderTest.java
@@ -36,7 +36,6 @@
 package org.deegree.filter.xml;
 
 import static org.junit.Assert.assertEquals;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,6 +50,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.deegree.commons.tom.primitive.PrimitiveValue;
+import org.deegree.commons.xml.XMLParsingException;
 import org.deegree.commons.xml.schema.RedirectingEntityResolver;
 import org.deegree.commons.xml.stax.XMLStreamUtils;
 import org.deegree.filter.Filter;
@@ -73,7 +73,6 @@ import org.deegree.workspace.standard.DefaultWorkspace;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
 
 /**
  * Tests the correct parsing of Filter Encoding 2.0.0 documents using the official examples (excluding filter
@@ -85,8 +84,6 @@ import org.slf4j.Logger;
  * @version $Revision$, $Date$
  */
 public class Filter200XMLDecoderTest {
-
-    private static final Logger LOG = getLogger( Filter200XMLDecoderTest.class );
 
     // files are not really fetched from this URL, but taken from cached version (module deegree-ogcschemas)
     private static final String OGC_EXAMPLES_BASE_URL = "http://schemas.opengis.net/filter/2.0/examples/";
@@ -329,6 +326,15 @@ public class Filter200XMLDecoderTest {
         for ( Filter filter : getFilters( "filter14.xml" ) ) {
             And and = (And) ( (OperatorFilter) filter ).getOperator();
         }
+    }
+
+    @Test(expected = XMLParsingException.class)
+    public void parsePropertyIsLessThanOrEuqlToWithLiteralContainingUnexpectedGeometry()
+                            throws Exception {
+        InputStream filterAsStream = this.getClass().getResourceAsStream( "v200/unexectedTestfilter.xml" );
+        XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader( filterAsStream );
+        XMLStreamUtils.skipStartDocument( xmlStream );
+        Filter200XMLDecoder.parse( xmlStream );
     }
 
     // @Test

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/filter/xml/v200/unexectedTestfilter.xml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/filter/xml/v200/unexectedTestfilter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fes:Filter xmlns:app="http://www.deegree.org/app" xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filter.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
+  <fes:PropertyIsLessThanOrEqualTo matchAction="All" matchCase="true">
+    <fes:ValueReference>app:name</fes:ValueReference>
+    <fes:Literal>
+      <gml:Envelope xmlns:gml="http://www.opengis.net/gml/3.2" srsName="urn:ogc:def:crs:EPSG::4326">
+        <gml:lowerCorner>-90 -180</gml:lowerCorner>
+        <gml:upperCorner>90 180</gml:upperCorner>
+      </gml:Envelope>
+    </fes:Literal>
+  </fes:PropertyIsLessThanOrEqualTo>
+</fes:Filter>

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -944,7 +944,10 @@ public class WebFeatureService extends AbstractOWS {
             sendServiceException( requestVersion, e, response );
         } catch ( XMLParsingException e ) {
             LOG.trace( "Stack trace:", e );
-            sendServiceException( requestVersion, new OWSException( e.getMessage(), INVALID_PARAMETER_VALUE ), response );
+            String exceptionCode = INVALID_PARAMETER_VALUE;
+            if ( VERSION_200.equals( requestVersion ) )
+                exceptionCode = OWSException.OPERATION_PROCESSING_FAILED;
+            sendServiceException( requestVersion, new OWSException( e.getMessage(), exceptionCode ), response );
         } catch ( MissingParameterException e ) {
             LOG.trace( "Stack trace:", e );
             sendServiceException( requestVersion, new OWSException( e ), response );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -794,6 +794,12 @@ public class WebFeatureService extends AbstractOWS {
             LOG.debug( "OWS-Exception: {}", e.getMessage() );
             LOG.trace( e.getMessage(), e );
             sendServiceException( requestVersion, e, response );
+        } catch ( XMLParsingException e ) {
+            LOG.trace( "Stack trace:", e );
+            String exceptionCode = INVALID_PARAMETER_VALUE;
+            if ( VERSION_200.equals( requestVersion ) )
+                exceptionCode = OWSException.OPERATION_PROCESSING_FAILED;
+            sendServiceException( requestVersion, new OWSException( e.getMessage(), exceptionCode ), response );
         } catch ( MissingParameterException e ) {
             LOG.debug( "OWS-Exception: {}", e.getMessage() );
             LOG.trace( e.getMessage(), e );


### PR DESCRIPTION
This pull requests lets the Filter200XmlDecoder throw an XMLParsingException if a Literal with gml-Geometry is detected. The handling of the WFS 2.0.0 is changed to throw an OperationProcessingFailed in case of a XMLParsingException.

The WFS 2.0.0 cite Testsuite is fixed by this pull request (Testclass org.opengis.cite.iso19142.basic.filter.ComparisonOperatorTests, Method invalidOperand_boundedBy()).