### PR TITLE
FIxed GetLegendGraphic with empty style parameter

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetLegendGraphic.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetLegendGraphic.java
@@ -80,7 +80,7 @@ public class GetLegendGraphic {
         }
         this.layer = new LayerRef( layer );
         String s = map.get( "STYLE" );
-        if ( s == null ) {
+        if ( s == null || "".equals( s )) {
             s = "default";
         }
         this.style = new StyleRef( s );


### PR DESCRIPTION
As described in #643 a NPE occurred if the style parameter is empty . This pull request fixes this by adding an additional check and using the default style name if missing.