### PR TITLE
Wms custom format cleanup

### DIFF
--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/geotiff/GeoTiffWriter.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/geotiff/GeoTiffWriter.java
@@ -299,6 +299,12 @@ public class GeoTiffWriter {
      */
     private static void write( AbstractRaster raster, ImageWriter writer )
                             throws IOException {
+        write( RasterFactory.imageFromRaster( raster ), raster.getRasterReference(), writer );
+
+    }
+
+    private static void write( BufferedImage img, RasterGeoReference ref, ImageWriter writer )
+                            throws IOException {
         ImageWriteParam encodeParam = writer.getDefaultWriteParam();
         IIOMetadata metadata = writer.getDefaultImageMetadata( null, encodeParam );
         TIFFDirectory tiffDir = null;
@@ -309,21 +315,20 @@ public class GeoTiffWriter {
                                    + e.getLocalizedMessage(), e );
         }
 
-        TIFFField tag = createModelTiePointTag( raster.getRasterReference() );
+        TIFFField tag = createModelTiePointTag( ref );
         if ( tag != null ) {
             tiffDir.addTIFFField( tag );
         }
-        tag = createModelPixelScaleTag( raster.getRasterReference() );
+        tag = createModelPixelScaleTag( ref );
         if ( tag != null ) {
             tiffDir.addTIFFField( tag );
         }
-        tag = createDirectoryTag( raster.getRasterReference() );
+        tag = createDirectoryTag( ref );
         if ( tag != null ) {
             tiffDir.addTIFFField( tag );
         }
         metadata = tiffDir.getAsMetadata();
-        BufferedImage image = RasterFactory.imageFromRaster( raster );
-        IIOImage wImage = new IIOImage( image, null, metadata );
+        IIOImage wImage = new IIOImage( img, null, metadata );
         writer.write( wImage );
 
     }
@@ -372,5 +377,14 @@ public class GeoTiffWriter {
         write( raster, writer );
         stream.flush();
         stream.close();
+    }
+
+    public static void save( BufferedImage img, RasterGeoReference ref, OutputStream out )
+                            throws IOException {
+        ImageOutputStream stream = ImageIO.createImageOutputStream( out );
+        ImageWriter writer = getWriter();
+        writer.setOutput( stream );
+        write( img, ref, writer );
+        stream.flush();
     }
 }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/ImageSerializer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/ImageSerializer.java
