### PR TITLE
[WIP]Fixed bug in SqlFeatureStore if configuration is stored in subfolders

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SqlFeatureStoreBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SqlFeatureStoreBuilder.java
@@ -84,7 +84,13 @@ public class SqlFeatureStoreBuilder implements ResourceBuilder<FeatureStore> {
         ConnectionProvider conn = workspace.getResource( ConnectionProviderProvider.class,
                                                          config.getJDBCConnId().getValue() );
         checkConnection( conn );
-        File file = metadata.getLocation().resolveToFile( metadata.getIdentifier().getId() + ".xml" );
+        String filename = metadata.getIdentifier().getId() + ".xml";
+        int pos;
+        if ( ( pos = filename.lastIndexOf( "/" ) ) > -1 ) {
+            // TRICKY if file is in a subfolder, this folder is part of the identifier AND the file-location:
+            filename = filename.substring( pos + 1 );
+        }
+        File file = metadata.getLocation().resolveToFile( filename );
         SQLFeatureStore fs = null;
         try {
             // TODO rewrite needed to properly resolve files using resource location


### PR DESCRIPTION
When the configuration of the feature ist stored in a subfolder of the features folder, this subfolder was added twice to the file-url. 

Example:
Configuration is stored in //path/to/datasources/feature/subfolder/config.xml
resolveToFile combines "//path/to/datasources/feature/subfolder/" and "subfolder/config" + ".xml"

With this Fix, only the filename ("config") is taken from the identifier to get the right filepath.
