### PR TITLE
changed srid from text to integer

### DIFF
--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/resources/org/deegree/metadata/iso/persistence/postgis/create.sql
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/resources/org/deegree/metadata/iso/persistence/postgis/create.sql
@@ -78,7 +78,7 @@ COMMENT ON COLUMN IDXTB_MAIN.SpecTitle IS 'Title of the specification dataQualit
 
 
 --Geospatial column in idxtb_main.bbox
-SELECT AddGeometryColumn('public','idxtb_main','bbox','-1','GEOMETRY','2');
+SELECT AddGeometryColumn('public','idxtb_main','bbox',-1,'GEOMETRY','2');
 
 CREATE TABLE IDXTB_Constraint ( 
 	id integer NOT NULL,


### PR DESCRIPTION
PostGIS 2 requires this parameter to be an integer. For PostGIS 1.5 the
value should be -1 when the srid is unknown. In PostGIS 2 providing a negative
value for srid is equivalent to providing 0, which is the PostGIS 2 value
for an unknown srid.

PostGIS versions tested:
- 1.5
- 2.1

Test performed:
```sql
create table test(id serial);
select AddGeometryColumn('public', 'test', 'geometry', -1, 'GEOMETRY', '2');
select srid from public.geometry_columns where f_table_name = 'test';
```

Test result:
- 1.5: srid = -1
- 2.1: srid = 0

Todo: also test in 2.0

fixes #531