### PR TITLE
Fixed exception of WFS if geometry operand is not a geometry property

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -50,6 +50,7 @@ import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.tom.sql.DefaultPrimitiveConverter;
 import org.deegree.commons.tom.sql.PrimitiveParticleConverter;
 import org.deegree.commons.utils.StringUtils;
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
 import org.deegree.commons.xml.NamespaceBindings;
 import org.deegree.filter.Expression;
 import org.deegree.filter.Filter;
@@ -193,6 +194,8 @@ public abstract class AbstractWhereBuilder {
                 }
                 postFilter = filter;
             } catch ( FilterEvaluationException e ) {
+                throw e;
+            } catch ( InvalidParameterValueException e ) {
                 throw e;
             } catch ( RuntimeException e ) {
                 LOG.error( e.getMessage(), e );

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISWhereBuilder.java
@@ -46,6 +46,7 @@ import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.tom.sql.DefaultPrimitiveConverter;
 import org.deegree.commons.tom.sql.PrimitiveParticleConverter;
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.filter.Expression;
 import org.deegree.filter.FilterEvaluationException;
@@ -207,7 +208,7 @@ public class PostGISWhereBuilder extends AbstractWhereBuilder {
         if ( !propNameExpr.isSpatial() ) {
             String msg = "Cannot evaluate spatial operator on database. Targeted property name '" + op.getPropName()
                          + "' does not denote a spatial column.";
-            throw new FilterEvaluationException( msg );
+            throw new InvalidParameterValueException( msg );
         }
 
         ICRS storageCRS = propNameExpr.getCRS();

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -72,6 +72,7 @@ import org.deegree.commons.tom.sql.ParticleConverter;
 import org.deegree.commons.tom.sql.SQLValueMangler;
 import org.deegree.commons.utils.JDBCUtils;
 import org.deegree.commons.utils.Pair;
+import org.deegree.commons.utils.kvp.InvalidParameterValueException;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.db.ConnectionProvider;
 import org.deegree.db.ConnectionProviderProvider;
@@ -944,6 +945,8 @@ public class SQLFeatureStore implements FeatureStore {
                 FeatureInputStream rs;
                 try {
                     rs = query( queries[i++] );
+                } catch ( InvalidParameterValueException e ){
+                    throw e;
                 } catch ( Throwable e ) {
                     LOG.debug( e.getMessage(), e );
                     throw new RuntimeException( e.getMessage(), e );
@@ -1371,6 +1374,11 @@ public class SQLFeatureStore implements FeatureStore {
             LOG.debug( "Executing SELECT took {} [ms] ", System.currentTimeMillis() - begin );
 
             result = new IteratorFeatureInputStream( new FeatureResultSetIterator( builder, rs, conn, stmt ) );
+        } catch ( InvalidParameterValueException e ) {
+            release( rs, stmt, conn );
+            String msg = "Error performing query by operator filter: " + e.getMessage();
+            LOG.error( msg, e );
+            throw e;
         } catch ( Exception e ) {
             release( rs, stmt, conn );
             String msg = "Error performing query by operator filter: " + e.getMessage();


### PR DESCRIPTION
Previously, when a geometry operand was not a geometry property a NoApplicableCode exception was thrown.

Example request:
```
<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs/2.0"
	count="10" service="WFS" startIndex="0" version="2.0.0">
	<wfs:Query xmlns:ns55="http://www.deegree.org/app" typeNames="ns55:gns_iceland">
		<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
			<fes:BBOX>
				<fes:ValueReference xmlns:tns="http://www.opengis.net/gml/3.2">tns:description</fes:ValueReference>
				<gml:Envelope xmlns:gml="http://www.opengis.net/gml/3.2"
					srsName="urn:ogc:def:crs:EPSG::4326">
					<gml:lowerCorner>62 -26</gml:lowerCorner>
					<gml:upperCorner>67.11 -6</gml:upperCorner>
				</gml:Envelope>
			</fes:BBOX>
		</fes:Filter>
	</wfs:Query>
</wfs:GetFeature>
```

The FE 2.0.0 specification (OGC 09-026r1 and ISO 19143:2010(E)) states that an InvalidParameterValue exception is expected (Chapter 8.3 Exceptions, page 43):
```
In the event that the fes:ValueReference element contains a reference to a value of a 
known resource type but that value if not defined for the resource type being queried, 
the service shall raise an InvalidParameterValue (as given in OGC 06-121r3, Table 25) 
exception.
```
This fix updates the exception code to InvalidParameterValue for the pictured case.

Following test of the OGC CITE WFS 2.0 test suite [1] is now passed due to this fix:
 * "invalid Geometry Operand"

[1] http://cite.opengeospatial.org/teamengine/