### PR TITLE
Fixed parsing of CompositeSurfaces in hierarchies for GML 3

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/AppSchemaGeometryHierarchy.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/AppSchemaGeometryHierarchy.java
@@ -70,7 +70,9 @@ public class AppSchemaGeometryHierarchy {
     private final Set<QName> abstractSurfaceElements;
 
     private final Set<QName> surfaceElements;
-
+    
+    private final Set<QName> compositeSurfaceElements;
+    
     private final Set<QName> solidElements;
 
     private final Set<QName> ringElements;
@@ -106,6 +108,9 @@ public class AppSchemaGeometryHierarchy {
         elName = new QName( gmlVersion.getNamespace(), "Surface" );
         surfaceElements = getConcreteSubstitutions( appSchema, elName );
 
+        elName = new QName( gmlVersion.getNamespace(), "CompositeSurface" );
+        compositeSurfaceElements = getConcreteSubstitutions( appSchema, elName );
+        
         elName = getAbstractElementName( "Solid", gmlVersion );
         solidElements = getConcreteSubstitutions( appSchema, elName );
 
@@ -159,7 +164,7 @@ public class AppSchemaGeometryHierarchy {
     public Set<QName> getCompositeCurveSubstitutions() {
         return compositeCurveElements;
     }
-
+    
     public Set<QName> getOrientableCurveSubstitutions() {
         return orientableCurveElements;
     }
@@ -170,6 +175,10 @@ public class AppSchemaGeometryHierarchy {
 
     public Set<QName> getSurfaceSubstitutions() {
         return surfaceElements;
+    }
+
+    public Set<QName> getCompositeSurfaceSubstitutions() {
+        return compositeSurfaceElements;
     }
 
     public Set<QName> getSolidElementNames() {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryReader.java
@@ -942,6 +942,8 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
                 surface = parseSurface( xmlStream, defaultCRS );
             } else if ( "Polygon".equals( elName.getLocalPart() ) ) {
                 surface = parsePolygon( xmlStream, defaultCRS );
+            } else if ( geometryHierarchy.getCompositeSurfaceSubstitutions().contains( elName ) ) {
+                surface = parseCompositeSurface( xmlStream, defaultCRS );
             } else {
                 String msg = "Unhandled surface geometry element: '" + xmlStream.getName() + "'.";
                 throw new XMLParsingException( xmlStream, msg );


### PR DESCRIPTION
Previously, CompositeSurfaces in hierarchies were not parsed for GML 3 and led to following exception:
```
XMLParsingException: Unhandled surface geometry element: '{http://www.opengis.net/gml}CompositeSurface'.
```

This fix enables parsing of CompositeSurfaces in geometry hierarchies for GML 3.