### PR TITLE
Fixed exception of WFS if requested feature (by resourceid) does not match the requested feature type (by typenames)

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -72,6 +72,7 @@ import org.deegree.commons.tom.sql.ParticleConverter;
 import org.deegree.commons.tom.sql.SQLValueMangler;
 import org.deegree.commons.utils.JDBCUtils;
 import org.deegree.commons.utils.Pair;
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.db.ConnectionProvider;
 import org.deegree.db.ConnectionProviderProvider;
@@ -125,6 +126,7 @@ import org.deegree.filter.spatial.BBOX;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryTransformer;
+import org.deegree.protocol.wfs.getfeature.TypeName;
 import org.deegree.sqldialect.SQLDialect;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
 import org.deegree.sqldialect.filter.DBField;
@@ -544,7 +546,7 @@ public class SQLFeatureStore implements FeatureStore {
             throw new UnsupportedOperationException( msg );
         }
 
-        FeatureInputStream rs = queryByIdFilterRelational( new IdFilter( id ), null );
+        FeatureInputStream rs = queryByIdFilterRelational( null, new IdFilter( id ), null );
         try {
             Iterator<Feature> iter = rs.iterator();
             if ( iter.hasNext() ) {
@@ -643,7 +645,7 @@ public class SQLFeatureStore implements FeatureStore {
                 throw new FilterEvaluationException( msg );
             }
             // should be no problem iterating over the features (id queries usually request only a few ids)
-            hits = queryByIdFilter( (IdFilter) filter, query.getSortProperties() ).count();
+            hits = queryByIdFilter( query.getTypeNames(), (IdFilter) filter, query.getSortProperties() ).count();
         }
         return hits;
     }
@@ -900,7 +902,7 @@ public class SQLFeatureStore implements FeatureStore {
                 String msg = "Invalid query. If no type names are specified, it must contain an IdFilter.";
                 throw new FilterEvaluationException( msg );
             }
-            result = queryByIdFilter( (IdFilter) filter, query.getSortProperties() );
+            result = queryByIdFilter( query.getTypeNames(), (IdFilter) filter, query.getSortProperties() );
         }
         return result;
     }
