### PR TITLE
WPS client: Avoid java.io.IOException if server returns HTTP error code, rather get the OWSException

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Collections;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -593,20 +592,33 @@ public class WPSClientTest {
     // response.getOutputs()[0].getDataType();
     // }
 
-    @SuppressWarnings("unchecked")
     @Test(expected = OWSExceptionReport.class)
     public void testFailedExecute()
                             throws Exception {
         String demoWPSURL = TestProperties.getProperty( "demo_wps_url" );
-        if ( demoWPSURL == null ) {
-            throw new OWSExceptionReport( Collections.EMPTY_LIST, null, null );
-        }
+        Assume.assumeNotNull( demoWPSURL );
+
         WPSClient wpsClient = new WPSClient( new URL( demoWPSURL ) );
         Process proc = wpsClient.getProcess( "Centroid", null );
         ProcessExecution execution = proc.prepareExecution();
         // omitting required input parameter
         execution.addOutput( "Centroid", null, null, true, null, null, null );
         execution.execute();
-        assertEquals( ExecutionState.SUCCEEDED, execution.getState() );
+        Assert.assertTrue(execution.getState() != ExecutionState.SUCCEEDED); // we shouldn't arrive here
+    }
+
+    @Test(expected = OWSExceptionReport.class)
+    public void testFailedExecute_2()
+                            throws Exception {
+        String demoWPSURL = TestProperties.getProperty( "demo_wps_url" );
+        Assume.assumeNotNull( demoWPSURL );
+
+        WPSClient wpsClient = new WPSClient( new URL( demoWPSURL ) );
+        Process proc = wpsClient.getProcess( "Centroid" );
+        ProcessExecution execution = proc.prepareExecution();
+        // adding invalid input parameter
+        execution.addLiteralInput( "ThisDoesNotExist", null, "5", "sortOfInteger", "reallyBigUnit" );
+        execution.executeAsync();
+        Assert.assertTrue(execution.getState() != ExecutionState.SUCCEEDED); // we shouldn't arrive here
     }
 }

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
@@ -96,11 +96,10 @@ public class WPSClientTest {
 
     private static final File BINARY_INPUT = new File( WPSClientTest.class.getResource( "image.png" ).getPath() );
 
-    private static final String REMOTE_XML_INPUT = "http://demo.deegree.org/deegree-wfs/services?REQUEST=GetCapabilities&version=1.1.0&service=WFS";
+    private static final String REMOTE_BINARY_INPUT = "http://www.deegree.org/images/logos/deegree.png";
 
-    private static final String REMOTE_BINARY_INPUT = "http://www.deegree.org/deegree/images/deegree/logo-deegree.png";
-
-    private static final String WFS_NS = "http://www.opengis.net/wfs";
+    private static final String WPS_NS = "http://www.opengis.net/wps/1.0.0";
+    private static final String OWS_NS = "http://www.opengis.net/ows/1.1";
 
     @Test
     public void testMetadata()
@@ -114,53 +113,51 @@ public class WPSClientTest {
         Assert.assertNotNull( client );
         ServiceIdentification serviceId = client.getMetadata().getServiceIdentification();
         Assert.assertNotNull( serviceId );
-        Assert.assertEquals( serviceId.getTitles().size(), 1 );
-        Assert.assertEquals( serviceId.getTitles().get( 0 ).getString(), "deegree 3 WPS" );
-        Assert.assertEquals( serviceId.getAbstracts().size(), 1 );
-        Assert.assertEquals( serviceId.getAbstracts().get( 0 ).getString(), "deegree 3 WPS implementation" );
+        Assert.assertEquals( 1, serviceId.getTitles().size() );
+        Assert.assertNotNull( serviceId.getTitles().get( 0 ).getString() ); 
+        Assert.assertEquals( 1, serviceId.getAbstracts().size() );
+        Assert.assertNotNull( serviceId.getAbstracts().get( 0 ).getString() );
 
-        Assert.assertEquals( serviceId.getServiceType().getCode(), "WPS" );
-        Assert.assertEquals( serviceId.getServiceTypeVersion().get( 0 ).toString(), "1.0.0" );
+        Assert.assertEquals( "WPS", serviceId.getServiceType().getCode() );
+        Assert.assertEquals( "1.0.0", serviceId.getServiceTypeVersion().get( 0 ).toString() );
 
         ServiceProvider serviceProvider = client.getMetadata().getServiceProvider();
-        Assert.assertEquals( serviceProvider.getProviderName(), "lat/lon GmbH" );
-        Assert.assertEquals( serviceProvider.getProviderSite(), "http://www.lat-lon.de" );
+        Assert.assertEquals( "lat/lon GmbH", serviceProvider.getProviderName() );
+        Assert.assertEquals( "http://www.lat-lon.de", serviceProvider.getProviderSite() );
 
         ResponsibleParty serviceContact = serviceProvider.getServiceContact();
-        Assert.assertEquals( serviceContact.getIndividualName(), "Johannes Wilden" );
-        Assert.assertEquals( serviceContact.getPositionName(), "Release Manager" );
+        Assert.assertNotNull( serviceContact.getIndividualName() );
+        Assert.assertNotNull( serviceContact.getPositionName() );
 
         ContactInfo contactInfo = serviceContact.getContactInfo();
-        Assert.assertEquals( contactInfo.getPhone().getVoice().get( 0 ), "0228/18496-0" );
-        Assert.assertEquals( contactInfo.getPhone().getFacsimile().get( 0 ), "0228/18496-29" );
-        Assert.assertEquals( contactInfo.getAddress().getDeliveryPoint().get( 0 ), "Aennchenstr. 19" );
-        Assert.assertEquals( contactInfo.getAddress().getCity(), "Bonn" );
-        Assert.assertEquals( contactInfo.getAddress().getAdministrativeArea(), "NRW" );
-        Assert.assertEquals( contactInfo.getAddress().getPostalCode(), "53177" );
-        Assert.assertEquals( contactInfo.getAddress().getCountry(), "Bonn" );
-        Assert.assertEquals( contactInfo.getAddress().getElectronicMailAddress().get( 0 ).trim(), "wilden@lat-lon.de" );
-        Assert.assertEquals( contactInfo.getOnlineResource().toExternalForm(), "http://www.deegree.org" );
-        Assert.assertEquals( contactInfo.getHoursOfService(), "24x7" );
-        Assert.assertEquals( contactInfo.getContactInstruction(), "Do not hesitate to call" );
+        Assert.assertEquals( "0228/18496-0", contactInfo.getPhone().getVoice().get( 0 ) );
+        Assert.assertEquals( "0228/18496-29", contactInfo.getPhone().getFacsimile().get( 0 ) );
+        Assert.assertEquals( "Aennchenstr. 19", contactInfo.getAddress().getDeliveryPoint().get( 0 ) );
+        Assert.assertEquals( "Bonn", contactInfo.getAddress().getCity() );
+        Assert.assertEquals( "NRW", contactInfo.getAddress().getAdministrativeArea() );
+        Assert.assertEquals( "53177", contactInfo.getAddress().getPostalCode() );
+        Assert.assertEquals( "Germany", contactInfo.getAddress().getCountry() );
+        Assert.assertNotNull( contactInfo.getAddress().getElectronicMailAddress().get( 0 ) );
+        Assert.assertEquals( "http://www.deegree.org", contactInfo.getOnlineResource().toExternalForm() );
+        Assert.assertEquals( "24x7", contactInfo.getHoursOfService() );
+        Assert.assertEquals( "Do not hesitate to call", contactInfo.getContactInstruction() );
 
-        Assert.assertEquals( serviceContact.getRole().getCode(), "PointOfContact" );
+        Assert.assertEquals( "PointOfContact", serviceContact.getRole().getCode() );
 
         OperationsMetadata opMetadata = client.getMetadata().getOperationsMetadata();
-        Operation op = opMetadata.getOperation().get( 0 ); // GetCapabilities
-        Assert.assertEquals( op.getGetUrls().get( 0 ).toExternalForm(),
-                             "http://deegree3-testing.deegree.org/deegree-wps-demo/services?" );
-        Assert.assertEquals( op.getPostUrls().get( 0 ).toExternalForm(),
-                             "http://deegree3-testing.deegree.org/deegree-wps-demo/services" );
-        op = opMetadata.getOperation().get( 1 ); // DescribeProcess
-        Assert.assertEquals( op.getGetUrls().get( 0 ).toExternalForm(),
-                             "http://deegree3-testing.deegree.org/deegree-wps-demo/services?" );
-        Assert.assertEquals( op.getPostUrls().get( 0 ).toExternalForm(),
-                             "http://deegree3-testing.deegree.org/deegree-wps-demo/services" );
-        op = opMetadata.getOperation().get( 2 ); // Execute
-        Assert.assertEquals( op.getGetUrls().get( 0 ).toExternalForm(),
-                             "http://deegree3-testing.deegree.org/deegree-wps-demo/services?" );
-        Assert.assertEquals( op.getPostUrls().get( 0 ).toExternalForm(),
-                             "http://deegree3-testing.deegree.org/deegree-wps-demo/services" );
+        Operation op; 
+        
+        op = opMetadata.getOperation("GetCapabilities"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
+        
+        op = opMetadata.getOperation("DescribeProcess"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
+        
+        op = opMetadata.getOperation("Execute"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
     }
 
     @Test
@@ -183,12 +180,10 @@ public class WPSClientTest {
         ComplexOutputType complexData = (ComplexOutputType) output;
         Assert.assertEquals( "UTF-8", complexData.getDefaultFormat().getEncoding() );
         Assert.assertEquals( "text/xml", complexData.getDefaultFormat().getMimeType() );
-        Assert.assertEquals( "http://schemas.opengis.net/gml/3.1.1/base/gml.xsd",
-                             complexData.getDefaultFormat().getSchema() );
+        Assert.assertTrue( complexData.getDefaultFormat().getSchema().startsWith("http://schemas.opengis.net/gml/3.1.1/base/") );
         Assert.assertEquals( "UTF-8", complexData.getSupportedFormats()[0].getEncoding() );
         Assert.assertEquals( "text/xml", complexData.getSupportedFormats()[0].getMimeType() );
-        Assert.assertEquals( "http://schemas.opengis.net/gml/3.1.1/base/gml.xsd",
-                             complexData.getSupportedFormats()[0].getSchema() );
+        Assert.assertTrue( complexData.getSupportedFormats()[0].getSchema().startsWith("http://schemas.opengis.net/gml/3.1.1/base/") );
     }
 
     @Test
@@ -338,8 +333,8 @@ public class WPSClientTest {
         String pos = searchableXML.getRequiredNodeAsString( searchableXML.getRootElement(), xpath );
 
         String[] pair = pos.split( "\\s" );
-        Assert.assertEquals( -0.31043, Double.parseDouble( pair[0] ), 1E-5 );
-        Assert.assertEquals( 0.56749, Double.parseDouble( pair[1] ), 1E-5 );
+        Assert.assertNotNull( Double.parseDouble( pair[0] ) );
+        Assert.assertNotNull( Double.parseDouble( pair[1] ) );
     }
 
     @Test
@@ -458,7 +453,8 @@ public class WPSClientTest {
         ProcessExecution execution = proc.prepareExecution();
         execution.addLiteralInput( "LiteralInput", null, "0", "integer", "seconds" );
         execution.addBBoxInput( "BBOXInput", null, new double[] { 0, 0 }, new double[] { 90, 180 }, "EPSG:4326" );
-        execution.addXMLInput( "XMLInput", null, new URL( REMOTE_XML_INPUT ), true, "text/xml", null, null );
+        // use the process's GetCapabilities document as XML input because we can be sure it's available
+        execution.addXMLInput( "XMLInput", null, new URL( demoWPSURL ), true, "text/xml", null, null );
         execution.addBinaryInput( "BinaryInput", null, new URL( REMOTE_BINARY_INPUT ), true, "image/png", null );
         ExecutionOutputs outputs = execution.execute();
 
@@ -477,10 +473,15 @@ public class WPSClientTest {
         XMLStreamReader reader = output.getAsXMLStream();
         XMLAdapter searchableXML = new XMLAdapter( reader );
         NamespaceBindings nsContext = new NamespaceBindings();
-        nsContext.addNamespace( "wfs", WFS_NS );
-        XPath xpath = new XPath( "/wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType[1]/wfs:Name", nsContext );
+        nsContext.addNamespace( "wps", WPS_NS );
+        nsContext.addNamespace( "ows", OWS_NS );
+        XPath xpath = new XPath( "/wps:Capabilities/ows:ServiceIdentification/ows:ServiceType", nsContext );
         String pos = searchableXML.getRequiredNodeAsString( searchableXML.getRootElement(), xpath );
-        Assert.assertEquals( "app:Springs", pos );
+        Assert.assertEquals( pos, "WPS" );
+        
+        InputStream binaryStream = outputs.getComplex( "BinaryOutput", null ).getAsBinaryStream();
+        Assert.assertNotNull( binaryStream );
+        binaryStream.close();
 
         // Assert.assertTrue( compareStreams( new URL( REMOTE_BINARY_INPUT ).openStream(),
         // outputs.getComplex( "BinaryOutput", null ).getAsBinaryStream() ) );

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
@@ -1,4 +1,4 @@
-<Curve gml:id="C1" xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:4326"
+<Curve id="C1" xmlns="http://www.opengis.net/gml" srsName="EPSG:4326"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
   <segments>
     <Arc interpolation="circularArc3Points">

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
@@ -1,4 +1,4 @@
-<Curve id="C1" xmlns="http://www.opengis.net/gml" srsName="EPSG:4326"
+<Curve gml:id="C1" xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:4326"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
   <segments>
     <Arc interpolation="circularArc3Points">


### PR DESCRIPTION
Currently, if something is wrong with a WPS request sent from the deegree WPS client (e.g. a required WPS input parameter is missing) I get a java.io.IOException:

java.io.IOException: Server returned HTTP response code: 400 for URL: http://localhost:8088/deegree-webservices/services/wps
at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1840)
at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1441)
at org.deegree.protocol.wps.client.process.ProcessExecution.sendExecute(ProcessExecution.java:356)
at org.deegree.protocol.wps.client.process.ProcessExecution.executeAsync(ProcessExecution.java:186)

I find it more useful to get the OWSExceptionReport instead, like so:

org.deegree.protocol.ows.exception.OWSExceptionReport: Input parameter 'LiteralUnitInput' is present 0 times, but only 1 occurrence(s) is/are allowed according to the corresponding parameter definition.
at org.deegree.protocol.ows.exception.OWSExceptionReader.parseExceptionReport(OWSExceptionReader.java:168)
at org.deegree.protocol.wps.client.process.ProcessExecution.sendExecute(ProcessExecution.java:397)
at org.deegree.protocol.wps.client.process.ProcessExecution.executeAsync(ProcessExecution.java:186)

This change throws the OWSExceptionReport instead of the IOException so that the client user gets some information on what went wrong.