### PR TITLE
Fixed LatLongBoundingBox in WFS 1.0.0 capabilities to use SRS of FeatureType

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -93,6 +93,8 @@ import org.deegree.commons.tom.ows.LanguageString;
 import org.deegree.commons.tom.ows.Version;
 import org.deegree.commons.utils.Pair;
 import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.exceptions.TransformationException;
+import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.feature.persistence.FeatureStore;
 import org.deegree.feature.persistence.FeatureStoreException;
@@ -287,8 +289,9 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             // }
 
             // wfs:SRS (minOccurs=1, maxOccurs=1)
+            ICRS querySrs = querySRS.get( 0 );
             writer.writeStartElement( WFS_NS, "SRS" );
-            writer.writeCharacters( querySRS.get( 0 ).getAlias() );
+            writer.writeCharacters( querySrs.getAlias() );
             writer.writeEndElement();
 
             // wfs:Operations (minOccurs=0, maxOccurs=1)
@@ -304,7 +307,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             }
             if ( env != null ) {
                 try {
-                    env = transformer.transform( env );
+                    env = transformEnvelopeIntoQuerySrs( querySrs, env );
                     Point min = env.getMin();
                     Point max = env.getMax();
                     double minX = min.get0();
@@ -1119,6 +1122,12 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
     private boolean isPostSupported( WFSRequestType requestType ) {
         return supportedEncodings.isEncodingSupported( requestType, "XML" )
                || supportedEncodings.isEncodingSupported( requestType, "SOAP" );
+    }
+
+    private Envelope transformEnvelopeIntoQuerySrs( ICRS querySrs, Envelope env )
+                            throws TransformationException, UnknownCRSException {
+        GeometryTransformer transformer = new GeometryTransformer( querySrs );
+        return transformer.transform( env );
     }
 
 }


### PR DESCRIPTION
Currently, the LatLongBoundingBox of a FeatureType is always exported in EPSG:4326 in WFS 1.0.0.
If the SRS of a FeatureType differs from EPSG:4326, the LatLongBoundingBox should be exported in that SRS (defined in WFS 1.0.0 Specification; Chapter 12.3.5).

Excerpt of WFS 1.0.0 Specification:
> The LatLongBoundingBox element is used to indicate the edges of an
> enclosing rectangle in the SRS of the associated feature type. Its purpose is
> to facilitate geographic searches by indicating where instances of the
> particular feature type exist. Since multiple LatLongBoundingBoxes can
> be specified, a WFS can indicate where various clusters of data may exist.

This fix corrects this behaviour in WFS 1.0.0 and exports LatLongBoundingBoxes in the corresponding FeatureType SRS.