### PR TITLE
Fixed rendering of text with initialGap and center

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/TextStroke.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/TextStroke.java
@@ -450,25 +450,19 @@ public class TextStroke implements Stroke {
         double textWidth = glyphVector.getLogicalBounds().getWidth();
         double shapeLength = getShapeLength( shape );
 
-        if ( !linePlacement.center ) {
-            textWidth += linePlacement.initialGap;
+        double initialGap = linePlacement.initialGap;
+        if ( linePlacement.center && !linePlacement.repeat ) {
+            double intialGapCenter = shapeLength / 2 - textWidth / 2;
+            if ( intialGapCenter >= linePlacement.initialGap ) {
+                initialGap = intialGapCenter;
+            }
         }
 
-        if ( textWidth > shapeLength ) {
+        if ( textWidth + initialGap > shapeLength ) {
             return new GeneralPath();
         }
 
         shape = handleUpsideDown( shape );
-
-        double initialGap;
-        if ( linePlacement.center && !linePlacement.repeat ) {
-            initialGap = shapeLength / 2 - textWidth / 2;
-            if ( initialGap < linePlacement.initialGap ) {
-                initialGap = linePlacement.initialGap;
-            }
-        } else {
-            initialGap = linePlacement.initialGap;
-        }
 
         if ( linePlacement.wordWise ) {
             GeneralPath path = tryWordWise( shape, initialGap );


### PR DESCRIPTION
The following style renders the labels in a center of a line with at least 10 initialGap.
```xml
<LabelPlacement> 
  <LinePlacement> 
    <PerpendicularOffset>-10</PerpendicularOffset> 
    <IsRepeated>false</IsRepeated>
    <InitialGap>10</InitialGap> 
    <PreventUpsideDown>true</PreventUpsideDown> 
    <Center>true</Center> 
    <WordWise>false</WordWise> 
  </LinePlacement>
</LabelPlacement>
```
Currently the text is also rendered if the length of the label with initialGap (if center is not possible) is longer than the line width, which leads to truncated text.
This pull requests fixes this by not rendering this labels. 