### PR TITLE
[WIP]3.4 Allow custom particle converter in table driven mode

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -160,6 +160,8 @@ public class SQLFeatureStore implements FeatureStore {
 
     private static final int DEFAULT_CACHE_SIZE = 10000;
 
+    private static transient final ThreadLocal<Query> CURRENT_THREAD_QUERY = new ThreadLocal<Query>();
+
     private final SQLFeatureStoreJAXB config;
 
     private final URL configURL;
@@ -626,6 +628,7 @@ public class SQLFeatureStore implements FeatureStore {
         }
 
         Filter filter = query.getFilter();
+        CURRENT_THREAD_QUERY.set( query );
 
         int hits = 0;
         if ( query.getTypeNames().length == 1 && ( filter == null || filter instanceof OperatorFilter ) ) {
@@ -885,6 +888,7 @@ public class SQLFeatureStore implements FeatureStore {
 
         FeatureInputStream result = null;
         Filter filter = query.getFilter();
+        CURRENT_THREAD_QUERY.set( query );
 
         if ( query.getTypeNames().length == 1 && ( filter == null || filter instanceof OperatorFilter ) ) {
             QName ftName = query.getTypeNames()[0].getFeatureTypeName();
@@ -1617,5 +1621,14 @@ public class SQLFeatureStore implements FeatureStore {
         } else {
             nullEscalation = config.isNullEscalation();
         }
+    }
+
+    /**
+     * Return the current thread query, if a query is currently processed
+     * 
+     * @return the ThreadLocal<Query> or null
+     */
+    public static ThreadLocal<Query> getCurrentThreadQuery() {
+        return CURRENT_THREAD_QUERY;
     }
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
@@ -354,7 +354,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
             }
             pt = new SimplePropertyType( propName, minOccurs, maxOccurs, primType, null, null );
             m = new PrimitiveMapping( path, minOccurs == 0, mapping, ( (SimplePropertyType) pt ).getPrimitiveType(),
-                                      jc, null );
+                                      jc, simpleDecl.getCustomConverter() );
         } else if ( propDecl instanceof GeometryParticleJAXB ) {
             GeometryParticleJAXB geomDecl = (GeometryParticleJAXB) propDecl;
             GeometryType type = null;
@@ -378,7 +378,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
             CoordinateDimension dim = crs.getDimension() == 3 ? DIM_2 : DIM_3;
             pt = new GeometryPropertyType( propName, minOccurs, maxOccurs, null, null, type, dim, INLINE );
             m = new GeometryMapping( path, minOccurs == 0, mapping, type, new GeometryStorageParams( crs, srid, dim ),
-                                     jc );
+                                     jc, geomDecl.getCustomConverter() );
         } else {
             LOG.warn( "Unhandled property declaration '" + propDecl.getClass() + "'. Skipping it." );
         }


### PR DESCRIPTION
Currently CustomParticleConverter can be configured for a SQLFeaturesStore regardless the operation mode of the SQLFeatureStore.

The Current Implementation only used the CustomParticleConverter if the SQLFeatureStore is in schema driven mode and ignores it otherwise.

As this is already fully available logic, it only has to be passed to activate it also for the table driven mode. 
The [documentation](http://download.deegree.org/documentation/3.4-RC1/html/featurestores.html#customizing-the-mapping-between-columns-and-properties) only lists the posibility to use this extension point but has no details for it.

It gets even more usefull if the query can be accesed from the thread wich is curently querying the data.
