### PR TITLE
Add support for partial SQL and partial post filtering in WhereBuilder

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/Filters.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/Filters.java
@@ -35,7 +35,9 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.filter;
 
+import static java.util.Arrays.asList;
 import static org.deegree.filter.Filter.Type.OPERATOR_FILTER;
+import static org.deegree.filter.Operator.Type.LOGICAL;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,6 +118,26 @@ import org.slf4j.LoggerFactory;
 public class Filters {
 
     private static Logger LOG = LoggerFactory.getLogger( Filters.class );
+
+    /**
+     * Extract all operators from an And-filter (which can all be filtered individually, as each operator can only
+     * narrow the result).
+     *
+     * @return list of operators, can be <code>null</code> (not an And-filter)
+     */
+    public static List<Operator> extractAndOperands( final Filter filter ) {
+        if ( filter != null && filter.getType() == OPERATOR_FILTER ) {
+            final OperatorFilter operatorFilter = (OperatorFilter) filter;
+            final Operator operator = operatorFilter.getOperator();
+            if ( operator.getType() == LOGICAL ) {
+                final LogicalOperator logicalOperator = (LogicalOperator) operator;
+                if ( logicalOperator.getSubType() == LogicalOperator.SubType.AND ) {
+                    return asList( logicalOperator.getParams() );
+                }
+            }
+        }
+        return null;
+    }
 
     /**
      * Tries to extract a {@link BBOX} constraint from the given {@link Filter} that can be used as a pre-filtering step

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/MockPropertyNameMapper.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/MockPropertyNameMapper.java
@@ -1,0 +1,35 @@
+package org.deegree.sqldialect.filter;
+
+import org.deegree.filter.expression.ValueReference;
+
+/**
+ * Mock implementation of {@link PropertyNameMapper} that maps any {@link ValueReference} to a column with the same
+ * name, except for {@link ValueReference}s that start with "UNMAPPABLE_".
+ *
+ * @author <a href="mailto:schneider@occamlabs.de">Markus schneider</a>
+ *
+ * @since 3.4
+ */
+public class MockPropertyNameMapper implements PropertyNameMapper {
+
+    @Override
+    public PropertyNameMapping getSpatialMapping( ValueReference propName, TableAliasManager aliasManager ) {
+        if ( isMappable( propName ) ) {
+            return new PropertyNameMapping( null, null, propName.getAsQName().getLocalPart(), null );
+        }
+        return null;
+    }
+
+    @Override
+    public PropertyNameMapping getMapping( ValueReference propName, TableAliasManager aliasManager ) {
+        if ( isMappable( propName ) ) {
+            return new PropertyNameMapping( null, null, propName.getAsQName().getLocalPart(), null );
+        }
+        return null;
+    }
+
+    private boolean isMappable( final ValueReference propName ) {
+        return !propName.getAsQName().getLocalPart().startsWith( "UNMAPPABLE" );
+    }
+
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/MockWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/MockWhereBuilder.java
@@ -1,0 +1,28 @@
+package org.deegree.sqldialect.filter;
+
+import org.deegree.filter.FilterEvaluationException;
+import org.deegree.filter.OperatorFilter;
+import org.deegree.filter.sort.SortProperty;
+import org.deegree.filter.spatial.SpatialOperator;
+import org.deegree.sqldialect.filter.expression.SQLOperation;
+
+/**
+ * Mock implementation of {@link AbstractWhereBuilder} that uses the {@link MockPropertyNameMapper}.
+ *
+ * @author <a href="mailto:schneider@occamlabs.de">Markus schneider</a>
+ *
+ * @since 3.4
+ */
+class MockWhereBuilder extends AbstractWhereBuilder {
+
+    MockWhereBuilder( final OperatorFilter filter, final SortProperty[] sortCrit ) throws FilterEvaluationException {
+        super( null, new MockPropertyNameMapper(), filter, sortCrit );
+    }
+
+    @Override
+    protected SQLOperation toProtoSQL( final SpatialOperator op )
+                            throws UnmappableException, FilterEvaluationException {
+        return null;
+    }
+
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/WhereBuilderTest.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/test/java/org/deegree/sqldialect/filter/WhereBuilderTest.java
@@ -1,0 +1,80 @@
+package org.deegree.sqldialect.filter;
+
+import static org.deegree.filter.MatchAction.ANY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.xml.namespace.QName;
+
+import org.deegree.commons.tom.primitive.PrimitiveValue;
+import org.deegree.filter.FilterEvaluationException;
+import org.deegree.filter.Operator;
+import org.deegree.filter.OperatorFilter;
+import org.deegree.filter.comparison.PropertyIsEqualTo;
+import org.deegree.filter.expression.Literal;
+import org.deegree.filter.expression.ValueReference;
+import org.deegree.filter.logical.And;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AbstractWhereBuilder}.
+ *
+ * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
+ *
+ * @since 3.4
+ */
+public class WhereBuilderTest {
+
+    @Test
+    public void buildUsingFullMapping()
+                            throws FilterEvaluationException, UnmappableException {
+        final OperatorFilter filter = createAndFilter( 2, 0 );
+        final MockWhereBuilder wb = new MockWhereBuilder( filter, null );
+        wb.build( true );
+
+        // full filter was mapped to SQL
+        final String actualSql = wb.getWhere().getSQL().toString();
+        assertEquals( "(MAPPABLE_0 = ? AND MAPPABLE_1 = ?)", actualSql );
+
+        // post filter is null
+        final OperatorFilter actualPostFilter = wb.getPostFilter();
+        assertNull( actualPostFilter );
+    }
+
+    @Test
+    public void buildUsingPartialMapping()
+                            throws FilterEvaluationException, UnmappableException {
+        final OperatorFilter filter = createAndFilter( 1, 1 );
+        final MockWhereBuilder wb = new MockWhereBuilder( filter, null );
+        wb.build( true );
+
+        // one part of filter was mapped to SQL
+        final String actualSql = wb.getWhere().getSQL().toString();
+        assertEquals( "MAPPABLE_0 = ?", actualSql );
+
+        // remaining part of filter was extracted as post filter
+        final OperatorFilter actualPostFilter = wb.getPostFilter();
+        final PropertyIsEqualTo operator = (PropertyIsEqualTo) actualPostFilter.getOperator();
+        final ValueReference ref = (ValueReference) operator.getParameter1();
+        assertEquals( "UNMAPPABLE_0", ref.getAsQName().getLocalPart() );
+    }
+
+    private OperatorFilter createAndFilter( final int numMappedOperands, final int numUnmappedOperands ) {
+        final Collection<Operator> operators = new ArrayList<Operator>();
+        for ( int i = 0; i < numMappedOperands; i++ ) {
+            final ValueReference param1 = new ValueReference( new QName( "MAPPABLE_" + i ) );
+            final Literal<PrimitiveValue> param2 = new Literal<PrimitiveValue>( "VALUE" );
+            operators.add( new PropertyIsEqualTo( param1, param2, true, ANY ) );
+        }
+        for ( int i = 0; i < numUnmappedOperands; i++ ) {
+            final ValueReference param1 = new ValueReference( new QName( "UNMAPPABLE_" + i ) );
+            final Literal<PrimitiveValue> param2 = new Literal<PrimitiveValue>( "VALUE" );
+            operators.add( new PropertyIsEqualTo( param1, param2, true, ANY ) );
+        }
+        final And and = new And( operators.toArray( new Operator[operators.size()] ) );
+        return new OperatorFilter( and );
+    }
+}


### PR DESCRIPTION
Prior to this patch, the WhereBuilder would either map a complete filter to a WHERE clause or (in case some parts of the filter are unmappable) use an empty WHERE clause and offer the complete filter for in-memory filtering.

A shortcoming of this approach is that a single unmappable part of a filter means that all objects will be be fetched from the database and will be filtered in memory. Depending on the structure of the filter, this can be improved, so the WHERE-clause can still be used to narrow the result set.

After this patch, the WhereBuilder supports partial SQL and partial in-memory filtering for a common use case: If the filter is based on a root AND operator, the filter will be split into a WHERE clause and a post filter part. The WHERE clause contains all mappable parts and the post filter the remaining parts.

Tests included.
