### PR TITLE
Fixes the groupId and artifactId for Tomcat Maven Plugin 

### DIFF
--- a/deegree-tests/deegree-compliance-tests/pom.xml
+++ b/deegree-tests/deegree-compliance-tests/pom.xml
@@ -112,8 +112,8 @@
           </plugin>
 
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>tomcat-maven-plugin</artifactId>
+            <groupId>org.apache.tomcat.maven</groupId>
+            <artifactId>tomcat7-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>start-tomcat</id>

--- a/deegree-tests/deegree-csw-bkg/pom.xml
+++ b/deegree-tests/deegree-csw-bkg/pom.xml
@@ -250,8 +250,8 @@
           </plugin>
 
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>tomcat-maven-plugin</artifactId>
+            <groupId>org.apache.tomcat.maven</groupId>
+            <artifactId>tomcat7-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>start-tomcat</id>

--- a/deegree-tests/deegree-testservice/pom.xml
+++ b/deegree-tests/deegree-testservice/pom.xml
@@ -45,8 +45,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <configuration>
           <ignorePackaging>true</ignorePackaging>
         </configuration>

--- a/deegree-tests/deegree-wms-remoteows-tests/pom.xml
+++ b/deegree-tests/deegree-wms-remoteows-tests/pom.xml
@@ -40,8 +40,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>start-tomcat</id>

--- a/deegree-tests/deegree-wms-similarity-tests/pom.xml
+++ b/deegree-tests/deegree-wms-similarity-tests/pom.xml
@@ -40,8 +40,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>start-tomcat</id>

--- a/deegree-tests/deegree-wms-tiling-tests/pom.xml
+++ b/deegree-tests/deegree-wms-tiling-tests/pom.xml
@@ -47,8 +47,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>start-tomcat</id>

--- a/deegree-tests/deegree-wmts-tests/pom.xml
+++ b/deegree-tests/deegree-wmts-tests/pom.xml
@@ -47,8 +47,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>start-tomcat</id>

--- a/deegree-tests/deegree-workspace-tests/pom.xml
+++ b/deegree-tests/deegree-workspace-tests/pom.xml
@@ -56,8 +56,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tomcat-maven-plugin</artifactId>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>start-tomcat</id>


### PR DESCRIPTION
The maven GAV for the Maven Tomcat plugin were not in line with the project root POM which was changed in PR #478. This PR fixes this.