### PR TITLE
Fixed exception status code to 404 if service with the requested identifier is not available

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/ows/exception/OWSException.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/ows/exception/OWSException.java
@@ -139,6 +139,11 @@ public class OWSException extends Exception {
      */
     public static final String NO_APPLICABLE_CODE = "NoApplicableCode";
 
+    /**
+     * exception code indicating an HTTP 404 error
+     */
+    public static final String NOT_FOUND = "NotFound";
+    
     private final String exceptionCode;
 
     private final String locator;

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -37,6 +37,7 @@ package org.deegree.services.controller;
 
 import static java.io.File.createTempFile;
 import static java.util.Collections.emptyList;
+import static org.deegree.commons.ows.exception.OWSException.NOT_FOUND;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.tom.ows.Version.parseVersion;
 import static org.reflections.util.ClasspathHelper.forClassLoader;
@@ -577,8 +578,7 @@ public class OGCFrontController extends HttpServlet {
             }
             if ( ows == null ) {
                 String msg = "No service with identifier '" + serviceId + "' available.";
-                OWSException e = new OWSException( msg, OWSException.NO_APPLICABLE_CODE );
-                throw e;
+                throw new OWSException( msg, NOT_FOUND );
             }
         }
         return ows;
@@ -608,9 +608,7 @@ public class OGCFrontController extends HttpServlet {
             }
             if ( ows == null ) {
                 String msg = "No service with identifier '" + serviceId + "' available.";
-                OWSException e = new OWSException( msg, OWSException.NO_APPLICABLE_CODE );
-                // sendException( null, e, response, null );
-                throw e;
+                throw new OWSException( msg, NOT_FOUND );
             }
         }
         return ows;
@@ -907,7 +905,7 @@ public class OGCFrontController extends HttpServlet {
             } else {
                 LOG.debug( "A security exception was thrown ( " + e.getLocalizedMessage()
                            + " but no credentials provider was configured, sending generic ogc exception." );
-                sendException( ows, new OWSException( e.getLocalizedMessage(), OWSException.NO_APPLICABLE_CODE ),
+                sendException( ows, new OWSException( e.getLocalizedMessage(), NO_APPLICABLE_CODE ),
                                response, null );
             }
         }

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/XMLExceptionSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/exception/serializer/XMLExceptionSerializer.java
@@ -36,6 +36,9 @@
 
 package org.deegree.services.controller.exception.serializer;
 
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.deegree.commons.ows.exception.OWSException.NOT_FOUND;
+
 import java.io.IOException;
 
 import javax.xml.stream.XMLStreamException;
@@ -61,7 +64,7 @@ public abstract class XMLExceptionSerializer implements ExceptionSerializer {
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( "application/vnd.ogc.se_xml" );
-        response.setStatus( 200 );
+        setStatusCode( exception, response );
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }
 
@@ -78,4 +81,19 @@ public abstract class XMLExceptionSerializer implements ExceptionSerializer {
     public abstract void serializeExceptionToXML( XMLStreamWriter writer, OWSException exception )
                             throws XMLStreamException;
 
+    /**
+     * Sets the status code to the response.
+     * 
+     * @param exception
+     *            the exception to serialize, never <code>null</code>
+     * @param response
+     *            the response to set the status code for, never <code>null</code>
+     */
+    protected void setStatusCode( OWSException exception, HttpResponseBuffer response ) {
+        if ( NOT_FOUND.equals( exception.getExceptionCode() ) )
+            response.setStatus( SC_NOT_FOUND );
+        else
+            response.setStatus( 200 );
+    }
+    
 }

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/OWS110ExceptionReportSerializer.java
@@ -35,6 +35,11 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.services.ows;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.deegree.commons.ows.exception.OWSException.NOT_FOUND;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.ows.exception.OWSException.OPERATION_PROCESSING_FAILED;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
@@ -44,6 +49,7 @@ import java.io.IOException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.apache.http.HttpStatus;
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ows.Version;
 import org.deegree.services.controller.exception.serializer.XMLExceptionSerializer;
@@ -78,16 +84,17 @@ public class OWS110ExceptionReportSerializer extends XMLExceptionSerializer {
     @Override
     public void serializeException( HttpResponseBuffer response, OWSException exception )
                             throws IOException, XMLStreamException {
-
         response.reset();
         response.setCharacterEncoding( "UTF-8" );
         response.setContentType( "application/xml" );
-        if ( NO_APPLICABLE_CODE.equals( exception.getExceptionCode() ) ) {
-            response.setStatus( 500 );
+        if ( NOT_FOUND.equals( exception.getExceptionCode() ) ) {
+            response.setStatus( SC_NOT_FOUND );
+        } else if ( NO_APPLICABLE_CODE.equals( exception.getExceptionCode() ) ) {
+            response.setStatus( SC_INTERNAL_SERVER_ERROR );
         } else if ( OPERATION_PROCESSING_FAILED.equals( exception.getExceptionCode() ) ) {
-            response.setStatus( 403 );
+            response.setStatus( SC_FORBIDDEN );
         } else {
-            response.setStatus( 400 );
+            response.setStatus( SC_BAD_REQUEST );
         }
         serializeExceptionToXML( response.getXMLWriter(), exception );
     }


### PR DESCRIPTION
Previously, an exception status code 500 was returned if a service with the requested identifier is not available.

Example:
* http://cite.deegree.org/deegree-webservices-3.4-RC1/services/wmts100/nonesuch

The WMTS 1.0.0 specification references in A.3.1.1 the HTTP/1.1 specification: http://www.ietf.org/rfc/rfc2616
Status code 404 is fitting more than 500:
```
10.4.5 404 Not Found

   The server has not found anything matching the Request-URI. No
   indication is given of whether the condition is temporary or
   permanent. The 410 (Gone) status code SHOULD be used if the server
   knows, through some internally configurable mechanism, that an old
   resource is permanently unavailable and has no forwarding address.
   This status code is commonly used when the server does not wish to
   reveal exactly why the request has been refused, or when no other
   response is applicable.
```
```
10.5.1 500 Internal Server Error

   The server encountered an unexpected condition which prevented it
   from fulfilling the request.
```

This fix changes the status code to 404 for the described case.
Attention: The status code is updated for all service types and not for WMTS only.

Due to the fix following test of the CITE WMTS 1.0.0 ETS [1] is passing:
* wmts:Server.KVP.GET.HTTP.Mandatory

[1] http://cite.opengeospatial.org/te2/about/wmts/1.0.0/site/