### PR TITLE
Validate crs and valid domain during transactions

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -435,8 +435,10 @@ class TransactionHandler {
 
     private FeatureCollection parseFeaturesOrCollection( XMLStreamReader xmlStream, GMLVersion inputFormat,
                                                          ICRS defaultCRS )
-                            throws XMLStreamException, XMLParsingException, UnknownCRSException,
-                            ReferenceResolvingException {
+                                                                                 throws XMLStreamException,
+                                                                                 XMLParsingException,
+                                                                                 UnknownCRSException,
+                                                                                 ReferenceResolvingException {
 
         FeatureCollection fc = null;
 
@@ -616,7 +618,8 @@ class TransactionHandler {
             PropertyType pt = ft.getPropertyDeclaration( propName );
             if ( pt == null ) {
                 throw new OWSException( "Cannot update property '" + propName + "' of feature type '" + ft.getName()
-                                        + "'. The feature type does not define this property.", OPERATION_NOT_SUPPORTED );
+                                        + "'. The feature type does not define this property.",
+                                        OPERATION_NOT_SUPPORTED );
             }
             XMLStreamReader xmlStream = replacement.getReplacementValue();
             int index = simpleMultiProp == null ? 0 : simpleMultiProp.second;
@@ -633,7 +636,8 @@ class TransactionHandler {
                     GMLFeatureReader featureReader = gmlReader.getFeatureReader();
 
                     ICRS crs = master.getDefaultQueryCrs();
-                    Property prop = featureReader.parseProperty( new XMLStreamReaderWrapper( xmlStream, null ), pt, crs );
+                    Property prop = featureReader.parseProperty( new XMLStreamReaderWrapper( xmlStream, null ), pt,
+                                                                 crs );
 
                     // TODO make this hack unnecessary
                     TypedObjectNode propValue = prop.getValue();
@@ -924,10 +928,15 @@ class TransactionHandler {
 
     private void evaluateSrsNameForFeatureCollection( FeatureCollection fc, List<ICRS> queryCRS, String handle )
                             throws OWSException {
-        Set<Geometry> geometries = new LinkedHashSet<Geometry>();
         for ( Feature feature : fc )
-            findFeaturesAndGeometries( feature, geometries, new LinkedHashSet<Feature>(), new LinkedHashSet<String>(),
-                                       new LinkedHashSet<String>() );
+            evaluateSrsNameForFeature( feature, queryCRS, handle );
+    }
+
+    private void evaluateSrsNameForFeature( Feature feature, List<ICRS> queryCRS, String handle )
+                            throws OWSException {
+        Set<Geometry> geometries = new LinkedHashSet<Geometry>();
+        findFeaturesAndGeometries( feature, geometries, new LinkedHashSet<Feature>(), new LinkedHashSet<String>(),
+                                   new LinkedHashSet<String>() );
         for ( Geometry geometry : geometries ) {
             ICRS crs = geometry.getCoordinateSystem();
             evaluateSrsName( crs, queryCRS, handle );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -790,7 +790,7 @@ public class WebFeatureService extends AbstractOWS {
                 }
                 checkTransactionsEnabled( requestName );
                 Transaction transaction = TransactionKVPAdapter.parse( kvpParamsUC );
-                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response );
+                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response, queryCRS );
                 break;
             default:
                 throw new RuntimeException( "Internal error: Unhandled request '" + requestName + "'." );
@@ -946,7 +946,7 @@ public class WebFeatureService extends AbstractOWS {
                 checkTransactionsEnabled( requestName );
                 TransactionXmlReader transactionReader = new TransactionXmlReaderFactory().createReader( xmlStream );
                 Transaction transaction = transactionReader.read( xmlStream );
-                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response );
+                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response, queryCRS );
                 break;
             default:
                 throw new RuntimeException( "Internal error: Unhandled request '" + requestName + "'." );
@@ -1107,7 +1107,7 @@ public class WebFeatureService extends AbstractOWS {
                 checkTransactionsEnabled( requestName );
                 TransactionXmlReader transactionReader = new TransactionXmlReaderFactory().createReader( requestVersion );
                 Transaction transaction = transactionReader.read( bodyXmlStream );
-                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response );
+                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response, queryCRS );
                 break;
             default:
                 throw new RuntimeException( "Internal error: Unhandled request '" + requestName + "'." );


### PR DESCRIPTION
Chapter A.2.18.2 of the WFS 2.0.0 states following:

> ...
> (1.) Insert another feature with geometries where the value of the srsName parameter is not one of the SRS values the server claims to support in its capabilities document. Verify that the server responds with an exception.
> (2.) Insert a final feature with geometries where the value of the srsName is one of the SRS values the server claims to support in its capabilities but the geometries in the insert action are encoded with an SRS that does not match the one asserted as the value of the srsName parameter. Verify that the server responds with an exception.

This enhancement enables those two behaviours for insert transactions:
1. A check is implemented if any srsName parameter value of the request is present in the capabilities document. If this is not the case, an exception is thrown.
2. A check is added if any used geometries are outside the valid domain of the corresponding SRS. If this is not the case, an exception is thrown.