### PR TITLE
enhanced external graphics with expressions by support of svg

### DIFF
--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/parser/GraphicSymbologyParser.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/parser/GraphicSymbologyParser.java
@@ -80,8 +80,8 @@ import org.deegree.style.se.unevaluated.Continuation.Updater;
 import org.deegree.style.styling.components.Fill;
 import org.deegree.style.styling.components.Graphic;
 import org.deegree.style.styling.components.Mark;
-import org.deegree.style.styling.components.Stroke;
 import org.deegree.style.styling.components.Mark.SimpleMark;
+import org.deegree.style.styling.components.Stroke;
 import org.deegree.style.utils.ShapeHelper;
 import org.slf4j.Logger;
 
@@ -129,14 +129,16 @@ class GraphicSymbologyParser {
                 }
             } else if ( in.getLocalName().equals( "ExternalGraphic" ) ) {
                 try {
-                    final Triple<BufferedImage, String, Continuation<List<BufferedImage>>> p = parseExternalGraphic( in );
+                    final Triple<BufferedImage, String, Continuation<List<Pair<BufferedImage, String>>>> p = parseExternalGraphic( in );
                     if ( p.third != null ) {
                         contn = new Continuation<Graphic>( contn ) {
                             @Override
                             public void updateStep( Graphic base, Feature f, XPathEvaluator<Feature> evaluator ) {
-                                LinkedList<BufferedImage> list = new LinkedList<BufferedImage>();
+                                LinkedList<Pair<BufferedImage, String>> list = new LinkedList<Pair<BufferedImage, String>>();
                                 p.third.evaluate( list, f, evaluator );
-                                base.image = list.poll();
+                                Pair<BufferedImage, String> image = list.poll();
+                                base.image = image.first;
+                                base.imageURL = image.second;
                             }
                         };
                     } else {
@@ -338,7 +340,7 @@ class GraphicSymbologyParser {
         return new Pair<Mark, Continuation<Mark>>( base, contn );
     }
 
-    private Triple<BufferedImage, String, Continuation<List<BufferedImage>>> parseExternalGraphic( final XMLStreamReader in )
+    private Triple<BufferedImage, String, Continuation<List<Pair<BufferedImage, String>>>> parseExternalGraphic( final XMLStreamReader in )
                             throws IOException, XMLStreamException {
         // TODO color replacement
 
@@ -348,7 +350,8 @@ class GraphicSymbologyParser {
         BufferedImage img = null;
         String url = null;
         Triple<InputStream, String, Continuation<StringBuffer>> pair = null;
-        Continuation<List<BufferedImage>> contn = null; // needs to be list to be updateable by reference...
+        Continuation<List<Pair<BufferedImage, String>>> contn = null; // needs to be list to be updateable by
+                                                                      // reference...
 
         while ( !( in.isEndElement() && in.getLocalName().equals( "ExternalGraphic" ) ) ) {
             in.nextTag();
@@ -383,25 +386,32 @@ class GraphicSymbologyParser {
                             return size() > 256; // yeah, hardcoded max size... TODO
                         }
                     };
-                    contn = new Continuation<List<BufferedImage>>() {
+                    contn = new Continuation<List<Pair<BufferedImage, String>>>() {
                         @Override
-                        public void updateStep( List<BufferedImage> base, Feature f, XPathEvaluator<Feature> evaluator ) {
+                        public void updateStep( List<Pair<BufferedImage, String>> base, Feature f,
+                                                XPathEvaluator<Feature> evaluator ) {
                             StringBuffer sb = new StringBuffer();
                             sbcontn.evaluate( sb, f, evaluator );
                             String file = sb.toString();
                             if ( cache.containsKey( file ) ) {
-                                base.add( cache.get( file ) );
+                                base.add( new Pair<BufferedImage, String>( cache.get( file ), null ) );
                                 return;
                             }
                             try {
-                                BufferedImage i;
-                                if ( context.location != null ) {
-                                    i = ImageIO.read( context.location.resolve( file ) );
+                                URL resolvedImageUrl = resolveImageUrl( file );
+                                BufferedImage image = null;
+                                String imageUrl = null;
+                                if ( resolvedImageUrl != null ) {
+                                    image = ImageIO.read( resolvedImageUrl );
+                                    if ( image != null ) {
+                                        cache.put( file, image );
+                                    } else {
+                                        imageUrl = resolvedImageUrl.toExternalForm();
+                                    }
                                 } else {
-                                    i = ImageIO.read( resolve( file, in ) );
+                                    imageUrl = file;
                                 }
-                                base.add( i );
-                                cache.put( file, i );
+                                base.add( new Pair<BufferedImage, String>( image, imageUrl ) );
                             } catch ( MalformedURLException e ) {
                                 // TODO Auto-generated catch block
                                 e.printStackTrace();
@@ -410,6 +420,19 @@ class GraphicSymbologyParser {
                                 e.printStackTrace();
                             }
                         }
+
+                        private URL resolveImageUrl( String file )
+                                                throws MalformedURLException {
+                            if ( context.location != null )
+                                return context.location.resolveToUrl( file );
+                            return resolve( file, in );
+                        }
+
+                        private BufferedImage asImage( URL resolvedImageUrl )
+                                                throws IOException {
+                            return ImageIO.read( resolvedImageUrl );
+                        }
+
                     };
                 }
             }
@@ -423,7 +446,7 @@ class GraphicSymbologyParser {
             }
         }
 
-        return new Triple<BufferedImage, String, Continuation<List<BufferedImage>>>( img, url, contn );
+        return new Triple<BufferedImage, String, Continuation<List<Pair<BufferedImage, String>>>>( img, url, contn );
     }
 
     private Triple<InputStream, String, Continuation<StringBuffer>> getOnlineResourceOrInlineContent( XMLStreamReader in )

--- a/deegree-core/deegree-core-style/src/main/resources/META-INF/schemas/se/1.1.0/symbology.xsd
+++ b/deegree-core/deegree-core-style/src/main/resources/META-INF/schemas/se/1.1.0/symbology.xsd
@@ -96,5 +96,15 @@
       </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:complexType name="OnlineResourceType">
+      <xsd:complexContent>
+        <xsd:extension base="OnlineResourceType">
+          <xsd:sequence>
+            <xsd:element ref="ogc:expression" minOccurs="0" />
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+
   </xsd:redefine>
 </xsd:schema>

--- a/deegree-core/deegree-core-style/src/main/resources/META-INF/schemas/se/1.1.0/text.xml
+++ b/deegree-core/deegree-core-style/src/main/resources/META-INF/schemas/se/1.1.0/text.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FeatureTypeStyle xmlns="http://www.opengis.net/se" xmlns:app="http://www.deegree.org/app" xmlns:ogc="http://www.opengis.net/ogc"
   xmlns:sed="http://www.deegree.org/se" xmlns:deegreeogc="http://www.deegree.org/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/se http://schemas.deegree.org/se/1.1.0/symbology.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/se ./symbology.xsd">
+  <!-- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/se http://schemas.deegree.org/se/1.1.0/symbology.xsd" -->
+
   <Name>CountyNames</Name>
   <!-- This rule shows the use of a Halo within a TextSymbolizer -->
   <Rule>
@@ -28,5 +30,20 @@
         <SvgParameter name="fill">#000000</SvgParameter>
       </Fill>
     </TextSymbolizer>
+    <PointSymbolizer>
+      <Graphic>
+        <ExternalGraphic>
+          <OnlineResource>
+            <ogc:PropertyName>app:icon</ogc:PropertyName>
+          </OnlineResource>
+          <Format>image/png</Format>
+        </ExternalGraphic>
+        <Size>30</Size>
+        <Displacement>
+          <DisplacementX>0</DisplacementX>
+          <DisplacementY>0</DisplacementY>
+        </Displacement>
+      </Graphic>
+    </PointSymbolizer>
   </Rule>
 </FeatureTypeStyle>

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/renderstyles.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/renderstyles.rst
@@ -280,7 +280,7 @@ Including an SVG graphic within a mark might look like this:
      <Size>10</Size>
       ...
     </Graphic>
-
+    
 ----
 Size
 ----
@@ -664,10 +664,6 @@ text rendering along lines:
 | WordWise              | Boolean    | true    | Tries to place individual words instead of individual characters| 
 +-----------------------+------------+---------+-----------------------------------------------------------------+
 
-^^^^^^^
-Example
-^^^^^^^ 
-
 .. code-block:: xml
 
     <LinePlacement>
@@ -677,7 +673,22 @@ Example
 	    <Center>true</Center>
 	    <WordWise>false</WordWise>
     </LinePlacement>
+  
+--------------------------
+ExternalGraphic extensions
+--------------------------
 
+deegree extends the OnlineResource element of ExternalGraphics to support ogc:Expressions as child elements. Example:
+
+.. code-block:: xml
+
+      <ExternalGraphic>
+        <OnlineResource>
+            <ogc:PropertyName>app:icon</ogc:PropertyName>
+        </OnlineResource>
+        <Format>image/svg</Format>
+      </ExternalGraphic> 
+      
 __________________________
 SE & FE Functions
 __________________________


### PR DESCRIPTION
deegree already supports ExternalGraphics with Expression as follows:
```xml
<ExternalGraphic>
  <OnlineResource>
    <ogc:PropertyName>app:icon</ogc:PropertyName>
  </OnlineResource>
  <Format>image/png</Format> 
</ExternalGraphic>	 
```

This pull requests enhanced this by the support of svgs. 
Furthermore an explanation in the documentation was added and the symbology.xsd enhanced.  