### PR TITLE
Fixed exception code and status code of response when invalid geometry is inserted

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -39,6 +39,7 @@ package org.deegree.services.wfs;
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 import static org.deegree.commons.ows.exception.OWSException.INVALID_PARAMETER_VALUE;
+import static org.deegree.commons.ows.exception.OWSException.INVALID_VALUE;
 import static org.deegree.commons.ows.exception.OWSException.MISSING_PARAMETER_VALUE;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.ows.exception.OWSException.OPERATION_NOT_SUPPORTED;
@@ -424,8 +425,10 @@ class TransactionHandler {
 
     private FeatureCollection parseFeaturesOrCollection( XMLStreamReader xmlStream, GMLVersion inputFormat,
                                                          ICRS defaultCRS )
-                            throws XMLStreamException, XMLParsingException, UnknownCRSException,
-                            ReferenceResolvingException {
+                                                                                 throws XMLStreamException,
+                                                                                 XMLParsingException,
+                                                                                 UnknownCRSException,
+                                                                                 ReferenceResolvingException {
 
         FeatureCollection fc = null;
 
@@ -605,7 +608,8 @@ class TransactionHandler {
             PropertyType pt = ft.getPropertyDeclaration( propName );
             if ( pt == null ) {
                 throw new OWSException( "Cannot update property '" + propName + "' of feature type '" + ft.getName()
-                                        + "'. The feature type does not define this property.", OPERATION_NOT_SUPPORTED );
+                                        + "'. The feature type does not define this property.",
+                                        OPERATION_NOT_SUPPORTED );
             }
             XMLStreamReader xmlStream = replacement.getReplacementValue();
             int index = simpleMultiProp == null ? 0 : simpleMultiProp.second;
@@ -622,7 +626,8 @@ class TransactionHandler {
                     GMLFeatureReader featureReader = gmlReader.getFeatureReader();
 
                     ICRS crs = master.getDefaultQueryCrs();
-                    Property prop = featureReader.parseProperty( new XMLStreamReaderWrapper( xmlStream, null ), pt, crs );
+                    Property prop = featureReader.parseProperty( new XMLStreamReaderWrapper( xmlStream, null ), pt,
+                                                                 crs );
 
                     // TODO make this hack unnecessary
                     TypedObjectNode propValue = prop.getValue();
@@ -641,6 +646,9 @@ class TransactionHandler {
                     xmlStream.require( END_ELEMENT, null, "Property" );
                     // contract: skip to next ELEMENT_EVENT
                     xmlStream.nextTag();
+                } catch ( XMLParsingException e ) {
+                    LOG.debug( e.getMessage(), e );
+                    throw new OWSException( e.getMessage(), INVALID_VALUE );
                 } catch ( Exception e ) {
                     LOG.debug( e.getMessage(), e );
                     throw new OWSException( e.getMessage(), NO_APPLICABLE_CODE );


### PR DESCRIPTION
This fix targets the transaction functionality of WFS 2.0.0.

Previously, when transactions were done with invalid geometries, the WFS 2.0.0 threw an NoApplicableCode exception with status code 500.

The specification says that following is expected:
 * status code: 400
 * exception code:  InvalidValue

Excerpt from WFS 2.0.0 specification:
```
15.2.5.2.1 Property element

In all cases, if the specified action results in invalidating the feature instance 
according to the feature type schema obtained using a DescribeFeatureType operation 
(see Clause 9), the server shall raise a InvalidValue exception (see 7.5).
```

This fix corrects the status and exception codes to implement the expected behaviour.

In addition, deegree now passes following test of the CITE WFS 2.0 test suite (Transactional CC) [1]:
 * "Update Bounded By With K M L Point"

[1] http://cite.opengeospatial.org/teamengine/