### PR TITLE
Fixed bug that value of constraint "SOAPEncoding" in WFS capabilities is always "FALSE"

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -904,7 +904,11 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             }
             constraints.add( new Domain( "KVPEncoding", "TRUE" ) );
             constraints.add( new Domain( "XMLEncoding", "TRUE" ) );
-            constraints.add( new Domain( "SOAPEncoding", "FALSE" ) );
+            if ( master.isSoapSupported() ) {
+                constraints.add( new Domain( "SOAPEncoding", "TRUE" ) );
+            } else {
+                constraints.add( new Domain( "SOAPEncoding", "FALSE" ) );
+            }
             constraints.add( new Domain( "ImplementsInheritance", "FALSE" ) );
             constraints.add( new Domain( "ImplementsRemoteResolve", "FALSE" ) );
             if ( master.isEnableResponsePaging() ) {

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -978,7 +978,7 @@ public class WebFeatureService extends AbstractOWS {
                             throws ServletException, IOException, org.deegree.services.authentication.SecurityException {
         LOG.debug( "doSOAP" );
 
-        if ( disableBuffering ) {
+        if ( !isSoapSupported() ) {
             super.doSOAP( soapDoc, request, response, multiParts, factory );
             return;
         }
@@ -1379,6 +1379,13 @@ public class WebFeatureService extends AbstractOWS {
      */
     public boolean isEnableResponsePaging() {
         return enableResponsePaging;
+    }
+
+    /**
+     * @return <code>true</code> if soap is supported, <code>false</code> otherwise
+     */
+    public boolean isSoapSupported() {
+        return !disableBuffering;
     }
 
     /**


### PR DESCRIPTION
The value of the constraint "SOAPEncoding" in WFS capabilities is always "FALSE", even if SOAP encoding is activated.

This pull request fixes this behaviour and sets "SOAPEncoding" to "TRUE" if SOAP is activated.