### PR TITLE
Fixed bug leading to erroneous HTML capabilities

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController130.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController130.java
@@ -120,6 +120,7 @@ public class WMSController130 extends WMSControllerBase {
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance().createXMLStreamWriter( stream );
                 new Capabilities130XMLAdapter( identification, provider, metadata, getUrl, postUrl, service, controller ).export( xmlWriter );
+                xmlWriter.close();
                 capabilitiesManager.serializeCapabilities( format, new ByteArrayInputStream( stream.toByteArray() ),
                                                            response.getOutputStream() );
             }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSControllerBase.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSControllerBase.java
@@ -152,8 +152,7 @@ public abstract class WMSControllerBase implements Controller {
                                                 String exceptionsFormat, WMSController controller )
                             throws ServletException {
         try {
-            exceptionsManager.serializeCapabilities( getVersion(), exceptionsFormat, response, e, exceptionSerializer,
-                                                     map );
+            exceptionsManager.serialize( getVersion(), exceptionsFormat, response, e, exceptionSerializer, map );
         } catch ( SerializingException se ) {
             LOG.info( "An exception occured during serializing the exception, default serializer is used. Exception: {}",
                       se.getMessage() );

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/exceptions/ExceptionsManager.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/exceptions/ExceptionsManager.java
@@ -139,9 +139,8 @@ public class ExceptionsManager {
      * @throws OWSException
      *             if an error occurred if the requested format is not supported
      */
-    public void serializeCapabilities( Version version, String format, HttpResponseBuffer response,
-                                       OWSException exception, XMLExceptionSerializer exceptionSerializer,
-                                       Map<String, String> map )
+    public void serialize( Version version, String format, HttpResponseBuffer response, OWSException exception,
+                           XMLExceptionSerializer exceptionSerializer, Map<String, String> map )
                             throws SerializingException {
         LOG.debug( "Generating capabilities output for format: {}", format );
 


### PR DESCRIPTION
If HTML is configured as output format for capabilities, the service returns an empty page due to a not closed xml writer.

This pull requests fixes this issue.