### PR TITLE
3.4 Bugfix: prevent control characters in content-type that break the transfer encoding

### DIFF
--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -56,7 +56,11 @@
       <groupId>org.deegree</groupId>
       <artifactId>deegree-featurestore-commons</artifactId>
       <version>${project.version}</version>
-    </dependency>      
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -35,6 +35,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.services.wfs;
 
+import static org.apache.commons.lang.StringUtils.trim;
 import static org.deegree.commons.ows.exception.OWSException.INVALID_PARAMETER_VALUE;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.ows.exception.OWSException.OPERATION_NOT_SUPPORTED;
@@ -554,7 +555,7 @@ public class WebFeatureService extends AbstractOWS {
                                                      + formatDef.getClass() + "'." );
                 }
                 for ( String mimeType : mimeTypes ) {
-                    mimeTypeToFormat.put( mimeType, format );
+                    mimeTypeToFormat.put( trim( mimeType ), format );
                 }
             }
         }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
@@ -35,6 +35,7 @@
 package org.deegree.services.wfs.format.gml;
 
 import static java.lang.Integer.MAX_VALUE;
+import static org.apache.commons.lang.StringUtils.trim;
 import static org.deegree.protocol.wfs.getfeature.ResultType.RESULTS;
 
 import java.io.IOException;
@@ -198,7 +199,7 @@ public class GmlFormat implements Format {
         }
 
         final GMLVersion gmlVersion = GMLVersion.valueOf( formatDef.getGmlVersion().value() );
-        final String mimeType = formatDef.getMimeType().get( 0 );
+        final String mimeType = trim( formatDef.getMimeType().get( 0 ) );
         final SFSProfiler geometrySimplifier = getSfsProfiler( formatDef.getGeometryLinearization() );
         this.options = new GmlFormatOptions( gmlVersion, responseContainerEl, responseFeatureMemberEl, schemaLocation,
                                              disableStreaming, generateBoundedByForFeatures, queryMaxFeatures,


### PR DESCRIPTION
Currently the WFS service sends the configured mime-type as content type to the client as it got read from the configuration.

Under Weblogic this reults to a problem if the configuration is formated like the following example: 

```xml
  <GMLFormat gmlVersion="GML_2">
    <MimeType>
      <![CDATA[text/xml; subtype="gml/2.1.2"]]>
    </MimeType>
    <MimeType>
      <![CDATA[text/xml; subtype=gml/2.1.2]]>
    </MimeType>
    <GetFeatureResponse>
      <DisableStreaming>true</DisableStreaming>
    </GetFeatureResponse>
  </GMLFormat>
```
This configuration fragment introduced additional white-space/control characters before or after the content-type so that a java/httpclient software faild to handle the transfer encoding of the result of deegree.

The effect could be fixed by removing the xml formatting, which is not a good solution as it could break any moment if someone formats the document:
```xml
  <GMLFormat gmlVersion="GML_2">
    <MimeType><![CDATA[text/xml; subtype="gml/2.1.2"]]></MimeType>
    <MimeType><![CDATA[text/xml; subtype=gml/2.1.2]]></MimeType>
    <GetFeatureResponse>
      <DisableStreaming>true</DisableStreaming>
    </GetFeatureResponse>
  </GMLFormat>
```