### PR TITLE
Fixed exception code and status code of response when non existent lock is requested

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/ows/exception/OWSException.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/ows/exception/OWSException.java
@@ -118,6 +118,12 @@ public class OWSException extends Exception {
      */
     public static final String CURRENT_UPDATE_SEQUENCE = "CurrentUpdateSequence";
 
+    /**
+     * what the text says
+     */
+    public static final String LOCK_HAS_EXPIRED = "LockHasExpired";
+    
+
     // OSW standard exceptions (+GetCapabilities exceptions)
     /**
      * the requested operation is not supported

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/DefaultLockManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/DefaultLockManager.java
@@ -55,7 +55,6 @@ import org.deegree.commons.jdbc.ResultSetIterator;
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.datetime.DateTime;
 import org.deegree.commons.utils.CloseableIterator;
-import org.deegree.commons.utils.kvp.InvalidParameterValueException;
 import org.deegree.db.ConnectionProvider;
 import org.deegree.feature.Feature;
 import org.deegree.feature.FeatureCollection;
@@ -95,8 +94,7 @@ public class DefaultLockManager implements LockManager {
      * @throws FeatureStoreException
      *             if the initialization of the locking backend fails
      */
-    public DefaultLockManager( FeatureStore store, ConnectionProvider connection )
-                            throws FeatureStoreException {
+    public DefaultLockManager( FeatureStore store, ConnectionProvider connection ) throws FeatureStoreException {
         this.store = store;
         this.connection = connection;
         initDatabase();
@@ -329,7 +327,7 @@ public class DefaultLockManager implements LockManager {
                 LOG.debug( "Using connection: " + conn );
                 stmt = conn.createStatement();
                 rs = stmt.executeQuery( "SELECT ID,ACQUIRED,EXPIRES FROM LOCKS" );
-                lockIter = new ResultSetIterator<Lock>( rs, conn, stmt ) {
+                lockIter = new ResultSetIterator<Lock>( rs, conn, stmt) {
                     @Override
                     protected Lock createElement( ResultSet rs )
                                             throws SQLException {
@@ -382,7 +380,7 @@ public class DefaultLockManager implements LockManager {
                 rs = stmt.executeQuery( "SELECT ACQUIRED,EXPIRES FROM LOCKS WHERE ID=" + lockIdInt + "" );
                 if ( !rs.next() ) {
                     String msg = Messages.getMessage( "LOCK_NO_SUCH_ID", lockId );
-                    throw new InvalidParameterValueException( msg, "lockId" );
+                    throw new LockHasExpiredException( msg, "lockId" );
                 }
                 Timestamp acquired = rs.getTimestamp( 1 );
                 Timestamp expires = rs.getTimestamp( 2 );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/LockHasExpiredException.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/LockHasExpiredException.java
@@ -1,0 +1,62 @@
+//$HeadURL$
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2015 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+----------------------------------------------------------------------------*/
+package org.deegree.feature.persistence.lock;
+
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
+
+/**
+ * Thrown to indicate that a lock has expired.
+ * 
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz</a>
+ */
+public class LockHasExpiredException extends InvalidParameterValueException {
+
+    private static final long serialVersionUID = -5937588941973626816L;
+
+    /**
+     * Constructs a new {@link LockHasExpiredException} with the specified detail message.
+     * 
+     * @param msg
+     *            the detail message (which is saved for later retrieval by the <code>Throwable.getMessage()</code>
+     *            method).
+     * @param parameter
+     *            the name of the missing parameter
+     */
+    public LockHasExpiredException( String msg, String parameter ) {
+        super( msg, parameter );
+    }
+
+}

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
@@ -35,6 +35,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.services.ows;
 
+import static org.deegree.commons.ows.exception.OWSException.LOCK_HAS_EXPIRED;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.ows.exception.OWSException.OPERATION_PROCESSING_FAILED;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
@@ -85,6 +86,8 @@ public class OWS110ExceptionReportSerializer extends XMLExceptionSerializer {
         if ( NO_APPLICABLE_CODE.equals( exception.getExceptionCode() ) ) {
             response.setStatus( 500 );
         } else if ( OPERATION_PROCESSING_FAILED.equals( exception.getExceptionCode() ) ) {
+            response.setStatus( 403 );
+        } else if ( LOCK_HAS_EXPIRED.equals( exception.getExceptionCode() ) ) {
             response.setStatus( 403 );
         } else {
             response.setStatus( 400 );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -282,11 +282,11 @@ public class WebFeatureService extends AbstractOWS {
         }
 
         queryMaxFeatures = jaxbConfig.getQueryMaxFeatures() == null ? DEFAULT_MAX_FEATURES
-                                                                    : jaxbConfig.getQueryMaxFeatures().intValue();
+                                                                   : jaxbConfig.getQueryMaxFeatures().intValue();
         resolveTimeOutInSeconds = jaxbConfig.getResolveTimeOutInSeconds();
         checkAreaOfUse = jaxbConfig.isQueryCheckAreaOfUse() == null ? false : jaxbConfig.isQueryCheckAreaOfUse();
         enableResponsePaging = jaxbConfig.isEnableResponsePaging() == null ? false
-                                                                           : jaxbConfig.isEnableResponsePaging();
+                                                                          : jaxbConfig.isEnableResponsePaging();
 
         service = new WfsFeatureStoreManager();
         try {
@@ -410,11 +410,12 @@ public class WebFeatureService extends AbstractOWS {
 
     private boolean isAtLeastOneRequestTypeConfigured( SupportedRequests supportedRequests ) {
         return supportedRequests.getCreateStoredQuery() != null || supportedRequests.getDescribeFeatureType() != null
-               || supportedRequests.getDescribeStoredQueries() != null || supportedRequests.getDropStoredQuery() != null
-               || supportedRequests.getGetCapabilities() != null || supportedRequests.getGetFeature() != null
-               || supportedRequests.getGetFeatureWithLock() != null || supportedRequests.getGetGmlObject() != null
-               || supportedRequests.getGetPropertyValue() != null || supportedRequests.getListStoredQueries() != null
-               || supportedRequests.getLockFeature() != null || supportedRequests.getTransaction() != null;
+               || supportedRequests.getDescribeStoredQueries() != null
+               || supportedRequests.getDropStoredQuery() != null || supportedRequests.getGetCapabilities() != null
+               || supportedRequests.getGetFeature() != null || supportedRequests.getGetFeatureWithLock() != null
+               || supportedRequests.getGetGmlObject() != null || supportedRequests.getGetPropertyValue() != null
+               || supportedRequests.getListStoredQueries() != null || supportedRequests.getLockFeature() != null
+               || supportedRequests.getTransaction() != null;
     }
 
     private Set<String> collectEnabledEncodings( RequestType supportedEncodingsForThisType,
@@ -507,13 +508,17 @@ public class WebFeatureService extends AbstractOWS {
 
         if ( formatList == null || formatList.isEmpty() ) {
             LOG.debug( "Using default format configuration." );
-            org.deegree.services.wfs.format.gml.GmlFormat gml21 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml21 = new org.deegree.services.wfs.format.gml.GmlFormat(
+                                                                                                                     this,
                                                                                                                      GML_2 );
-            org.deegree.services.wfs.format.gml.GmlFormat gml30 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml30 = new org.deegree.services.wfs.format.gml.GmlFormat(
+                                                                                                                     this,
                                                                                                                      GML_30 );
-            org.deegree.services.wfs.format.gml.GmlFormat gml31 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml31 = new org.deegree.services.wfs.format.gml.GmlFormat(
+                                                                                                                     this,
                                                                                                                      GML_31 );
-            org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat(
+                                                                                                                     this,
 
                                                                                                                      GML_32 );
             mimeTypeToFormat.put( "application/gml+xml; version=2.1", gml21 );
@@ -564,12 +569,11 @@ public class WebFeatureService extends AbstractOWS {
         }
     }
 
-    private OWSMetadataProvider initMetadataProvider( DeegreeServicesMetadataType serviceMetadata,
-                                                      DeegreeWFS jaxbConfig )
-                                                                              throws ResourceInitException {
+    private OWSMetadataProvider initMetadataProvider( DeegreeServicesMetadataType serviceMetadata, DeegreeWFS jaxbConfig )
+                            throws ResourceInitException {
         OWSMetadataProvider provider = null;
-        provider = workspace.getResource( OWSMetadataProviderProvider.class,
-                                          getMetadata().getIdentifier().getId() + "_metadata" );
+        provider = workspace.getResource( OWSMetadataProviderProvider.class, getMetadata().getIdentifier().getId()
+                                                                             + "_metadata" );
 
         if ( provider == null ) {
             ServiceIdentification serviceId = MetadataUtils.convertFromJAXB( serviceMetadata.getServiceIdentification() );
@@ -642,8 +646,7 @@ public class WebFeatureService extends AbstractOWS {
                     try {
                         xmlStream = XMLInputFactory.newInstance().createXMLStreamReader( domSource );
                     } catch ( Exception t ) {
-                        throw new ResourceInitException( "Error extracting extended capabilities: " + t.getMessage(),
-                                                         t );
+                        throw new ResourceInitException( "Error extracting extended capabilities: " + t.getMessage(), t );
                     }
                     OMElement omEl = new XMLAdapter( xmlStream ).getRootElement();
                     for ( String wfsVersion : extendedCapConfig.getWfsVersions() ) {
@@ -655,8 +658,8 @@ public class WebFeatureService extends AbstractOWS {
                     }
                 }
             }
-            provider = new DefaultOWSMetadataProvider( serviceId, serviceProvider, wfsVersionToExtendedCaps, ftMetadata,
-                                                       Collections.<String, String> emptyMap(), null );
+            provider = new DefaultOWSMetadataProvider( serviceId, serviceProvider, wfsVersionToExtendedCaps,
+                                                       ftMetadata, Collections.<String, String> emptyMap(), null );
         }
         return provider;
     }
@@ -685,7 +688,7 @@ public class WebFeatureService extends AbstractOWS {
     @Override
     public void doKVP( Map<String, String> kvpParamsUC, HttpServletRequest request, HttpResponseBuffer response,
                        List<FileItem> multiParts )
-                                               throws ServletException, IOException {
+                            throws ServletException, IOException {
 
         LOG.debug( "doKVP" );
         Version requestVersion = null;
@@ -837,7 +840,7 @@ public class WebFeatureService extends AbstractOWS {
     @Override
     public void doXML( XMLStreamReader xmlStream, HttpServletRequest request, HttpResponseBuffer response,
                        List<FileItem> multiParts )
-                                               throws ServletException, IOException {
+                            throws ServletException, IOException {
 
         LOG.debug( "doXML" );
         Version requestVersion = null;
@@ -987,8 +990,7 @@ public class WebFeatureService extends AbstractOWS {
     @Override
     public void doSOAP( SOAPEnvelope soapDoc, HttpServletRequest request, HttpResponseBuffer response,
                         List<FileItem> multiParts, SOAPFactory factory )
-                                                throws ServletException, IOException,
-                                                org.deegree.services.authentication.SecurityException {
+                            throws ServletException, IOException, org.deegree.services.authentication.SecurityException {
         LOG.debug( "doSOAP" );
 
         if ( disableBuffering ) {
@@ -1276,7 +1278,7 @@ public class WebFeatureService extends AbstractOWS {
      */
     public static XMLStreamWriter getXMLResponseWriter( HttpResponseBuffer writer, String mimeType,
                                                         String schemaLocation )
-                                                                                throws XMLStreamException, IOException {
+                            throws XMLStreamException, IOException {
 
         boolean needsEncoding = mimeType.startsWith( "text" );
         XMLStreamWriter xmlWriter = writer.getXMLWriter( needsEncoding );
@@ -1297,7 +1299,7 @@ public class WebFeatureService extends AbstractOWS {
 
     private void sendSoapException( SOAPEnvelope soapDoc, SOAPFactory factory, HttpResponseBuffer response,
                                     OWSException e, ServletRequest request, Version requestVersion )
-                                                            throws OMException, ServletException {
+                            throws OMException, ServletException {
         XMLExceptionSerializer serializer = getExceptionSerializer( requestVersion );
         sendSOAPException( soapDoc.getHeader(), factory, response, e, serializer, null, null, request.getServerName(),
                            request.getCharacterEncoding() );
@@ -1427,8 +1429,8 @@ public class WebFeatureService extends AbstractOWS {
             version = VERSION_110;
         }
         if ( !offeredVersions.contains( version ) ) {
-            throw new OWSException( Messages.get( "CONTROLLER_UNSUPPORTED_VERSION", version,
-                                                  getOfferedVersionsString() ),
+            throw new OWSException(
+                                    Messages.get( "CONTROLLER_UNSUPPORTED_VERSION", version, getOfferedVersionsString() ),
                                     OWSException.INVALID_PARAMETER_VALUE );
         }
         return version;
@@ -1437,7 +1439,8 @@ public class WebFeatureService extends AbstractOWS {
     private void checkGetFeatureWithLockRequest( Version requestVersion, GetFeatureWithLock getFeatureWithLock ) {
         if ( VERSION_200.equals( requestVersion )
              && HITS.equals( getFeatureWithLock.getPresentationParams().getResultType() ) )
-            throw new InvalidParameterValueException( "ResultType 'hits' is not allowed in GetFeatureWithLock requests!" );
+            throw new InvalidParameterValueException(
+                                                      "ResultType 'hits' is not allowed in GetFeatureWithLock requests!" );
     }
 
 }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -36,6 +36,7 @@
 package org.deegree.services.wfs;
 
 import static org.deegree.commons.ows.exception.OWSException.INVALID_PARAMETER_VALUE;
+import static org.deegree.commons.ows.exception.OWSException.LOCK_HAS_EXPIRED;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.ows.exception.OWSException.OPERATION_NOT_SUPPORTED;
 import static org.deegree.commons.utils.StringUtils.REMOVE_DOUBLE_FIELDS;
@@ -116,6 +117,7 @@ import org.deegree.cs.CRSUtils;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.feature.persistence.FeatureStore;
+import org.deegree.feature.persistence.lock.LockHasExpiredException;
 import org.deegree.feature.types.FeatureType;
 import org.deegree.gml.GMLVersion;
 import org.deegree.protocol.ows.getcapabilities.GetCapabilities;
@@ -280,11 +282,11 @@ public class WebFeatureService extends AbstractOWS {
         }
 
         queryMaxFeatures = jaxbConfig.getQueryMaxFeatures() == null ? DEFAULT_MAX_FEATURES
-                                                                   : jaxbConfig.getQueryMaxFeatures().intValue();
+                                                                    : jaxbConfig.getQueryMaxFeatures().intValue();
         resolveTimeOutInSeconds = jaxbConfig.getResolveTimeOutInSeconds();
         checkAreaOfUse = jaxbConfig.isQueryCheckAreaOfUse() == null ? false : jaxbConfig.isQueryCheckAreaOfUse();
         enableResponsePaging = jaxbConfig.isEnableResponsePaging() == null ? false
-                                                                          : jaxbConfig.isEnableResponsePaging();
+                                                                           : jaxbConfig.isEnableResponsePaging();
 
         service = new WfsFeatureStoreManager();
         try {
@@ -408,12 +410,11 @@ public class WebFeatureService extends AbstractOWS {
 
     private boolean isAtLeastOneRequestTypeConfigured( SupportedRequests supportedRequests ) {
         return supportedRequests.getCreateStoredQuery() != null || supportedRequests.getDescribeFeatureType() != null
-               || supportedRequests.getDescribeStoredQueries() != null
-               || supportedRequests.getDropStoredQuery() != null || supportedRequests.getGetCapabilities() != null
-               || supportedRequests.getGetFeature() != null || supportedRequests.getGetFeatureWithLock() != null
-               || supportedRequests.getGetGmlObject() != null || supportedRequests.getGetPropertyValue() != null
-               || supportedRequests.getListStoredQueries() != null || supportedRequests.getLockFeature() != null
-               || supportedRequests.getTransaction() != null;
+               || supportedRequests.getDescribeStoredQueries() != null || supportedRequests.getDropStoredQuery() != null
+               || supportedRequests.getGetCapabilities() != null || supportedRequests.getGetFeature() != null
+               || supportedRequests.getGetFeatureWithLock() != null || supportedRequests.getGetGmlObject() != null
+               || supportedRequests.getGetPropertyValue() != null || supportedRequests.getListStoredQueries() != null
+               || supportedRequests.getLockFeature() != null || supportedRequests.getTransaction() != null;
     }
 
     private Set<String> collectEnabledEncodings( RequestType supportedEncodingsForThisType,
@@ -506,17 +507,13 @@ public class WebFeatureService extends AbstractOWS {
 
         if ( formatList == null || formatList.isEmpty() ) {
             LOG.debug( "Using default format configuration." );
-            org.deegree.services.wfs.format.gml.GmlFormat gml21 = new org.deegree.services.wfs.format.gml.GmlFormat(
-                                                                                                                     this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml21 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
                                                                                                                      GML_2 );
-            org.deegree.services.wfs.format.gml.GmlFormat gml30 = new org.deegree.services.wfs.format.gml.GmlFormat(
-                                                                                                                     this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml30 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
                                                                                                                      GML_30 );
-            org.deegree.services.wfs.format.gml.GmlFormat gml31 = new org.deegree.services.wfs.format.gml.GmlFormat(
-                                                                                                                     this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml31 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
                                                                                                                      GML_31 );
-            org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat(
-                                                                                                                     this,
+            org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat( this,
 
                                                                                                                      GML_32 );
             mimeTypeToFormat.put( "application/gml+xml; version=2.1", gml21 );
@@ -567,11 +564,12 @@ public class WebFeatureService extends AbstractOWS {
         }
     }
 
-    private OWSMetadataProvider initMetadataProvider( DeegreeServicesMetadataType serviceMetadata, DeegreeWFS jaxbConfig )
-                            throws ResourceInitException {
+    private OWSMetadataProvider initMetadataProvider( DeegreeServicesMetadataType serviceMetadata,
+                                                      DeegreeWFS jaxbConfig )
+                                                                              throws ResourceInitException {
         OWSMetadataProvider provider = null;
-        provider = workspace.getResource( OWSMetadataProviderProvider.class, getMetadata().getIdentifier().getId()
-                                                                             + "_metadata" );
+        provider = workspace.getResource( OWSMetadataProviderProvider.class,
+                                          getMetadata().getIdentifier().getId() + "_metadata" );
 
         if ( provider == null ) {
             ServiceIdentification serviceId = MetadataUtils.convertFromJAXB( serviceMetadata.getServiceIdentification() );
@@ -644,7 +642,8 @@ public class WebFeatureService extends AbstractOWS {
                     try {
                         xmlStream = XMLInputFactory.newInstance().createXMLStreamReader( domSource );
                     } catch ( Exception t ) {
-                        throw new ResourceInitException( "Error extracting extended capabilities: " + t.getMessage(), t );
+                        throw new ResourceInitException( "Error extracting extended capabilities: " + t.getMessage(),
+                                                         t );
                     }
                     OMElement omEl = new XMLAdapter( xmlStream ).getRootElement();
                     for ( String wfsVersion : extendedCapConfig.getWfsVersions() ) {
@@ -656,8 +655,8 @@ public class WebFeatureService extends AbstractOWS {
                     }
                 }
             }
-            provider = new DefaultOWSMetadataProvider( serviceId, serviceProvider, wfsVersionToExtendedCaps,
-                                                       ftMetadata, Collections.<String, String> emptyMap(), null );
+            provider = new DefaultOWSMetadataProvider( serviceId, serviceProvider, wfsVersionToExtendedCaps, ftMetadata,
+                                                       Collections.<String, String> emptyMap(), null );
         }
         return provider;
     }
@@ -686,7 +685,7 @@ public class WebFeatureService extends AbstractOWS {
     @Override
     public void doKVP( Map<String, String> kvpParamsUC, HttpServletRequest request, HttpResponseBuffer response,
                        List<FileItem> multiParts )
-                            throws ServletException, IOException {
+                                               throws ServletException, IOException {
 
         LOG.debug( "doKVP" );
         Version requestVersion = null;
@@ -809,6 +808,13 @@ public class WebFeatureService extends AbstractOWS {
             LOG.debug( "OWS-Exception: {}", e.getMessage() );
             LOG.trace( e.getMessage(), e );
             sendServiceException( requestVersion, new OWSException( e ), response );
+        } catch ( LockHasExpiredException e ) {
+            LOG.debug( "OWS-Exception: {}", e.getMessage() );
+            LOG.trace( e.getMessage(), e );
+            if ( VERSION_200.equals( requestVersion ) )
+                sendServiceException( requestVersion, new OWSException( e.getMessage(), LOCK_HAS_EXPIRED ), response );
+            else
+                sendServiceException( requestVersion, new OWSException( e ), response );
         } catch ( InvalidParameterValueException e ) {
             LOG.debug( "OWS-Exception: {}", e.getMessage() );
             LOG.trace( e.getMessage(), e );
@@ -831,7 +837,7 @@ public class WebFeatureService extends AbstractOWS {
     @Override
     public void doXML( XMLStreamReader xmlStream, HttpServletRequest request, HttpResponseBuffer response,
                        List<FileItem> multiParts )
-                            throws ServletException, IOException {
+                                               throws ServletException, IOException {
 
         LOG.debug( "doXML" );
         Version requestVersion = null;
@@ -963,6 +969,12 @@ public class WebFeatureService extends AbstractOWS {
         } catch ( MissingParameterException e ) {
             LOG.trace( "Stack trace:", e );
             sendServiceException( requestVersion, new OWSException( e ), response );
+        } catch ( LockHasExpiredException e ) {
+            LOG.trace( "Stack trace:", e );
+            if ( VERSION_200.equals( requestVersion ) )
+                sendServiceException( requestVersion, new OWSException( e.getMessage(), LOCK_HAS_EXPIRED ), response );
+            else
+                sendServiceException( requestVersion, new OWSException( e ), response );
         } catch ( InvalidParameterValueException e ) {
             LOG.trace( "Stack trace:", e );
             sendServiceException( requestVersion, new OWSException( e ), response );
@@ -975,7 +987,8 @@ public class WebFeatureService extends AbstractOWS {
     @Override
     public void doSOAP( SOAPEnvelope soapDoc, HttpServletRequest request, HttpResponseBuffer response,
                         List<FileItem> multiParts, SOAPFactory factory )
-                            throws ServletException, IOException, org.deegree.services.authentication.SecurityException {
+                                                throws ServletException, IOException,
+                                                org.deegree.services.authentication.SecurityException {
         LOG.debug( "doSOAP" );
 
         if ( disableBuffering ) {
@@ -1126,6 +1139,14 @@ public class WebFeatureService extends AbstractOWS {
         } catch ( MissingParameterException e ) {
             LOG.trace( "Stack trace:", e );
             sendSoapException( soapDoc, factory, response, new OWSException( e ), request, requestVersion );
+
+        } catch ( LockHasExpiredException e ) {
+            LOG.trace( "Stack trace:", e );
+            if ( VERSION_200.equals( requestVersion ) )
+                sendSoapException( soapDoc, factory, response, new OWSException( e.getMessage(), LOCK_HAS_EXPIRED ),
+                                   request, requestVersion );
+            else
+                sendSoapException( soapDoc, factory, response, new OWSException( e ), request, requestVersion );
         } catch ( InvalidParameterValueException e ) {
             LOG.trace( "Stack trace:", e );
             sendSoapException( soapDoc, factory, response, new OWSException( e ), request, requestVersion );
@@ -1255,7 +1276,7 @@ public class WebFeatureService extends AbstractOWS {
      */
     public static XMLStreamWriter getXMLResponseWriter( HttpResponseBuffer writer, String mimeType,
                                                         String schemaLocation )
-                            throws XMLStreamException, IOException {
+                                                                                throws XMLStreamException, IOException {
 
         boolean needsEncoding = mimeType.startsWith( "text" );
         XMLStreamWriter xmlWriter = writer.getXMLWriter( needsEncoding );
@@ -1276,7 +1297,7 @@ public class WebFeatureService extends AbstractOWS {
 
     private void sendSoapException( SOAPEnvelope soapDoc, SOAPFactory factory, HttpResponseBuffer response,
                                     OWSException e, ServletRequest request, Version requestVersion )
-                            throws OMException, ServletException {
+                                                            throws OMException, ServletException {
         XMLExceptionSerializer serializer = getExceptionSerializer( requestVersion );
         sendSOAPException( soapDoc.getHeader(), factory, response, e, serializer, null, null, request.getServerName(),
                            request.getCharacterEncoding() );
@@ -1406,8 +1427,8 @@ public class WebFeatureService extends AbstractOWS {
             version = VERSION_110;
         }
         if ( !offeredVersions.contains( version ) ) {
-            throw new OWSException(
-                                    Messages.get( "CONTROLLER_UNSUPPORTED_VERSION", version, getOfferedVersionsString() ),
+            throw new OWSException( Messages.get( "CONTROLLER_UNSUPPORTED_VERSION", version,
+                                                  getOfferedVersionsString() ),
                                     OWSException.INVALID_PARAMETER_VALUE );
         }
         return version;
@@ -1416,8 +1437,7 @@ public class WebFeatureService extends AbstractOWS {
     private void checkGetFeatureWithLockRequest( Version requestVersion, GetFeatureWithLock getFeatureWithLock ) {
         if ( VERSION_200.equals( requestVersion )
              && HITS.equals( getFeatureWithLock.getPresentationParams().getResultType() ) )
-            throw new InvalidParameterValueException(
-                                                      "ResultType 'hits' is not allowed in GetFeatureWithLock requests!" );
+            throw new InvalidParameterValueException( "ResultType 'hits' is not allowed in GetFeatureWithLock requests!" );
     }
 
 }


### PR DESCRIPTION
This fix targets the locking functionality of WFS 2.0.0.

Previously, when LockFeature was requested with a non existent lockId, the WFS 2.0.0 threw an InvalidParameterValue exception with status code 400.

The specification says that following is expected:
 * status code: 403
 * exception code: LockHasExpired

Excerpt from WFS 2.0.0 specification:
```
12.2.4.2 lockId parameter

A lockId parameter specified within a LockFeature operations shall be used to reset the expiry time of an existing lock.
...
Such a LockFeature operation shall be executed before the specified lock has expired; otherwise the server shall raise a LockHasExpired exception (see Table 3).
...
```

This fix corrects the status and exception codes to implement the expected behaviour.

In addition, deegree now passes following tests of the CITE WFS 2.0 test suite (Locking CC) [1]:
 * "Reset Nonexistent Lock"
 * "Lock All Query Results_20 Seconds"

[1] http://cite.opengeospatial.org/teamengine/