### PR TITLE
Fixed exception of WFS if unsupported SRS is requested

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/query/xml/QueryXMLAdapter.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/query/xml/QueryXMLAdapter.java
@@ -40,6 +40,7 @@ import static org.deegree.commons.xml.CommonNamespaces.FES_20_NS;
 import static org.deegree.protocol.wfs.WFSConstants.WFS_200_NS;
 
 import java.math.BigInteger;
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,11 +55,13 @@ import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ResolveMode;
 import org.deegree.commons.tom.ResolveParams;
 import org.deegree.commons.utils.StringUtils;
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
 import org.deegree.commons.xml.NamespaceBindings;
 import org.deegree.commons.xml.XMLParsingException;
 import org.deegree.commons.xml.XPath;
 import org.deegree.commons.xml.stax.XMLStreamReaderWrapper;
 import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.filter.Filter;
 import org.deegree.filter.expression.ValueReference;
@@ -247,7 +250,11 @@ public class QueryXMLAdapter extends AbstractWFSRequestXMLAdapter {
         ICRS crs = null;
         String srsName = getNodeAsString( queryEl, new XPath( "@srsName", nsContext ), null );
         if ( srsName != null ) {
-            crs = CRSManager.getCRSRef( srsName );
+            try {
+                crs = CRSManager.lookup( srsName );
+            } catch ( UnknownCRSException e ) {
+                throw new InvalidParameterValueException( e.getMessage(), "srsName" );
+            }
         }
 
         // <xsd:attribute name="featureVersion" type="xsd:string"/>


### PR DESCRIPTION
Previously, when an unsupported SRS was requested via WFS 2.0 a NoApplicableCode exception was thrown.

Example request:
```
<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs/2.0" count="10" service="WFS" startIndex="0" version="2.0.0"> <wfs:Query
                                 xmlns:ns4="http://www.deegree.org/app" srsName="urn:ogc:def:crs:EPSG::32690" typeNames="ns4:gns_iceland"/> </wfs:GetFeature>
```

The WFS 2.0 specification (09-025r1) states that an InvalidParameterValue exception is expected:
```
7.6.5.5 srsName parameter
...
If the specified CRS is not supported for the specified feature type, the WFS shall raise an
InvalidParameterValue exception (see Table 3).
...
```

This fix corrects the thrown exception for the pictured case.

Following test of the OGC CITE WFS 2.0 test suite [1] is now passed due to this fix:
 * "get Feature In Unsupported CRS"

[1] http://cite.opengeospatial.org/teamengine/