### PR TITLE
Fixed handling of BigDecimal data type

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/primitive/XMLValueMangler.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/primitive/XMLValueMangler.java
@@ -47,8 +47,8 @@ import java.math.BigInteger;
 
 import org.deegree.commons.tom.datetime.Date;
 import org.deegree.commons.tom.datetime.DateTime;
-import org.deegree.commons.tom.datetime.Time;
 import org.deegree.commons.tom.datetime.Temporal;
+import org.deegree.commons.tom.datetime.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,7 +164,11 @@ public class XMLValueMangler {
                     xml = "" + o;
                     break;
                 case DECIMAL:
-                    xml = "" + o;
+                    if ( o instanceof BigDecimal ) {
+                        xml = ( (BigDecimal) o ).toPlainString();
+                    } else {
+                        xml = "" + o;
+                    }
                     break;
                 case DOUBLE:
                     xml = "" + o;


### PR DESCRIPTION
Previously, the handling of BigDecimal data type was not correct in deegree as exponents could be returned in a GML response. For example, following property value is possible in a GetFeature response: "5.4578635E+10".

This pull request fixes that BigDecimal are always exported as plain text (without exponent).