### PR TITLE
Fixed GetLegendGraphic from RemoteWMSLayer

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
@@ -107,7 +107,11 @@ class LegendBuilder {
         if ( url != null ) {
             try {
                 BufferedImage legend = ImageIO.read( url );
-                return new Pair<Integer, Integer>( legend.getWidth(), legend.getHeight() );
+                if ( legend != null ) {
+                    return new Pair<Integer, Integer>( legend.getWidth(), legend.getHeight() );
+                } else {
+                    LOG.warn( "Legend file {} could not be read, using dynamic legend.", url );
+                }
             } catch ( IOException e ) {
                 LOG.warn( "Legend file {} could not be read, using dynamic legend: {}", url, e.getLocalizedMessage() );
                 LOG.trace( "Stack trace:", e );

--- a/deegree-layers/deegree-layers-remotewms/src/main/java/org/deegree/layer/persistence/remotewms/RemoteWmsLayerBuilder.java
+++ b/deegree-layers/deegree-layers-remotewms/src/main/java/org/deegree/layer/persistence/remotewms/RemoteWmsLayerBuilder.java
@@ -110,6 +110,8 @@ class RemoteWmsLayerBuilder {
             LayerMetadata confMd = configured.get( name );
             if ( confMd != null ) {
                 confMd.merge( md );
+                confMd.setStyles( md.getStyles() );
+                confMd.setLegendStyles( md.getLegendStyles() );
                 map.put( confMd.getName(), new RemoteWMSLayer( name, confMd, client, opts ) );
             }
         }

--- a/deegree-layers/deegree-layers-remotewms/src/main/java/org/deegree/layer/persistence/remotewms/RemoteWmsLayerBuilder.java
+++ b/deegree-layers/deegree-layers-remotewms/src/main/java/org/deegree/layer/persistence/remotewms/RemoteWmsLayerBuilder.java
@@ -82,9 +82,41 @@ class RemoteWmsLayerBuilder {
     }
 
     Map<String, Layer> buildLayerMap() {
-        RequestOptionsType opts = cfg.getRequestOptions();
+        Map<String, LayerMetadata> configured = collectConfiguredLayers();
+        if ( configured.isEmpty() )
+            return parseAllRemoteLayers();
+        return collectConfiguredRemoteLayers( configured );
+    }
+
+    private Map<String, Layer> parseAllRemoteLayers() {
         Map<String, Layer> map = new LinkedHashMap<String, Layer>();
 
+        RequestOptionsType opts = cfg.getRequestOptions();
+        List<LayerMetadata> layers = client.getLayerTree().flattenDepthFirst();
+        for ( LayerMetadata md : layers ) {
+            if ( md.getName() != null ) {
+                map.put( md.getName(), new RemoteWMSLayer( md.getName(), md, client, opts ) );
+            }
+        }
+        return map;
+    }
+
+    private Map<String, Layer> collectConfiguredRemoteLayers( Map<String, LayerMetadata> configured ) {
+        Map<String, Layer> map = new LinkedHashMap<String, Layer>();
+        RequestOptionsType opts = cfg.getRequestOptions();
+        List<LayerMetadata> layers = client.getLayerTree().flattenDepthFirst();
+        for ( LayerMetadata md : layers ) {
+            String name = md.getName();
+            LayerMetadata confMd = configured.get( name );
+            if ( confMd != null ) {
+                confMd.merge( md );
+                map.put( confMd.getName(), new RemoteWMSLayer( name, confMd, client, opts ) );
+            }
+        }
+        return map;
+    }
+
+    private Map<String, LayerMetadata> collectConfiguredLayers() {
         Map<String, LayerMetadata> configured = new HashMap<String, LayerMetadata>();
         if ( cfg.getLayer() != null ) {
             for ( LayerType l : cfg.getLayer() ) {
@@ -105,25 +137,7 @@ class RemoteWmsLayerBuilder {
                 configured.put( l.getOriginalName(), md );
             }
         }
-
-        List<LayerMetadata> layers = client.getLayerTree().flattenDepthFirst();
-        if ( configured.isEmpty() ) {
-            for ( LayerMetadata md : layers ) {
-                if ( md.getName() != null ) {
-                    map.put( md.getName(), new RemoteWMSLayer( md.getName(), md, client, opts ) );
-                }
-            }
-        } else {
-            for ( LayerMetadata md : layers ) {
-                String name = md.getName();
-                LayerMetadata confMd = configured.get( name );
-                if ( confMd != null ) {
-                    confMd.merge( md );
-                    map.put( confMd.getName(), new RemoteWMSLayer( name, confMd, client, opts ) );
-                }
-            }
-        }
-        return map;
+        return configured;
     }
 
 }


### PR DESCRIPTION
This pull requests enables support of GetLegendGraphic from RemoteWMSLayer. Previously a NPE was thrown cause the legend of the RemoteWMSLayer was not available. This NPE was fixed by checking if the legend is null (e.g. not readable from remote service). Furthermore  the RemoteWMSLayerBuilder was enhanced to provide the legends from the remote service.