### PR TITLE
3.4 Resolve deegree schema files localy if possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,17 @@
                 </schemaIncludes>
                 <schemaDirectory>src/main/resources/META-INF/schemas/</schemaDirectory>
                 <episode>true</episode>
-                <catalog>target/deegree.xmlcatalog</catalog>
-                <catalogResolver>org.jvnet.jaxb2.maven2.resolver.tools.ClasspathCatalogResolver</catalogResolver>
+                <catalogResolver>org.deegree.uncoupled.jaxb.CatalogResolver</catalogResolver>
               </configuration>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.deegree</groupId>
+              <artifactId>deegree-jaxb-resolver</artifactId>
+              <version>1.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.deegree</groupId>

--- a/uncoupled/deegree-jaxb-resolver/pom.xml
+++ b/uncoupled/deegree-jaxb-resolver/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>deegree-jaxb-plugin</artifactId>
+	<artifactId>deegree-jaxb-resolver</artifactId>
 	<version>1.0</version>
-	<name>deegree-jaxb-plugin</name>
+	<name>deegree-jaxb-resolver</name>
 	<packaging>jar</packaging>
-	<description>3.4-RC2</description>
+	<description>JAXB resolver to search for deegree schema files on classpath</description>
 
 	<parent>
 		<groupId>org.deegree</groupId>

--- a/uncoupled/deegree-jaxb-resolver/pom.xml
+++ b/uncoupled/deegree-jaxb-resolver/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>deegree-jaxb-plugin</artifactId>
+	<version>1.0</version>
+	<name>deegree-jaxb-plugin</name>
+	<packaging>jar</packaging>
+	<description>3.4-RC2</description>
+
+	<parent>
+		<groupId>org.deegree</groupId>
+		<artifactId>deegree</artifactId>
+		<version>3.4-RC1</version>
+	</parent>
+
+	<repositories>
+		<repository>
+			<id>deegree-repo</id>
+			<url>http://repo.deegree.org/content/groups/public</url>
+			<releases>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<!-- TRICKY require to start compiler forked, to allow build against reference in rt.jar -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArgs>
+						<arg>-XDignore.symbol.file</arg>
+					</compilerArgs>
+					<fork>true</fork>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>java</groupId>
+			<artifactId>rt</artifactId>
+			<version>1.0</version>
+			<scope>system</scope>
+			<systemPath>${java.home}/lib/rt.jar</systemPath>
+		</dependency>
+	</dependencies>
+</project>

--- a/uncoupled/deegree-jaxb-resolver/src/main/java/org/deegree/uncoupled/jaxb/CatalogResolver.java
+++ b/uncoupled/deegree-jaxb-resolver/src/main/java/org/deegree/uncoupled/jaxb/CatalogResolver.java
@@ -1,0 +1,96 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree
+ Copyright (C) 2001-2014 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit GmbH -
+ and others
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ e-mail: info@deegree.org
+ website: http://www.deegree.org/
+----------------------------------------------------------------------------*/
+package org.deegree.uncoupled.jaxb;
+
+import java.net.URL;
+
+/**
+ * JAXB Catalog Resolver
+ * 
+ * The Resolver is build to allow JAXB to find deegree bundled schemas inside the build classpath instead of resolving
+ * schema files online.
+ * 
+ * <blockquote> <b>Note:</b> Eclipse only builds this class if the following setting is changed, because of internal
+ * API:
+ * 
+ * <pre>
+ * Window > Preferences > Java > Compiler > Errors/Warnings
+ *  - Deprecated and restricted API
+ *    Set "Forbidden reference (access rules)" to "Warning"
+ * </pre>
+ * 
+ * </blockquote>
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ */
+public class CatalogResolver extends com.sun.org.apache.xml.internal.resolver.tools.CatalogResolver {
+
+    private static final String REWRITE_FROM = "http://schemas.deegree.org/";
+
+    private static final String REWRITE_TO = "META-INF/schemas/";
+
+    private boolean debug = false;
+
+    public CatalogResolver() {
+        String dbg = System.getProperty( "deeegree.jaxb.debug" );
+        if ( dbg != null && !dbg.isEmpty() ) {
+            debug = true;
+        }
+    }
+
+    @Override
+    public String getResolvedEntity( String publicId, String systemId ) {
+
+        if ( systemId != null && systemId.toLowerCase().startsWith( REWRITE_FROM ) ) {
+            if ( debug ) {
+                System.err.println( "*** deegree JAXB CatalogResolver: publicId: " + publicId + " systemId: "
+                                    + systemId );
+            }
+
+            String newid = REWRITE_TO + systemId.substring( REWRITE_FROM.length() );
+
+            try {
+                URL resource = Thread.currentThread().getContextClassLoader().getResource( newid );
+                if ( resource == null ) {
+                    resource = getClass().getResource( "/" + newid );
+                }
+                if ( resource != null ) {
+                    if ( debug ) {
+                        System.err.println( "Resolved localy to: " + resource );
+                    }
+                    return resource.toString();
+                }
+            } catch ( Exception ex ) {
+                System.err.println( "Error: " + ex.getMessage() );
+            }
+        }
+
+        // Use default lookup
+        return super.getResolvedEntity( publicId, systemId );
+    }
+}


### PR DESCRIPTION
This pull request fixes #649 by replaceing the currently used classpath resolver from the jaxb plugin with a custom one.

The resolver tries to lookup all schemas first in `CLASSPATH:META-INF/schemas` and if not found falls back to the default behavior, online lookup.

**This resolver is not a final solution for the overall schema situation**, but the TMC agreed on 09.08.2016 that this PR is used as intermediate soultion until a rework of the build / jaxb handling was made.

On Updates to the resolver the builds have to be done manually by:
1.  Updateing the version
2.  Locally building, ideally with the oldest supported jdk (currently 1.6)
3.  Upload the artifact to the deegree repository on repo.deegree.org in the section for public 3rd party artefacts. Or by submitting the artefact to the tmc to upload the artefact for a specific PR.