### PR TITLE
Altered epsg:3857 to use a spherical formula

### DIFF
--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
@@ -21848,18 +21848,36 @@
                 <crs:UsedProjection>projection_for_epsg:900913</crs:UsedProjection>
         </crs:ProjectedCRS>
         <crs:ProjectedCRS>
-                <crs:Id>epsg:3395</crs:Id>
                 <crs:Id>epsg:3857</crs:Id>
                 <crs:Id>google_maps</crs:Id>
-                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#3395</crs:Id>
-                <crs:Id>urn:ogc:def:crs:epsg::3395</crs:Id>
-                <crs:Id>urn:opengis:def:crs:epsg::3395</crs:Id>
                 <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#3857</crs:Id>
                 <crs:Id>urn:ogc:def:crs:epsg::3857</crs:Id>
                 <crs:Id>urn:opengis:def:crs:epsg::3857</crs:Id>
                 <crs:Name>Google_Maps</crs:Name>
                 <crs:Name>WGS 84 / Pseudo-Mercator</crs:Name>
                 <crs:Name>WGS 84 / Popular Visualisation Pseudo-Mercator</crs:Name>
+                <crs:Name>World Mercator</crs:Name>
+                <crs:AreaOfUse>-180.0,-80.0,180.0,84.0</crs:AreaOfUse>
+                <crs:AreaOfUse>World between 80°S and 84°N.</crs:AreaOfUse>
+                <crs:Axis>
+                        <crs:Name>x</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>east</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:Axis>
+                        <crs:Name>y</crs:Name>
+                        <crs:Units>metre</crs:Units>
+                        <crs:AxisOrientation>north</crs:AxisOrientation>
+                </crs:Axis>
+                <crs:UsedGeographicCRS>google_maps_geographiccrs</crs:UsedGeographicCRS>
+                <crs:UsedProjection>epsg:3856</crs:UsedProjection>
+        </crs:ProjectedCRS>
+        <crs:ProjectedCRS>
+                <crs:Id>epsg:3395</crs:Id>
+                <crs:Id>http://www.opengis.net/gml/srs/epsg.xml#3395</crs:Id>
+                <crs:Id>urn:ogc:def:crs:epsg::3395</crs:Id>
+                <crs:Id>urn:opengis:def:crs:epsg::3395</crs:Id>
+                <crs:Name>WGS 84 / World Mercator</crs:Name>
                 <crs:Name>World Mercator</crs:Name>
                 <crs:AreaOfUse>-180.0,-80.0,180.0,84.0</crs:AreaOfUse>
                 <crs:AreaOfUse>World between 80°S and 84°N.</crs:AreaOfUse>

--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/projection-definitions.xml
@@ -10774,6 +10774,15 @@
 		<crs:FalseNorthing>0.0</crs:FalseNorthing>
 	</crs:Mercator>
 	<crs:Mercator>
+		<crs:Id>epsg:3856</crs:Id>
+		<crs:Name>Pseudo-Mercator</crs:Name>
+		<crs:LatitudeOfNaturalOrigin>0.0</crs:LatitudeOfNaturalOrigin>
+		<crs:LongitudeOfNaturalOrigin>0.0</crs:LongitudeOfNaturalOrigin>
+		<crs:ScaleFactor>1.0</crs:ScaleFactor>
+		<crs:FalseEasting>0.0</crs:FalseEasting>
+		<crs:FalseNorthing>0.0</crs:FalseNorthing>
+	</crs:Mercator>
+	<crs:Mercator>
 		<crs:Id>projection_for_epsg:900913</crs:Id>
 		<crs:LatitudeOfNaturalOrigin>0.0</crs:LatitudeOfNaturalOrigin>
 		<crs:LongitudeOfNaturalOrigin>0.0</crs:LongitudeOfNaturalOrigin>


### PR DESCRIPTION
According to "1.3.3.2 Popular Visualisation Pseudo Mercator" in EPSG Guidance Note 7-2 (http://www.iogp.org/pubs/373-07-2.pdf), epsg:3857 should use a spherical formula.

* Split epsg:3857 and epsg:3395 into two seperate crs-definitions.
* Altered epsg:3857 to use a spherical formula.
* Added epsg:3856 to projection-definitions.

Ref comment in issue:
https://github.com/deegree/deegree3/issues/653