### PR TITLE
Support Java SE 8 added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 sudo: false
 language: java
 jdk:
+  - oraclejdk8
   - openjdk7
   - oraclejdk7
 install: "travis_retry mvn install -Pintegration-tests -DskipTests=true -B -V"

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -108,9 +108,12 @@
       <artifactId>serializer</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
 </project>
-

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -98,10 +98,6 @@
     </dependency>
     <dependency>
       <groupId>com.oracle</groupId>
-      <artifactId>ojdbc6</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.oracle</groupId>
       <artifactId>xdb</artifactId>
     </dependency>
     <dependency>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/src/test/java/org/deegree/tile/persistence/remotewms/RemoteWMSTileStoreTest.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/src/test/java/org/deegree/tile/persistence/remotewms/RemoteWMSTileStoreTest.java
@@ -41,6 +41,7 @@
 package org.deegree.tile.persistence.remotewms;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -96,7 +97,8 @@ public class RemoteWMSTileStoreTest {
         GenericTileStore store = (GenericTileStore) ws.getResource( TileStoreProvider.class, "tiles26912" );
         SpatialMetadata metadata = store.getTileDataSet( "tiles26912" ).getTileMatrixSet().getSpatialMetadata();
         assertEquals( 1, metadata.getCoordinateSystems().size() );
-        assertEquals( "urn:opengis:def:crs:epsg::26912", metadata.getCoordinateSystems().get( 0 ).getId() );
+
+        assertTrue( metadata.getCoordinateSystems().get(0).hasId("urn:opengis:def:crs:epsg::26912", false, true) );
         assertEquals( 228563.303, metadata.getEnvelope().getMin().get0(), 0.001 );
         assertEquals( 4103089.15, metadata.getEnvelope().getMin().get1(), 0.001 );
         assertEquals( 779065.703, metadata.getEnvelope().getMax().get0(), 0.001 );

--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -57,14 +57,6 @@
       <artifactId>deegree-featurestore-commons</artifactId>
       <version>${project.version}</version>
     </dependency>      
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/installation.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/installation.rst
@@ -15,7 +15,7 @@ deegree webservices work on any platform with a compatible Java installation, in
 * Mac OS X
 * Solaris
 
-Supported Java versions are `OpenJDK <http://openjdk.java.net>`_ version 7 (currently only available for Linux), `Oracle Java 7 (JDK) <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ and `Oracle Java 6 (JDK) <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_  [#f1]_. Other Java versions may work, but are not officially supported by the deegree development team.
+Supported Java versions are `Oracle Java 8/7/6 (JDK) <http://www.oracle.com/technetwork/java/javase/downloads/index.html>` [#f1]_, `OpenJDK <http://openjdk.java.net>`_ version 8/7 (currently only available for Linux). Other Java versions may work, but are not officially supported by the deegree development team.
 
 -----------
 Downloading
@@ -63,10 +63,10 @@ You may minimize this window, but don't close it as long as you want to be able 
 To shut deegree webservices down, switch back to the terminal window and press ``CTRL+C`` or simply close it. 
 
 .. tip::
-  If you want to run deegree webservices on system startup automatically, consider installing `Apache Tomcat 7 <http://tomcat.apache.org>`_ as a system service. Afterwards, download the WAR version of deegree webservices and deploy it into your Tomcat installation (e.g. by copying the WAR file into the ``webapps`` folder). Consult the Tomcat documentation for more information and options.
+  If you want to run deegree webservices on system startup automatically, consider installing `Apache Tomcat 8/7 <http://tomcat.apache.org>`_ as a system service. Afterwards, download the WAR version of deegree webservices and deploy it into your Tomcat installation (e.g. by copying the WAR file into the ``webapps`` folder). Consult the Tomcat documentation for more information and options.
 
 .. rubric:: Footnotes
 
-.. [#f1] Update 4 or better.
-.. [#f2] A Servlet 2.5 compliant web container is required. We recommend using the latest Apache Tomcat 7 release.
+.. [#f1] In case you consider to run Oracle JDK 6 or 7 be aware that both versions are out of maintenance and reached EOF.
+.. [#f2] A Servlet 2.5 compliant web container is required. We recommend using the latest Apache Tomcat 8 release.
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   </distributionManagement>
 
   <prerequisites>
-    <maven>3.0.3</maven>
+    <maven>3.0.5</maven>
   </prerequisites>
 
   <pluginRepositories>
@@ -125,7 +125,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.10</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -145,18 +145,18 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.16</version>
+          <version>2.19</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.16</version>
+          <version>2.19</version>
         </plugin>
         <!-- reporting and site -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.4</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>
@@ -189,7 +189,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -376,7 +376,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>commons-digester</groupId>
@@ -591,7 +591,7 @@
       <dependency>
         <groupId>com.sun.xml.fastinfoset</groupId>
         <artifactId>FastInfoset</artifactId>
-        <version>1.2.12</version>
+        <version>1.2.13</version>
         <exclusions>
           <exclusion>
             <groupId>javax.xml.bind</groupId>
@@ -652,12 +652,12 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.5</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.netty</groupId>
         <artifactId>netty</artifactId>
-        <version>3.2.9.Final</version>
+        <version>3.2.10.Final</version>
       </dependency>
       <!-- JAI -->
       <dependency>
@@ -948,7 +948,7 @@
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache-core</artifactId>
-        <version>2.6.5</version>
+        <version>2.6.11</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -998,7 +998,7 @@
       <dependency>
         <groupId>org.reflections</groupId>
         <artifactId>reflections</artifactId>
-        <version>0.9.8</version>
+        <version>0.9.10</version>
         <exclusions>
           <exclusion>
             <groupId>ch.qos.logback</groupId>
@@ -1106,70 +1106,103 @@
     <profile>
       <id>site-all-reports</id>
       <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.2</version>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-          <findbugsXmlOutput>true</findbugsXmlOutput>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>2.7.1</version>
-        <configuration>
-          <linkXref>true</linkXref>
-          <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-          <minimumTokens>100</minimumTokens>
-          <targetJdk>${java.version}</targetJdk>
-          <excludes>
-            <exclude>**/generated/*.java</exclude>
-          </excludes>
-          <excludeRoots>
-            <excludeRoot>target/generated-sources</excludeRoot>
-          </excludeRoots>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.9.1</version>
-        <configuration>
-          <configLocation>checkstyle.xml</configLocation>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <configuration>
-          <detectLinks>false</detectLinks>
-          <detectOfflineLinks>false</detectOfflineLinks>
-          <aggregate>false</aggregate>
-          <minmemory>128m</minmemory>
-          <maxmemory>1g</maxmemory>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.3</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-          <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <version>2.5.2</version>
+            <configuration>
+              <xmlOutput>true</xmlOutput>
+              <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
+              <findbugsXmlOutput>true</findbugsXmlOutput>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <version>2.7.1</version>
+            <configuration>
+              <linkXref>true</linkXref>
+              <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+              <minimumTokens>100</minimumTokens>
+              <targetJdk>${java.version}</targetJdk>
+              <excludes>
+                <exclude>**/generated/*.java</exclude>
+              </excludes>
+              <excludeRoots>
+                <excludeRoot>target/generated-sources</excludeRoot>
+              </excludeRoots>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>2.9.1</version>
+            <configuration>
+              <configLocation>checkstyle.xml</configLocation>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.3</version>
+            <configuration>
+              <detectLinks>false</detectLinks>
+              <detectOfflineLinks>false</detectOfflineLinks>
+              <aggregate>false</aggregate>
+              <minmemory>128m</minmemory>
+              <maxmemory>1g</maxmemory>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jxr-plugin</artifactId>
+            <version>2.3</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-project-info-reports-plugin</artifactId>
+            <version>2.4</version>
+            <configuration>
+              <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+              <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+            </configuration>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+    <profile>
+      <id>java8-enable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <java.version>1.8</java.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.3</version>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.3</version>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </reporting>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Fixes #625 to support JDK 8 if available to compile and run deegree. Adds Oracle JDK 8 to travis-ci config file.
