### PR TITLE
Fixed possible NullPointerException during creation of WMS 1.3.0 capabilities

### DIFF
--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/metadata/SpatialMetadata.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/metadata/SpatialMetadata.java
@@ -36,6 +36,7 @@
 package org.deegree.geometry.metadata;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.deegree.cs.coordinatesystems.ICRS;
@@ -59,25 +60,45 @@ public class SpatialMetadata {
     private List<ICRS> coordinateSystems;
 
     /**
+     * Instantiates an empty SpatialMetadata instance.
+     */
+    public SpatialMetadata() {
+        this( null, Collections.<ICRS> emptyList() );
+    }
+
+    /**
+     * Instantiates an SpatialMetadata instance with envelope and coordinate systems.
+     * 
      * @param envelope
+     *            may be <code>null</code>
      * @param coordinateSystems
+     *            may be empty but never <code>null</code>
      */
     public SpatialMetadata( Envelope envelope, List<ICRS> coordinateSystems ) {
         this.envelope = envelope;
         this.coordinateSystems = coordinateSystems;
     }
 
+    /**
+     * Instantiates an SpatialMetadata from another SpatialMetadata instance.
+     * 
+     * @param spatialMetadata
+     *            may be <code>null</code>
+     **/
     public SpatialMetadata( SpatialMetadata spatialMetadata ) {
         if ( spatialMetadata != null ) {
             this.envelope = copyEnvelope( spatialMetadata.envelope );
             this.coordinateSystems = new ArrayList<ICRS>();
             if ( spatialMetadata.coordinateSystems != null )
                 this.coordinateSystems.addAll( spatialMetadata.coordinateSystems );
+        } else {
+            this.envelope = null;
+            this.coordinateSystems = Collections.emptyList();
         }
     }
 
     /**
-     * @return the envelope
+     * @return the envelope may be <code>null</code>
      */
     public Envelope getEnvelope() {
         return envelope;
@@ -85,14 +106,14 @@ public class SpatialMetadata {
 
     /**
      * @param envelope
-     *            the envelope to set
+     *            the envelope to set, may be <code>null</code>
      */
     public void setEnvelope( Envelope envelope ) {
         this.envelope = envelope;
     }
 
     /**
-     * @return the coordinateSystems, never null
+     * @return the coordinateSystems, never <code>null</code>
      */
     public List<ICRS> getCoordinateSystems() {
         return coordinateSystems;
@@ -100,7 +121,7 @@ public class SpatialMetadata {
 
     /**
      * @param coordinateSystems
-     *            the coordinateSystems to set, may not be null
+     *            the coordinateSystems to set, never <code>null</code>
      */
     public void setCoordinateSystems( List<ICRS> coordinateSystems ) {
         this.coordinateSystems = coordinateSystems;
@@ -111,7 +132,7 @@ public class SpatialMetadata {
      * passed are not changed!
      * 
      * @param spatialMetadataToMerge
-     *            SpatialMetadata to merge, may be <code>null</code>
+     *            SpatialMetadata to merge, never <code>null</code>
      */
     public SpatialMetadata merge( SpatialMetadata spatialMetadataToMerge ) {
         if ( spatialMetadataToMerge == null )

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
@@ -207,12 +207,7 @@ public class Capabilities130XMLAdapter {
             writeElement( writer, WMSNS, "Title", "Root" );
 
             // TODO think about a push approach instead of a pull approach
-            SpatialMetadata smd = new SpatialMetadata( null, null );
-            for ( Theme t : themes ) {
-                for ( org.deegree.layer.Layer l : Themes.getAllLayers( t ) ) {
-                    smd.merge( l.getMetadata().getSpatialMetadata() );
-                }
-            }
+            SpatialMetadata smd = mergeSpatialMetadata( themes );
             if ( smd != null ) {
                 writeSrsAndEnvelope( writer, smd.getCoordinateSystems(), smd.getEnvelope() );
             }
@@ -283,6 +278,18 @@ public class Capabilities130XMLAdapter {
         for ( String format : exceptionsManager.getSupportedFormats( WMSConstants.VERSION_130 ) ) {
             writeElement( writer, "Format", format );
         }
+    }
+
+    private SpatialMetadata mergeSpatialMetadata( List<Theme> themes ) {
+        if ( themes.isEmpty() )
+            return null;
+        SpatialMetadata smd = new SpatialMetadata();
+        for ( Theme t : themes ) {
+            for ( org.deegree.layer.Layer l : Themes.getAllLayers( t ) ) {
+                smd.merge( l.getMetadata().getSpatialMetadata() );
+            }
+        }
+        return smd;
     }
 
 }


### PR DESCRIPTION
When WMS 1.3.0 capabilities are created a NullPointerException occurs if a layer does not have a CRS configured.
As the CRS is not mandatory (see [1]; there is a ref to group SpatialMetadata) there should not be thrown any exception.

This fix prevents the previously thrown NullPointerException.

[1] http://schemas.deegree.org/commons/spatialmetadata/3.1.0/spatialmetadata.xsd