### PR TITLE
Fixed bug in GmlGetFeatureHandler with WFS 2.0.0 and GetFeatureById

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -207,6 +207,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                     xmlStream.writeAttribute( "lockId", lock.getId() );
                 }
             }
+            prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
         } else if ( request.getVersion().equals( VERSION_110 ) ) {
             if ( responseContainerEl != null ) {
                 xmlStream.setPrefix( responseContainerEl.getPrefix(), responseContainerEl.getNamespaceURI() );
@@ -221,6 +222,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                 }
                 xmlStream.writeAttribute( "timeStamp", getTimestamp() );
             }
+            prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
         } else if ( request.getVersion().equals( VERSION_200 ) && ( !isGetFeatureById ) ) {
             xmlStream.setPrefix( "wfs", WFS_200_NS );
             xmlStream.writeStartElement( WFS_200_NS, "FeatureCollection" );
@@ -229,8 +231,8 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
             if ( lock != null ) {
                 xmlStream.writeAttribute( "lockId", lock.getId() );
             }
+            prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
         }
-        prebindNamespaces( xmlStream, format.getGmlFormatOptions().getPrebindNamespaces() );
 
         if ( !isGetFeatureById ) {
             // ensure that namespace for feature member elements is bound


### PR DESCRIPTION
When the WFS 2.0.0 request is GetFeatureById (example below), the xmlStream had no start element to insert the namespace with prebindNamespaces, what went into an error.
So the "prebindNamespaces" was moved into the if-blocks.


Example request:

```xml
<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs/2.0" count="10" service="WFS"
	                startIndex="0"
	                version="2.0.0">
	<wfs:StoredQuery id="urn:ogc:def:query:OGC-WFS::GetFeatureById">
		<wfs:Parameter name="id">EXAMPLE.123456</wfs:Parameter>
	</wfs:StoredQuery>
</wfs:GetFeature>
```