@@ -944,6 +946,8 @@ public class SQLFeatureStore implements FeatureStore {
                 FeatureInputStream rs;
                 try {
                     rs = query( queries[i++] );
+                } catch ( InvalidParameterValueException e ) {
+                    throw e;
                 } catch ( Throwable e ) {
                     LOG.debug( e.getMessage(), e );
                     throw new RuntimeException( e.getMessage(), e );
@@ -959,12 +963,12 @@ public class SQLFeatureStore implements FeatureStore {
         return new CombinedFeatureInputStream( rsIter );
     }
 
-    private FeatureInputStream queryByIdFilter( IdFilter filter, SortProperty[] sortCrit )
+    private FeatureInputStream queryByIdFilter( TypeName[] typeNames, IdFilter filter, SortProperty[] sortCrit )
                             throws FeatureStoreException {
         if ( blobMapping != null ) {
             return queryByIdFilterBlob( filter, sortCrit );
         }
-        return queryByIdFilterRelational( filter, sortCrit );
+        return queryByIdFilterRelational( typeNames, filter, sortCrit );
     }
 
     private FeatureInputStream queryByIdFilterBlob( IdFilter filter, SortProperty[] sortCrit )
@@ -1010,7 +1014,7 @@ public class SQLFeatureStore implements FeatureStore {
         return result;
     }
 
-    private FeatureInputStream queryByIdFilterRelational( IdFilter filter, SortProperty[] sortCrit )
+    private FeatureInputStream queryByIdFilterRelational( TypeName[] typeNames, IdFilter filter, SortProperty[] sortCrit )
                             throws FeatureStoreException {
 
         LinkedHashMap<QName, List<IdAnalysis>> ftNameToIdAnalysis = new LinkedHashMap<QName, List<IdAnalysis>>();
@@ -1039,6 +1043,7 @@ public class SQLFeatureStore implements FeatureStore {
 
         QName ftName = ftNameToIdAnalysis.keySet().iterator().next();
         FeatureType ft = getSchema().getFeatureType( ftName );
+        checkIfFeatureTypIsRequested( typeNames, ft );
         FeatureTypeMapping ftMapping = getSchema().getFtMapping( ftName );
         FIDMapping fidMapping = ftMapping.getFidMapping();
         List<IdAnalysis> idKernels = ftNameToIdAnalysis.get( ftName );
@@ -1618,4 +1623,18 @@ public class SQLFeatureStore implements FeatureStore {
             nullEscalation = config.isNullEscalation();
         }
     }
+
+    private void checkIfFeatureTypIsRequested( TypeName[] typeNames, FeatureType ft ) {
+        if ( typeNames != null && typeNames.length > 0 ) {
+            boolean isFeatureTypeRequested = false;
+            for ( TypeName typeName : typeNames ) {
+                if ( typeName.getFeatureTypeName().equals( ft.getName() ) )
+                    isFeatureTypeRequested = true;
+            }
+            if ( !isFeatureTypeRequested )
+                throw new InvalidParameterValueException( "Requested feature does not match the requested feature type.",
+                                                          "RESOURCEID" );
+        }
+    }
+    
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -966,12 +966,13 @@ public class SQLFeatureStore implements FeatureStore {
     private FeatureInputStream queryByIdFilter( TypeName[] typeNames, IdFilter filter, SortProperty[] sortCrit )
                             throws FeatureStoreException {
         if ( blobMapping != null ) {
-            return queryByIdFilterBlob( filter, sortCrit );
+            return queryByIdFilterBlob( typeNames, filter, sortCrit );
         }
         return queryByIdFilterRelational( typeNames, filter, sortCrit );
     }
 
-    private FeatureInputStream queryByIdFilterBlob( IdFilter filter, SortProperty[] sortCrit )
+    private FeatureInputStream queryByIdFilterBlob( TypeName[] typeNames,
+                                                    IdFilter filter, SortProperty[] sortCrit )
                             throws FeatureStoreException {
 
         FeatureInputStream result = null;
@@ -998,7 +999,7 @@ public class SQLFeatureStore implements FeatureStore {
             begin = System.currentTimeMillis();
             rs = stmt.executeQuery();
             LOG.debug( "Executing SELECT took {} [ms] ", System.currentTimeMillis() - begin );
-            FeatureBuilder builder = new FeatureBuilderBlob( this, blobMapping );
+            FeatureBuilder builder = new FeatureBuilderBlob( this, blobMapping, typeNames );
             result = new IteratorFeatureInputStream( new FeatureResultSetIterator( builder, rs, conn, stmt ) );
         } catch ( Exception e ) {
             release( rs, stmt, conn );
@@ -1629,7 +1630,7 @@ public class SQLFeatureStore implements FeatureStore {
         }
     }
 
-    private void checkIfFeatureTypIsRequested( TypeName[] typeNames, FeatureType ft ) {
+    public void checkIfFeatureTypIsRequested( TypeName[] typeNames, FeatureType ft ) {
         if ( typeNames != null && typeNames.length > 0 ) {
             boolean isFeatureTypeRequested = false;
             for ( TypeName typeName : typeNames ) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/FeatureBuilderBlob.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/FeatureBuilderBlob.java
@@ -44,6 +44,7 @@ import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.feature.Feature;
 import org.deegree.feature.persistence.sql.FeatureBuilder;
 import org.deegree.feature.persistence.sql.SQLFeatureStore;
+import org.deegree.protocol.wfs.getfeature.TypeName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +68,8 @@ public class FeatureBuilderBlob implements FeatureBuilder {
 
     private final ICRS crs;
 
+    private TypeName[] typeNames;
+
     /**
      * Creates a new {@link FeatureBuilderBlob} instance.
      * 
@@ -76,12 +79,28 @@ public class FeatureBuilderBlob implements FeatureBuilder {
      *            blob mapping parameters, must not be <code>null</code>
      */
     public FeatureBuilderBlob( SQLFeatureStore fs, BlobMapping blobMapping ) {
+        this( fs, blobMapping, null );
+    }
+
+    /**
+     * Creates a new {@link FeatureBuilderBlob} instance.
+     *
+     * @param fs
+     *            feature store, must not be <code>null</code>
+     * @param blobMapping
+     *            blob mapping parameters, must not be <code>null</code>
+     * @param typeNames
+     *            list of requested type names, if {@link #buildFeature(ResultSet)} is invoked and a feature is not in
+     *            this list an exception is thrown
+     */
+    public FeatureBuilderBlob( SQLFeatureStore fs, BlobMapping blobMapping, TypeName[] typeNames ) {
         this.fs = fs;
         this.blobMapping = blobMapping;
         this.codec = blobMapping.getCodec();
         this.crs = blobMapping.getCRS();
+        this.typeNames = typeNames;
     }
-
+    
     @Override
     public List<String> getInitialSelectList() {
         List<String> columns = new ArrayList<String>();
@@ -109,10 +128,13 @@ public class FeatureBuilderBlob implements FeatureBuilder {
             } else {
                 LOG.debug( "Cache hit." );
             }
+            fs.checkIfFeatureTypIsRequested( typeNames, feature.getType() );
         } catch ( Exception e ) {
             String msg = "Cannot recreate feature from result set: " + e.getMessage();
             throw new SQLException( msg, e );
         }
         return feature;
     }
+    
+    
 }


### PR DESCRIPTION
Previously, when a requested feature (by resourceid) did not match the requested feature type (by typenames) a FeatureCollection was returned.

The WFS 2.0 specification (09-025r1) states that an InvalidParameterValue exception is expected (Chapter 7.9.2.4.1 typeNames parameter, page 34):

```
For KVP-encoded ad hoc query expressions the typeNames parameter shall be encoded 
using the TYPENAMES keyword (see Table 8). The TYPENAMES parameter is mandatory 
in all cases except when the RESOURCEID parameter is specified. In this case the 
TYPENAMES parameter may be omitted because each feature instance can be 
identified by its resource identifier alone (see 7.2). If both the TYPENAMES and
RESOURCEID parameters are specified then all the feature instances identified by 
the RESOURCEID parameter shall be of the type specified by the TYPENAMES 
parameter; otherwise the server shall raise an InvalidParameterValue exception 
(see OGC 06-121r3:2009, Table 25) where the "locator" attribute 
(see OGC 06-121r3:2009, 8.4) value shall be set to "RESOURCEID".
```

This fix corrects the behaviour of the WFS and an InvalidParameterValue exception is returned instead of a FeatureCollection for the pictured case.

Following test of the OGC CITE WFS 2.0 test suite [1] is now passed due to this fix:
- "inconsistent Feature Identifier And Type"

[1] http://cite.opengeospatial.org/teamengine/
