### PR TITLE
Implemented Temporal Filter After, Before, During, TEquals for PostgreSQL

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -77,6 +77,7 @@ import org.deegree.filter.logical.Not;
 import org.deegree.filter.sort.SortProperty;
 import org.deegree.filter.spatial.BBOX;
 import org.deegree.filter.spatial.SpatialOperator;
+import org.deegree.filter.temporal.TemporalOperator;
 import org.deegree.geometry.Geometry;
 import org.deegree.sqldialect.SQLDialect;
 import org.deegree.sqldialect.filter.expression.SQLArgument;
@@ -313,6 +314,9 @@ public abstract class AbstractWhereBuilder {
             sql = toProtoSQL( (SpatialOperator) op );
             break;
         }
+        case TEMPORAL: {
+            sql = toProtoSQL( (TemporalOperator) op );
+        }
         }
         return sql;
     }
@@ -487,7 +491,7 @@ public abstract class AbstractWhereBuilder {
         return sqlOper;
     }
 
-    private void inferType( SQLExpression expr1, SQLExpression expr2 ) {
+    protected void inferType( SQLExpression expr1, SQLExpression expr2 ) {
         PrimitiveType pt1 = expr1.getPrimitiveType();
         PrimitiveType pt2 = expr2.getPrimitiveType();
         if ( pt1 == null && pt2 != null ) {
@@ -501,7 +505,7 @@ public abstract class AbstractWhereBuilder {
         }
     }
 
-    private void inferType( SQLExpression expr1, SQLExpression expr2, SQLExpression expr3 ) {
+    protected void inferType( SQLExpression expr1, SQLExpression expr2, SQLExpression expr3 ) {
         PrimitiveType pt1 = expr1.getPrimitiveType();
         PrimitiveType pt2 = expr2.getPrimitiveType();
         PrimitiveType pt3 = expr3.getPrimitiveType();
@@ -535,6 +539,10 @@ public abstract class AbstractWhereBuilder {
         Literal<PrimitiveValue> escapedLiteral = new Literal<PrimitiveValue>( new PrimitiveValue( s ), null );
         return new PropertyIsLike( (ValueReference) propName, escapedLiteral, wildCard, singleChar, escapeChar,
                                    matchCase, null );
+    }
+
+    protected void addExpression( SQLOperationBuilder builder, SQLExpression expr ) {
+        addExpression( builder, expr, true );
     }
 
     protected void addExpression( SQLOperationBuilder builder, SQLExpression expr, Boolean matchCase ) {
@@ -657,6 +665,23 @@ public abstract class AbstractWhereBuilder {
      */
     protected abstract SQLOperation toProtoSQL( SpatialOperator op )
                             throws UnmappableException, FilterEvaluationException;
+
+    /**
+     * Translates the given {@link TemporalOperator} into an {@link SQLOperation}.
+     * 
+     * @param op
+     *            temporal operator to be translated, must not be <code>null</code>
+     * @return corresponding SQL expression, may be <code>null</code>
+     * @throws UnmappableException
+     *             if translation is not possible (usually due to unmappable property names)
+     * @throws FilterEvaluationException
+     *             if the filter contains invalid {@link ValueReference}s
+     */
+    protected SQLOperation toProtoSQL( TemporalOperator op )
+                            throws UnmappableException, FilterEvaluationException {
+        LOG.warn( "Mapping of temporal operators to SQL is not implemented (and probably not possible)." );
+        return null;
+    }
 
     /**
      * Translates the given {@link Expression} into an {@link SQLExpression}.
@@ -837,7 +862,8 @@ public abstract class AbstractWhereBuilder {
                 throw new UnmappableException( "Only primitive valued literals are currently supported." );
             }
         }
-        PrimitiveParticleConverter converter = new DefaultPrimitiveConverter( new PrimitiveType( STRING ), null, false );
+        PrimitiveParticleConverter converter = new DefaultPrimitiveConverter( new PrimitiveType( STRING ), null,
+                                                                              false );
         return new SQLArgument( null, converter );
     }
 

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISWhereBuilder.java
@@ -403,7 +403,7 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
             if ( isTimeInstant( parameter2 ) ) {
                 TimePosition timePosition = ( (GenericTimeInstant) ( (Literal<?>) parameter2 ).getValue() ).getPosition();
                 second = createDateExpression( timePosition );
-            } else  if ( isTimePeriod( (Literal<?>) parameter2 ) ) {
+            } else  if ( isTimePeriod( parameter2 ) ) {
                 TimePosition end = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getEndPosition();
                 second = createDateExpression( end );
             } else {
@@ -420,7 +420,7 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
             if ( isTimeInstant( parameter2 ) ) {
                 TimePosition timePosition = ( (GenericTimeInstant) ( (Literal<?>) parameter2 ).getValue() ).getPosition();
                 second = createDateExpression( timePosition );
-            } else  if ( isTimePeriod( (Literal<?>) parameter2 ) ) {
+            } else  if ( isTimePeriod( parameter2 ) ) {
                 TimePosition begin = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getBeginPosition();
                 second = createDateExpression( begin );
             } else {
@@ -446,7 +446,7 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
         }
         case DURING: {
             Expression parameter2 = op.getParameter2();
-            if ( isTimePeriod( (Literal<?>) parameter2 ) ) {
+            if ( isTimePeriod( parameter2 ) ) {
                 TimePosition begin = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getBeginPosition();
                 TimePosition end = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getEndPosition();
                 SQLExpression valueReference = toProtoSQL( op.getParameter1() );
@@ -564,12 +564,12 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
         return builder.toOperation();
     }
 
-    private boolean isTimePeriod( Literal<?> parameter2 ) {
-        return parameter2 instanceof Literal && parameter2.getValue() instanceof GenericTimePeriod;
+    private boolean isTimePeriod( Expression parameter2 ) {
+        return parameter2 instanceof Literal && ( (Literal<?>) parameter2 ).getValue() instanceof GenericTimePeriod;
     }
 
     private boolean isTimeInstant( Expression parameter2 ) {
-        return parameter2 instanceof Literal && ((Literal<?>)parameter2).getValue() instanceof GenericTimeInstant;
+        return parameter2 instanceof Literal && ( (Literal<?>) parameter2 ).getValue() instanceof GenericTimeInstant;
     }
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISWhereBuilder.java
@@ -83,6 +83,7 @@ import org.deegree.sqldialect.filter.expression.SQLOperationBuilder;
 import org.deegree.sqldialect.filter.islike.IsLikeString;
 import org.deegree.time.position.IndeterminateValue;
 import org.deegree.time.position.TimePosition;
+import org.deegree.time.primitive.GenericTimeInstant;
 import org.deegree.time.primitive.GenericTimePeriod;
 
 /**
@@ -397,35 +398,60 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
         switch ( op.getSubType() ) {
         case AFTER: {
             SQLExpression first = toProtoSQL( op.getParameter1() );
-            SQLExpression second = toProtoSQL( op.getParameter2() );
+            Expression parameter2 = op.getParameter2();
+            SQLExpression second;
+            if ( isTimeInstant( parameter2 ) ) {
+                TimePosition timePosition = ( (GenericTimeInstant) ( (Literal<?>) parameter2 ).getValue() ).getPosition();
+                second = createDateExpression( timePosition );
+            } else  if ( isTimePeriod( (Literal<?>) parameter2 ) ) {
+                TimePosition end = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getEndPosition();
+                second = createDateExpression( end );
+            } else {
+                second = toProtoSQL( parameter2 );
+            }
             inferType( first, second );
             sql = createSqlAfter( first, second );
             break;
         }
         case BEFORE: {
             SQLExpression first = toProtoSQL( op.getParameter1() );
-            SQLExpression second = toProtoSQL( op.getParameter2() );
+            Expression parameter2 = op.getParameter2();
+            SQLExpression second;
+            if ( isTimeInstant( parameter2 ) ) {
+                TimePosition timePosition = ( (GenericTimeInstant) ( (Literal<?>) parameter2 ).getValue() ).getPosition();
+                second = createDateExpression( timePosition );
+            } else  if ( isTimePeriod( (Literal<?>) parameter2 ) ) {
+                TimePosition begin = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getBeginPosition();
+                second = createDateExpression( begin );
+            } else {
+                second = toProtoSQL( parameter2 );
+            }
             inferType( first, second );
             sql = createSqlBefore( first, second );
             break;
         }
         case TEQUALS: {
             SQLExpression first = toProtoSQL( op.getParameter1() );
-            SQLExpression second = toProtoSQL( op.getParameter2() );
+            Expression parameter2 = op.getParameter2();
+            SQLExpression second;
+            if ( isTimeInstant( parameter2 ) ) {
+                TimePosition timePosition = ( (GenericTimeInstant) ( (Literal<?>) parameter2 ).getValue() ).getPosition();
+                second = createDateExpression( timePosition );
+            } else {
+                second = toProtoSQL( parameter2 );
+            }
             inferType( first, second );
             sql = createSqlEquals( first, second );
             break;
         }
         case DURING: {
             Expression parameter2 = op.getParameter2();
-            if ( parameter2 instanceof Literal
-                 && ( (Literal<?>) parameter2 ).getValue() instanceof GenericTimePeriod ) {
+            if ( isTimePeriod( (Literal<?>) parameter2 ) ) {
                 TimePosition begin = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getBeginPosition();
                 TimePosition end = ( (GenericTimePeriod) ( (Literal<?>) parameter2 ).getValue() ).getEndPosition();
                 SQLExpression valueReference = toProtoSQL( op.getParameter1() );
                 SQLExpression beginExpr = createDateExpression( begin );
                 SQLExpression endExpr = createDateExpression( end );
-
                 sql = createSqlDuring( valueReference, beginExpr, endExpr );
             }
             break;
@@ -537,4 +563,13 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
         builder.add( ")" );
         return builder.toOperation();
     }
+
+    private boolean isTimePeriod( Literal<?> parameter2 ) {
+        return parameter2 instanceof Literal && parameter2.getValue() instanceof GenericTimePeriod;
+    }
+
+    private boolean isTimeInstant( Expression parameter2 ) {
+        return parameter2 instanceof Literal && ((Literal<?>)parameter2).getValue() instanceof GenericTimeInstant;
+    }
+
 }


### PR DESCRIPTION
Previously, usage of Temporal Filter After, Before, During, TEquals with PostgreSQL did not have a effect on the returned features as the filter was not applied.

This pull requests provides an implementation of these filters for PostgreSQL.

In addition, temporal filters can now be applied with following input:
- After
  - Literal
  - TimeInstant
  - TimePeriod
- Before
  - Literal
  - TimeInstant
  - TimePeriod
- TEquals
  - Literal
  - TimeInstant
- During
  - TimePeriod
