### PR TITLE
Fixed serialization and status code of SOAP 1.1 exceptions

### DIFF
--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializer.java
@@ -104,10 +104,15 @@ public class SOAPExceptionSerializer implements ExceptionSerializer {
                             throws IOException, XMLStreamException {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
-        if ( detailSerializer != null )
-            detailSerializer.setExceptionStatusCode( response, exception );
-        else
+        if ( detailSerializer != null ) {
+            if ( exception != null && exception instanceof SOAPException ) {
+                detailSerializer.setExceptionStatusCode( response, ( (SOAPException) exception ).getDetail() );
+            } else {
+                detailSerializer.setExceptionStatusCode( response, exception );
+            }
+        } else {
             response.setStatus( 200 );
+        }
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializer.java
@@ -36,8 +36,11 @@
 
 package org.deegree.services.controller.exception.serializer;
 
+import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
+import static org.deegree.commons.ows.exception.OWSException.OPERATION_PROCESSING_FAILED;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 
+import java.io.IOException;
 import java.util.Iterator;
 
 import javax.xml.stream.XMLStreamException;
@@ -60,6 +63,7 @@ import org.apache.axiom.soap.SOAPHeader;
 import org.apache.axiom.soap.SOAPVersion;
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.services.controller.exception.SOAPException;
+import org.deegree.services.controller.utils.HttpResponseBuffer;
 
 /**
  * The <code>SoapExceptionSerializer</code> class TODO add class documentation here.
@@ -69,7 +73,7 @@ import org.deegree.services.controller.exception.SOAPException;
  * 
  * @version $Revision$, $Date$
  */
-public class SOAPExceptionSerializer extends XMLExceptionSerializer {
+public class SOAPExceptionSerializer implements ExceptionSerializer {
 
     private SOAPFactory factory;
 
@@ -95,6 +99,22 @@ public class SOAPExceptionSerializer extends XMLExceptionSerializer {
 
         this.header = header;
 
+    }
+
+    @Override
+    public void serializeException( HttpResponseBuffer response, OWSException exception )
+                            throws IOException, XMLStreamException {
+        response.reset();
+        response.setCharacterEncoding( "UTF-8" );
+        response.setContentType( "application/soap+xml" );
+        if ( NO_APPLICABLE_CODE.equals( exception.getExceptionCode() ) ) {
+            response.setStatus( 500 );
+        } else if ( OPERATION_PROCESSING_FAILED.equals( exception.getExceptionCode() ) ) {
+            response.setStatus( 403 );
+        } else {
+            response.setStatus( 400 );
+        }
+        serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 
     public void serializeExceptionToXML( XMLStreamWriter writer, OWSException owsException )

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializer.java
@@ -36,8 +36,6 @@
 
 package org.deegree.services.controller.exception.serializer;
 
-import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
-import static org.deegree.commons.ows.exception.OWSException.OPERATION_PROCESSING_FAILED;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 
 import java.io.IOException;
@@ -106,14 +104,10 @@ public class SOAPExceptionSerializer implements ExceptionSerializer {
                             throws IOException, XMLStreamException {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
-        response.setContentType( "application/soap+xml" );
-        if ( NO_APPLICABLE_CODE.equals( exception.getExceptionCode() ) ) {
-            response.setStatus( 500 );
-        } else if ( OPERATION_PROCESSING_FAILED.equals( exception.getExceptionCode() ) ) {
-            response.setStatus( 403 );
-        } else {
-            response.setStatus( 400 );
-        }
+        if ( detailSerializer != null )
+            detailSerializer.setExceptionStatusCode( response, exception );
+        else
+            response.setStatus( 200 );
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/XMLExceptionSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/XMLExceptionSerializer.java
@@ -61,8 +61,18 @@ public abstract class XMLExceptionSerializer implements ExceptionSerializer {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( "application/vnd.ogc.se_xml" );
-        response.setStatus( 200 );
+        setExceptionStatusCode( response, exception );
         serializeExceptionToXML( response.getXMLWriter(), exception );
+    }
+
+    /**
+     * Sets the statusCode to the response.
+     * 
+     * @param response
+     * @param exception
+     */
+    public void setExceptionStatusCode( HttpResponseBuffer response, OWSException exception ) {
+        response.setStatus( 200 );
     }
 
     /**

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
@@ -82,7 +82,7 @@ public class OWS110ExceptionReportSerializer extends XMLExceptionSerializer {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( "application/xml" );
-
+        setExceptionStatusCode( response, exception );
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
@@ -82,6 +82,12 @@ public class OWS110ExceptionReportSerializer extends XMLExceptionSerializer {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( "application/xml" );
+
+        serializeExceptionToXML( response.getXMLWriter(), exception );
+    }
+
+    @Override
+    public void setExceptionStatusCode( HttpResponseBuffer response, OWSException exception ) {
         if ( NO_APPLICABLE_CODE.equals( exception.getExceptionCode() ) ) {
             response.setStatus( 500 );
         } else if ( OPERATION_PROCESSING_FAILED.equals( exception.getExceptionCode() ) ) {
@@ -89,7 +95,6 @@ public class OWS110ExceptionReportSerializer extends XMLExceptionSerializer {
         } else {
             response.setStatus( 400 );
         }
-        serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 
     @Override

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/PreOWSExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/PreOWSExceptionReportSerializer.java
@@ -69,7 +69,7 @@ public class PreOWSExceptionReportSerializer extends XMLExceptionSerializer {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( mimeType );
-        response.setStatus( 200 );
+        setExceptionStatusCode( response, exception );
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializerTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializerTest.java
@@ -1,0 +1,102 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+----------------------------------------------------------------------------*/
+package org.deegree.services.controller.exception.serializer;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.apache.axiom.soap.impl.llom.soap11.SOAP11Factory;
+import org.apache.axiom.soap.impl.llom.soap12.SOAP12Factory;
+import org.deegree.commons.ows.exception.OWSException;
+import org.deegree.commons.tom.ows.Version;
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
+import org.deegree.services.controller.exception.SOAPException;
+import org.deegree.services.ows.OWS110ExceptionReportSerializer;
+import org.junit.Test;
+
+/**
+ * currently it is only tested that no exception occurs
+ * 
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class SOAPExceptionSerializerTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testSerializeExceptionToXML_SOAP11()
+                            throws Exception {
+        SOAP11Factory factory = new SOAP11Factory();
+        XMLExceptionSerializer detailSerializer = new OWS110ExceptionReportSerializer( new Version( 2, 0, 0 ) );
+        SOAPExceptionSerializer soapExceptionSerializer = new SOAPExceptionSerializer( factory.getSOAPVersion(), null,
+                                                                                       factory, detailSerializer );
+        SOAPException soapException = createException();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        XMLStreamWriter writer = XMLOutputFactory.newInstance().createXMLStreamWriter( stream );
+        writer.writeStartDocument();
+        soapExceptionSerializer.serializeExceptionToXML( writer, soapException );
+        writer.writeEndDocument();
+        writer.close();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testSerializeExceptionToXML_SOAP12()
+                            throws Exception {
+        SOAP12Factory factory = new SOAP12Factory();
+        SOAPExceptionSerializer soapExceptionSerializer = createExceptionSerializer( factory );
+        SOAPException soapException = createException();
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        XMLStreamWriter writer = XMLOutputFactory.newInstance().createXMLStreamWriter( stream );
+        writer.writeStartDocument();
+        soapExceptionSerializer.serializeExceptionToXML( writer, soapException );
+        writer.writeEndDocument();
+        writer.close();
+    }
+
+    private SOAPException createException() {
+        OWSException owsException = new OWSException( new InvalidParameterValueException( "version" ) );
+        return new SOAPException( "reason", "code", owsException );
+    }
+
+    private SOAPExceptionSerializer createExceptionSerializer( SOAP12Factory factory ) {
+        XMLExceptionSerializer detailSerializer = new OWS110ExceptionReportSerializer( new Version( 2, 0, 0 ) );
+        return new SOAPExceptionSerializer( factory.getSOAPVersion(), null, factory, detailSerializer );
+    }
+
+}

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CswExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CswExceptionReportSerializer.java
@@ -80,7 +80,7 @@ public class CswExceptionReportSerializer extends XMLExceptionSerializer {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( "application/xml" );
-        response.setStatus( 200 );
+        setExceptionStatusCode( response, exception );
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 


### PR DESCRIPTION
Serialization of SOAP 1.1 exceptions fails:
```
Caused by: java.lang.UnsupportedOperationException
	at org.apache.axiom.soap.impl.llom.soap11.SOAP11Factory.createSOAPFaultValue(SOAP11Factory.java:170)
	at org.deegree.services.controller.exception.serializer.SOAPExceptionSerializer.serializeExceptionToXML(SOAPExceptionSerializer.java:143)
	at org.deegree.services.controller.exception.serializer.XMLExceptionSerializer.serializeException(XMLExceptionSerializer.java:65)
	at org.deegree.services.controller.AbstractOWS.sendException(AbstractOWS.java:447)
	... 23 more
```

In addition, the OWS110 exception codes are erroneous (always 200 instead of 400/403/500).

Both issues are fixed by this pull request.