@@ -33,18 +33,19 @@
 
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
-package org.deegree.services.wms.controller.plugins;
+package org.deegree.rendering.r2d;
 
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.io.OutputStream;
+
+import org.deegree.rendering.r2d.context.RenderingInfo;
 
 /**
  * <code>ImageSerializer</code>
  * 
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
- * @author last edited by: $Author$
- * 
- * @version $Revision$, $Date$
+ * @author <a href="mailto:niklasch@grit.de">Sebastian Niklasch</a>
  */
 public interface ImageSerializer {
 
@@ -52,6 +53,7 @@ public interface ImageSerializer {
      * @param img
      * @param out
      */
-    void serialize( BufferedImage img, OutputStream out );
+    void serialize( RenderingInfo rinfo, BufferedImage img, OutputStream out )
+                            throws IOException;
 
 }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/ImageRenderContext.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/ImageRenderContext.java
@@ -72,12 +72,15 @@ public class ImageRenderContext extends Java2DRenderContext {
     private final BufferedImage image;
 
     private final String format;
+    
+    private final RenderingInfo info;
 
     private ImageRenderContext( RenderingInfo info, BufferedImage image, Graphics2D graphics, OutputStream outputStream ) {
         super( info, graphics, outputStream );
         
         this.image = image;
         this.format = info.getFormat();
+        this.info = info;
     }
     
     public static RenderContext createInstance( RenderingInfo info, BufferedImage image, OutputStream outputStream ) {
@@ -95,6 +98,7 @@ public class ImageRenderContext extends Java2DRenderContext {
     public boolean close() throws IOException {        
         try {
             graphics.dispose();
+            
             if ( outputStream != null ) {
                 BufferedImage image = this.image;
                 String format = this.format.substring( this.format.indexOf( "/" ) + 1 );
@@ -105,7 +109,12 @@ public class ImageRenderContext extends Java2DRenderContext {
                     image = ColorQuantizer.quantizeImage( image, 256, false, false );
                     format = "png";
                 }
-                return write( image, format, outputStream );
+                
+                if (info.getSerializer() != null){
+                    info.getSerializer().serialize( info, image, outputStream );
+                } else {
+                    return write( image, format, outputStream );
+                }
             }
         } finally {
             closeQuietly( outputStream );

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/RenderingInfo.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/RenderingInfo.java
@@ -41,6 +41,7 @@ import java.awt.Color;
 import java.util.Map;
 
 import org.deegree.geometry.Envelope;
+import org.deegree.rendering.r2d.ImageSerializer;
 import org.deegree.rendering.r2d.RenderHelper;
 
 /**
@@ -68,9 +69,16 @@ public class RenderingInfo {
     private int x, y, featureCount;
 
     private Map<String, String> parameters;
+    
+    private ImageSerializer serializer;
 
     public RenderingInfo( String format, int width, int height, boolean transparent, Color bgcolor, Envelope envelope,
                           double pixelSize, Map<String, String> parameters ) {
+        this(format, width, height, transparent, bgcolor, envelope, pixelSize, parameters, null);
+    }
+    
+    public RenderingInfo( String format, int width, int height, boolean transparent, Color bgcolor, Envelope envelope,
+                          double pixelSize, Map<String, String> parameters, ImageSerializer serializer ) {
         this.format = format;
         this.width = width;
         this.height = height;
@@ -79,6 +87,7 @@ public class RenderingInfo {
         this.envelope = envelope;
         this.pixelSize = pixelSize;
         this.parameters = parameters;
+        this.serializer = serializer;
     }
 
     public void setFormat( String format ) {
@@ -172,5 +181,8 @@ public class RenderingInfo {
     public double getResolution() {
         return RenderHelper.calcResolution( envelope, width, height );
     }
-
+    
+    public ImageSerializer getSerializer() {
+        return serializer;
+    }
 }

--- a/deegree-services/deegree-services-wms/pom.xml
+++ b/deegree-services/deegree-services-wms/pom.xml
@@ -97,6 +97,10 @@
       <artifactId>servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/plugins/ImageSerializerGeoTiff.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/plugins/ImageSerializerGeoTiff.java
@@ -1,0 +1,89 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+
+package org.deegree.services.wms.controller.plugins;
+
+import static javax.imageio.ImageIO.write;
+import static org.deegree.coverage.raster.geom.RasterGeoReference.create;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.deegree.coverage.raster.geom.RasterGeoReference;
+import org.deegree.coverage.raster.geom.RasterGeoReference.OriginLocation;
+import org.deegree.coverage.raster.io.imageio.geotiff.GeoTiffWriter;
+import org.deegree.rendering.r2d.ImageSerializer;
+import org.deegree.rendering.r2d.context.RenderingInfo;
+import org.slf4j.Logger;
+
+/**
+ * <code>ImageSerializerGeoTiff</code>
+ * 
+ * @author <a href="mailto:niklasch@grit.de">Sebastian Niklasch</a>
+ */
+
+public class ImageSerializerGeoTiff implements ImageSerializer {
+    private static final Logger LOG = getLogger( ImageSerializerGeoTiff.class );
+
+    private String formatName = "tiff";
+
+    @Override
+    public void serialize( RenderingInfo rinfo, BufferedImage img, OutputStream out )
+                            throws IOException {
+        if ( rinfo != null && rinfo.getEnvelope() != null ) {
+            long ts, te;
+            RasterGeoReference geoRef = create( OriginLocation.OUTER, rinfo.getEnvelope(), img.getWidth(),
+                                                img.getHeight() );
+
+            ts = System.currentTimeMillis();
+            GeoTiffWriter.save( img, geoRef, out );
+            te = System.currentTimeMillis();
+
+            LOG.debug( "Encoding into {} duration {} ms", formatName, te - ts );
+        } else {
+            LOG.debug( "Rendering without spatial information, because no envelope is availible. Using ImageIO" );
+            write( img, formatName, out );
+        }
+    }
+}

--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
@@ -94,6 +94,13 @@
                 <complexType>
                   <sequence>
                     <element name="JavaClass" type="string" />
+                    <element name="File" type="string" />
+                    <element name="Property" minOccurs="0" maxOccurs="unbounded">
+                      <complexType>
+                        <attribute name="name" use="required" />
+                        <attribute name="value" use="required" />            
+                      </complexType>
+                    </element>
                   </sequence>
                 </complexType>
               </element>
@@ -135,6 +142,20 @@
             <enumeration value="image/svg+xml" />
           </restriction>
         </simpleType>
+      </element>
+      <element name="CustomGetMapFormat" minOccurs="0" maxOccurs="unbounded">
+        <complexType>
+          <sequence>
+            <element name="Format" type="string" />
+            <element name="JavaClass" type="string" />
+            <element name="Property" minOccurs="0" maxOccurs="unbounded">
+              <complexType>
+                <attribute name="name" use="required" />
+                <attribute name="value" use="required" />            
+              </complexType>
+            </element>
+          </sequence>
+        </complexType>
       </element>
     </sequence>
   </complexType>

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -309,7 +309,7 @@ Here's an example of a linearized version of the example geometry as it would be
 Adding custom output formats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Using option element ``CustomFormat``, it possible to plug-in your own Java classes to generate the output for a specific mime type (e.g. a binary format)
+Using option element ``CustomFormat``, it is possible to plug-in your own Java classes to generate the output for a specific mime type (e.g. a binary format)
 
 +-----------+-------------+---------+------------------------------------------------------+
 | Option    | Cardinality | Value   | Description                                          |
@@ -734,7 +734,7 @@ This is how the configuration section looks like for configuring only ``image/pn
 """""""""""""""""""""""""""""
 Custom format provider class
 """""""""""""""""""""""""""""
-Using option element ``CustomGetMapFormat``, it possible to plug-in your own Java classes to generate the output for a specific mime type
+Using option element ``CustomGetMapFormat``, it is possible to plug-in your own Java classes to generate the output for a specific mime type
 
 +-----------+-------------+---------+------------------------------------------------------+
 | Option    | Cardinality | Value   | Description                                          |

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -530,6 +530,7 @@ This is how the configuration section looks like for configuring a deegree templ
     <GetFeatureInfoFormat>
       <File>../customformat.gfi</File>
       <Format>text/html</Format>
+      <Property name="customname" value="customvalue" \>
     </GetFeatureInfoFormat>
   </FeatureInfoFormats>
 
@@ -541,6 +542,7 @@ The configuration for the XSLT approach looks like this:
     <GetFeatureInfoFormat>
       <XSLTFile gmlVersion="GML_32">../customformat.xsl</XSLTFile>
       <Format>text/html</Format>
+      <Property name="customname" value="customvalue" \>
     </GetFeatureInfoFormat>
   </FeatureInfoFormats>
 
@@ -727,6 +729,36 @@ This is how the configuration section looks like for configuring only ``image/pn
 
   <GetMapFormats>
     <GetMapFormat>image/png</GetMapFormat>
+  </GetMapFormats>
+
+"""""""""""""""""""""""""""""
+Custom format provider class
+"""""""""""""""""""""""""""""
+Using option element ``CustomGetMapFormat``, it possible to plug-in your own Java classes to generate the output for a specific mime type
+
++-----------+-------------+---------+------------------------------------------------------+
+| Option    | Cardinality | Value   | Description                                          |
++===========+=============+=========+======================================================+
+| Format    | 1..1        | String  | Mime type associated with this format configuration  |
++-----------+-------------+---------+------------------------------------------------------+
+| JavaClass | 1..1        | String  | Qualified Java class name                            |
++-----------+-------------+---------+------------------------------------------------------+
+| Property  | 0..n        | Complex | Configure properties of the JavaClass                |
++-----------+-------------+---------+------------------------------------------------------+
+
+* ``Format``: Mime type associated with this format configuration (and announced in GetCapabilities)
+* ``JavaClass``: Therefore, an implementation of interface ``org.deegree.rendering.r2d.ImageSerializer`` must be present on the classpath.
+* ``Property``:
+
+This is how the configuration looks like for the implementation of GeoTIFF:
+
+.. code-block:: xml
+
+  <GetMapFormats>
+    <CustomGetMapFormat>
+      <Format>image/tiff</Format>
+      <JavaClass>org.deegree.services.wms.controller.plugins.ImageSerializerGeoTiff</JavaClass>
+    </CustomGetMapFormat>
   </GetMapFormats>
 
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Modified the custom format implementation of WMS. For FeatureInfo the xml-schema supports properties and for GetMap CustomGetMapFormats can be added by implementing the ImageSerializer. 
In the ImageSerializerGeoTiff a custim GetMap-Format is added for GeoTIFF.
