### PR TITLE
Updated behaviour of replace transaction in WFS 2.0.0

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
@@ -36,6 +36,7 @@
 package org.deegree.feature.persistence.memory;
 
 import static org.deegree.feature.i18n.Messages.getMessage;
+import static org.deegree.protocol.wfs.transaction.action.IDGenMode.USE_EXISTING;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -569,7 +570,7 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
         }
         GenericFeatureCollection col = new GenericFeatureCollection();
         col.add( replacement );
-        List<String> ids = performInsert( col, idGenMode );
+        List<String> ids = performInsert( col, USE_EXISTING );
         if ( ids.isEmpty() || ids.size() > 1 ) {
             throw new FeatureStoreException( "Unable to determine new feature id." );
         }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
@@ -37,6 +37,7 @@ package org.deegree.feature.persistence.sql;
 
 import static org.deegree.feature.Features.findFeaturesAndGeometries;
 import static org.deegree.feature.types.property.GeometryPropertyType.CoordinateDimension.DIM_2;
+import static org.deegree.protocol.wfs.transaction.action.IDGenMode.USE_EXISTING;
 
 import java.io.ByteArrayOutputStream;
 import java.sql.Connection;
@@ -1062,7 +1063,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
         }
         final GenericFeatureCollection col = new GenericFeatureCollection();
         col.add( replacement );
-        final List<String> ids = performInsert( col, idGenMode );
+        final List<String> ids = performInsert( col, USE_EXISTING );
         if ( ids.isEmpty() || ids.size() > 1 ) {
             throw new FeatureStoreException( "Unable to determine new feature id." );
         }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/FeatureRow.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/FeatureRow.java
@@ -44,6 +44,9 @@ import java.util.Set;
 
 import org.deegree.commons.jdbc.SQLIdentifier;
 import org.deegree.commons.tom.primitive.BaseType;
+import org.deegree.commons.tom.primitive.PrimitiveType;
+import org.deegree.commons.tom.primitive.PrimitiveValue;
+import org.deegree.commons.tom.sql.PrimitiveParticleConverter;
 import org.deegree.commons.utils.Pair;
 import org.deegree.feature.Feature;
 import org.deegree.feature.persistence.FeatureStoreException;
@@ -199,9 +202,13 @@ public class FeatureRow extends InsertRow {
         }
         for ( int i = 0; i < fidMapping.getColumns().size(); i++ ) {
             Pair<SQLIdentifier, BaseType> idColumn = fidMapping.getColumns().get( i );
-            // TODO mapping to non-string columns
             Object value = idKernels[i];
-            addPreparedArgument( idColumn.getFirst(), value );
+            BaseType baseType = idColumn.second != null ? idColumn.second : BaseType.STRING;
+            PrimitiveType type = new PrimitiveType( baseType );
+            PrimitiveValue primitiveValue = new PrimitiveValue( value, type );
+            PrimitiveParticleConverter primitiveConverter = mgr.getDialect().getPrimitiveConverter( idColumn.first.getName(),
+                                                                                                    type );
+            addPreparedArgument( idColumn.getFirst(), primitiveValue, primitiveConverter );
         }
     }
 

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -130,6 +130,9 @@ By default, WFS-T requests will be rejected. Setting the ``EnableTransactions`` 
 .. hint::
    In a WFS 1.1.0 insert, the id generation mode can be overridden by attribute *idGenMode* of the ``Insert`` element. WFS 1.0.0 and WFS 2.0.0 don't support to specify the id generation mode on a request basis.
 
+.. hint::
+   When a feature is replaced the ``UseExisting`` option is always activated for that transaction. The gml:id of the feature is used for the new version of the feature. The filter is used to identify the feature to be replaced.
+
 ^^^^^^^^^^^^^^^^^^
 SupportedRequests
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Previously, when idGenMode useExisting was not activated, a replace transaction of the WFS 2.0.0 generated a new gml:id for the replaced feature (technically, a delete and insert operation is executed).
This is not conform to the specification as a replace transaction should replace an existing feature and not create a new one.

This behaviour was fixed by always activating the UseExisting option for replace transactions. This makes replacements of existing features possbile even if idGenMode useExisting is not activated.

When discussing this pull request, it has to be considered, that the current behaviour of deegree is modified. Now, a replace transaction with disabled UseExisting option uses the gml:id of the feature of the request instead of generating a new gml:id.

In addition, deegree now passes following test of the CITE WFS 2.0 test suite (Transactional CC) [1] when idGenMode useExisting is not activated:
 *  "replace Feature"

[1] http://cite.opengeospatial.org/teamengine/