### PR TITLE
Fixed NullPointerException occuring when LockFeature (WFS) is requested via SOAP

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/LockFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/LockFeatureHandler.java
@@ -162,8 +162,7 @@ class LockFeatureHandler {
         }
 
         writer.writeEndElement();
-        writer.writeEndDocument();
-        writer.close();
+        writer.flush();
     }
 
     private void writeLockFeatureResponse110( HttpResponseBuffer response, Lock lock )
@@ -186,8 +185,7 @@ class LockFeatureHandler {
         }
 
         writer.writeEndElement();
-        writer.writeEndDocument();
-        writer.close();
+        writer.flush();
     }
 
     private void writeLockFeatureResponse200( HttpResponseBuffer response, Lock lock )
@@ -210,8 +208,7 @@ class LockFeatureHandler {
         }
 
         writer.writeEndElement();
-        writer.writeEndDocument();
-        writer.close();
+        writer.flush();
     }
 
     private void writeFeaturesLocked100or110( Lock lock, XMLStreamWriter writer )


### PR DESCRIPTION
When a WFS is used to request LockFeature via SOAP, a NPE occurs:
```
<ows:ExceptionReport xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="2.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ows:Exception exceptionCode="InvalidRequest">
      <ows:ExceptionText>java.lang.NullPointerException</ows:ExceptionText>
   </ows:Exception>
</ows:ExceptionReport>
```

This pull request fixes this so that a valid response is returned (equal to the one retrieved by POST).