### PR TITLE
Fixed creation of new SQLFeatureStore in deegree console

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SqlFeatureStoreBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SqlFeatureStoreBuilder.java
@@ -51,6 +51,7 @@ import org.deegree.db.ConnectionProviderProvider;
 import org.deegree.feature.persistence.FeatureStore;
 import org.deegree.feature.persistence.sql.jaxb.SQLFeatureStoreJAXB;
 import org.deegree.workspace.ResourceBuilder;
+import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.Workspace;
 import org.slf4j.Logger;
 
@@ -82,6 +83,7 @@ public class SqlFeatureStoreBuilder implements ResourceBuilder<FeatureStore> {
     public FeatureStore build() {
         ConnectionProvider conn = workspace.getResource( ConnectionProviderProvider.class,
                                                          config.getJDBCConnId().getValue() );
+        checkConnection( conn );
         File file = metadata.getLocation().resolveToFile( metadata.getIdentifier().getId() + ".xml" );
         SQLFeatureStore fs = null;
         try {
@@ -91,6 +93,15 @@ public class SqlFeatureStoreBuilder implements ResourceBuilder<FeatureStore> {
             LOG.trace( "Stack trace:", e );
         }
         return fs;
+    }
+
+    private void checkConnection( ConnectionProvider conn ) {
+        if ( conn == null ) {
+            String msg = "Unable to create SqlFeatureStore: Connection with identifier "
+                         + config.getJDBCConnId().getValue() + " is not available.";
+            LOG.error( msg );
+            throw new ResourceInitException( msg );
+        }
     }
 
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SqlFeatureStoreProvider.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SqlFeatureStoreProvider.java
@@ -61,7 +61,7 @@ public class SqlFeatureStoreProvider extends FeatureStoreProvider {
 
     private static final String CONFIG_NS = "http://www.deegree.org/datasource/feature/sql";
 
-    static final URL CONFIG_SCHEMA = SqlFeatureStoreProvider.class.getResource( "/META-INF/schemas/datasource/feature/sql/3.2.0/sql.xsd" );
+    static final URL CONFIG_SCHEMA = SqlFeatureStoreProvider.class.getResource( "/META-INF/schemas/datasource/feature/sql/3.4.0/sql.xsd" );
 
     @Override
     public String getNamespace() {


### PR DESCRIPTION
This pull requests fixes the creation of new SQLFeatureStores in the deegree console by correcting the version in the path of the CONFIG_SCHEMA. Currently an exception 'null' occurs and the file  is not created in the file system. 
Furthermore the exception handling is improved if the configured database connection is not available or not valid. 
