### PR TITLE
Enhanced GFI response of coverage layer with dimension to return UOM

### DIFF
--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageDimensionHandler.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageDimensionHandler.java
@@ -73,6 +73,15 @@ class CoverageDimensionHandler {
         this.layerDims = layerDims;
     }
 
+    public Dimension<?> getDimension() {
+        if ( layerDims != null ) {
+            for ( Dimension<?> layerDim : layerDims.values() ) {
+                return layerDim;
+            }
+        }
+        return null;
+    }
+
     RangeSet getDimensionFilter( Map<String, List<?>> dims, List<String> headers )
                             throws OWSException {
 
@@ -123,7 +132,7 @@ class CoverageDimensionHandler {
 
     private void handleDimensionValue( Dimension<?> dim, Object o, List<Interval<?, ?>> intervals,
                                        List<SingleValue<?>> singleValues, List<String> headers, String name )
-                            throws OWSException {
+                                                               throws OWSException {
         if ( !dim.getNearestValue() && !dim.isValid( o ) ) {
             throw new OWSException( "The value for the " + name + " dimension is invalid: " + o.toString(),
                                     "InvalidDimensionValue" );
@@ -168,7 +177,8 @@ class CoverageDimensionHandler {
                 max = iv.max.toString();
             }
             intervals.add( new Interval<String, String>( new SingleValue<String>( Void, min ),
-                                                         new SingleValue<String>( Void, max ), open, null, false, null ) );
+                                                         new SingleValue<String>( Void, max ), open, null, false,
+                                                         null ) );
         } else {
             if ( dim.getNearestValue() ) {
                 Object nearest = dim.getNearestValue( o );

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoHandler.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoHandler.java
@@ -46,10 +46,15 @@ import static org.deegree.coverage.raster.utils.CoverageTransform.transform;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
 
 import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.commons.tom.gml.property.PropertyType;
 import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
@@ -66,6 +71,7 @@ import org.deegree.feature.GenericFeatureCollection;
 import org.deegree.feature.property.GenericProperty;
 import org.deegree.feature.types.FeatureType;
 import org.deegree.geometry.Envelope;
+import org.deegree.layer.dims.Dimension;
 import org.slf4j.Logger;
 
 /**
@@ -80,6 +86,8 @@ class CoverageFeatureInfoHandler {
 
     private static final Logger LOG = getLogger( CoverageFeatureInfoHandler.class );
 
+    private static final QName VALUE_PROP = new QName( "http://www.deegree.org/app", "value", "app" );
+
     private AbstractRaster raster;
 
     private Envelope bbox;
@@ -88,17 +96,21 @@ class CoverageFeatureInfoHandler {
 
     private InterpolationType interpol;
 
+    private CoverageDimensionHandler dimensionHandler;
+
     CoverageFeatureInfoHandler( AbstractRaster raster, Envelope bbox, FeatureType featureType,
-                                InterpolationType interpol ) {
+                                InterpolationType interpol, CoverageDimensionHandler dimensionHandler ) {
         this.raster = raster;
         this.bbox = bbox;
         this.featureType = featureType;
         this.interpol = interpol;
+        this.dimensionHandler = dimensionHandler;
     }
 
     FeatureCollection handleFeatureInfo() {
         try {
-            SimpleRaster res = transform( raster, bbox, Grid.fromSize( 1, 1, MAX_VALUE, bbox ), interpol.toString() ).getAsSimpleRaster();
+            SimpleRaster res = transform( raster, bbox, Grid.fromSize( 1, 1, MAX_VALUE, bbox ),
+                                          interpol.toString() ).getAsSimpleRaster();
             RasterData data = res.getRasterData();
             GenericFeatureCollection col = new GenericFeatureCollection();
             List<Property> props = new LinkedList<Property>();
@@ -108,7 +120,7 @@ class CoverageFeatureInfoHandler {
             case USHORT: {
                 PrimitiveValue val = new PrimitiveValue( new BigDecimal( 0xffff & data.getShortSample( 0, 0, 0 ) ),
                                                          new PrimitiveType( BaseType.DECIMAL ) );
-                props.add( new GenericProperty( featureType.getPropertyDeclarations().get( 0 ), val ) );
+                props.add( new GenericProperty( findValueProperty(), null, val, createAttributeList() ) );
                 break;
             }
             case BYTE: {
@@ -116,7 +128,7 @@ class CoverageFeatureInfoHandler {
                 for ( int i = 0; i < data.getBands(); ++i ) {
                     PrimitiveValue val = new PrimitiveValue( new BigDecimal( 0xff & data.getByteSample( 0, 0, i ) ),
                                                              new PrimitiveType( BaseType.DECIMAL ) );
-                    props.add( new GenericProperty( featureType.getPropertyDeclarations().get( 0 ), val ) );
+                    props.add( new GenericProperty( findValueProperty(), val ) );
                 }
                 break;
             }
@@ -125,12 +137,12 @@ class CoverageFeatureInfoHandler {
             case UNDEFINED:
                 LOG.warn( "The raster is of type '{}', this is handled as float currently.", dataType );
             case FLOAT:
-                props.add( new GenericProperty( featureType.getPropertyDeclarations().get( 0 ),
+                props.add( new GenericProperty( findValueProperty(), null,
                                                 new PrimitiveValue( new BigDecimal( data.getFloatSample( 0, 0, 0 ) ),
-                                                                    new PrimitiveType( BaseType.DECIMAL ) ) ) );
+                                                                    new PrimitiveType( BaseType.DECIMAL ) ),
+                                                createAttributeList() ) );
                 break;
             }
-
             Feature f = new GenericFeature( featureType, null, props, null );
             col.add( f );
             return col;
@@ -139,6 +151,35 @@ class CoverageFeatureInfoHandler {
             LOG.error( "Unable to create raster feature info: {}", e.getLocalizedMessage() );
         }
         return null;
+    }
+
+    private PropertyType findValueProperty() {
+        List<PropertyType> propertyDeclarations = featureType.getPropertyDeclarations();
+        for ( PropertyType propertyType : propertyDeclarations ) {
+            if ( VALUE_PROP.equals( propertyType.getName() ) ) {
+                return propertyType;
+            }
+        }
+        LOG.warn( "Could not find property with name 'value', use the first property." );
+        return propertyDeclarations.get( 0 );
+    }
+
+    private Map<QName, PrimitiveValue> createAttributeList() {
+        Map<QName, PrimitiveValue> attrs = new HashMap<QName, PrimitiveValue>();
+        if ( dimensionHandler != null && dimensionHandler.getDimension() != null ) {
+            Dimension<?> dimension = dimensionHandler.getDimension();
+            String uom = createUom( dimension );
+            if ( uom != null )
+                attrs.put( new QName( "uom" ), new PrimitiveValue( uom ) );
+        }
+        return attrs;
+    }
+
+    private String createUom( Dimension<?> dimension ) {
+        String unitSymbol = dimension.getUnitSymbol();
+        if ( unitSymbol != null && unitSymbol.length() > 0 )
+            return unitSymbol;
+        return dimension.getUnits();
     }
 
 }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoHandler.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoHandler.java
@@ -128,7 +128,7 @@ class CoverageFeatureInfoHandler {
                 for ( int i = 0; i < data.getBands(); ++i ) {
                     PrimitiveValue val = new PrimitiveValue( new BigDecimal( 0xff & data.getByteSample( 0, 0, i ) ),
                                                              new PrimitiveType( BaseType.DECIMAL ) );
-                    props.add( new GenericProperty( findValueProperty(), val ) );
+                    props.add( new GenericProperty( findValueProperty(), null, val, createAttributeList() ) );
                 }
                 break;
             }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureTypeBuilder.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureTypeBuilder.java
@@ -41,18 +41,18 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.layer.persistence.coverage;
 
-import static org.deegree.commons.tom.primitive.BaseType.DECIMAL;
+import static org.slf4j.LoggerFactory.getLogger;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.io.InputStream;
 
 import javax.xml.namespace.QName;
 
-import org.deegree.commons.tom.gml.property.PropertyType;
+import org.deegree.commons.xml.GenericLSInput;
+import org.deegree.feature.types.AppSchema;
 import org.deegree.feature.types.FeatureType;
-import org.deegree.feature.types.GenericAppSchema;
-import org.deegree.feature.types.GenericFeatureType;
-import org.deegree.feature.types.property.SimplePropertyType;
+import org.deegree.gml.schema.GMLAppSchemaReader;
+import org.slf4j.Logger;
+import org.w3c.dom.ls.LSInput;
 
 /**
  * Builds the standard coverage feature type for feature info.
@@ -64,15 +64,20 @@ import org.deegree.feature.types.property.SimplePropertyType;
  */
 class CoverageFeatureTypeBuilder {
 
+    private static final Logger LOG = getLogger( CoverageFeatureTypeBuilder.class );
+
     static FeatureType buildFeatureType() {
-        List<PropertyType> pts = new LinkedList<PropertyType>();
-        pts.add( new SimplePropertyType( new QName( "http://www.deegree.org/app", "value", "app" ), 0, -1, DECIMAL,
-                                         null, null ) );
-        FeatureType featureType = new GenericFeatureType( new QName( "http://www.deegree.org/app", "data", "app" ),
-                                                          pts, false );
-        // needed to get the back reference to the schema into the featureType (it's a strange mechanism indeed)
-        new GenericAppSchema( new FeatureType[] { featureType }, null, null, null, null, null );
-        return featureType;
+        try {
+            LSInput input = new GenericLSInput();
+            InputStream schema = CoverageFeatureTypeBuilder.class.getResourceAsStream( "gfiSchema.xsd" );
+            input.setByteStream( schema );
+            GMLAppSchemaReader decoder = new GMLAppSchemaReader( null, null, input );
+            AppSchema extractAppSchema = decoder.extractAppSchema();
+            return extractAppSchema.getFeatureType( new QName( "http://www.deegree.org/app", "data", "app" ) );
+        } catch ( Exception e ) {
+            LOG.error( "Could not read schema for GFI response on CoverageFeatureType", e );
+            return null;
+        }
     }
 
 }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
@@ -153,7 +153,7 @@ public class CoverageLayer extends AbstractLayer {
 
             return new CoverageLayerData( raster, bbox, query.getWidth(), query.getHeight(),
                                           InterpolationType.NEAREST_NEIGHBOR, filter, style,
-                                          getMetadata().getFeatureTypes().get( 0 ) );
+                                          getMetadata().getFeatureTypes().get( 0 ) , dimensionHandler );
         } catch ( OWSException e ) {
             throw e;
         } catch ( Throwable e ) {

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayerData.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayerData.java
@@ -89,8 +89,17 @@ public class CoverageLayerData implements LayerData {
 
     private final FeatureType featureType;
 
+    private CoverageDimensionHandler dimensionHandler;
+
     public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
                               RangeSet filter, Style style, FeatureType featureType ) {
+        this( raster, bbox, width, height, interpol, filter, style, featureType, null );
+
+    }
+
+    public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
+                              RangeSet filter, Style style, FeatureType featureType,
+                              CoverageDimensionHandler dimensionHandler ) {
         this.raster = raster;
         this.bbox = bbox;
         this.width = width;
@@ -99,6 +108,7 @@ public class CoverageLayerData implements LayerData {
         this.filter = filter;
         this.style = style;
         this.featureType = featureType;
+        this.dimensionHandler = dimensionHandler;
     }
 
     @Override
@@ -136,9 +146,10 @@ public class CoverageLayerData implements LayerData {
                 result = new RasterFilter( result ).apply( cbr, filter );
             }
 
-            LinkedList<Triple<Styling, LinkedList<Geometry>, String>> list = style == null || style.isDefault() ? null
-                                                                                                               : style.evaluate( null,
-                                                                                                                                 null );
+            LinkedList<Triple<Styling, LinkedList<Geometry>, String>> list = style == null
+                                                                             || style.isDefault() ? null
+                                                                                                  : style.evaluate( null,
+                                                                                                                    null );
             if ( list != null && list.size() > 0 ) {
                 for ( Triple<Styling, LinkedList<Geometry>, String> t : list ) {
                     renderer.render( (RasterStyling) t.first, result );
@@ -154,7 +165,8 @@ public class CoverageLayerData implements LayerData {
 
     @Override
     public FeatureCollection info() {
-        CoverageFeatureInfoHandler handler = new CoverageFeatureInfoHandler( raster, bbox, featureType, interpol );
+        CoverageFeatureInfoHandler handler = new CoverageFeatureInfoHandler( raster, bbox, featureType, interpol,
+                                                                             dimensionHandler );
         return handler.handleFeatureInfo();
     }
 

--- a/deegree-layers/deegree-layers-coverage/src/main/resources/org/deegree/layer/persistence/coverage/gfiSchema.xsd
+++ b/deegree-layers/deegree-layers-coverage/src/main/resources/org/deegree/layer/persistence/coverage/gfiSchema.xsd
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" xmlns:app="http://www.deegree.org/app"
+  xmlns:xlink="http://www.w3.org/1999/xlink" targetNamespace="http://www.deegree.org/app" elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd" />
+  <element name="data" substitutionGroup="gml:_Feature">
+    <complexType>
+      <complexContent>
+        <extension base="gml:AbstractFeatureType">
+          <sequence>
+            <element name="value" minOccurs="0" maxOccurs="unbounded">
+              <complexType>
+                <simpleContent>
+                  <extension base="decimal">
+                    <attribute name="uom" type="string" use="optional" />
+                  </extension>
+                </simpleContent>
+              </complexType>
+            </element>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+</schema>


### PR DESCRIPTION
This pull request enhances the GetFeatureInfo response of a coverage layer with dimensions to additionally return the UnitsOfMeasure. The UOM is added as an attribute to the corresponding element.
Example:

```
<?xml version='1.0' encoding='UTF-8'?>
<FeatureCollection xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.deegree.org/app http://localhost:8080/deegree-webservices/services/wms?request=GetFeatureInfoSchema&amp;layers=test http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd">
  <gml:boundedBy>
    <gml:null>missing</gml:null>
  </gml:boundedBy>
  <gml:featureMember>
    <app0:data xmlns:app0="http://www.deegree.org/app">
      <app0:value uom="m">612</app0:value>
    </app0:data>
  </gml:featureMember>
</FeatureCollection>
```
