### PR TITLE
Fixed NPE if geoemtry to render is outside the requested map extent

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DLabelRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DLabelRenderer.java
@@ -128,6 +128,10 @@ public class Java2DLabelRenderer implements LabelRenderer {
     }
     
     private void handleGeometryTypes( TextStyling styling, String text, Font font, Geometry geom ) {
+        if( geom == null ) {
+            LOG.warn( "null geometry cannot be handled." );
+            return;
+        }
         if ( geom instanceof Point ) {
             labelList.add( createLabel( styling, font, text, (Point) geom ) );
         } else if ( geom instanceof Surface && styling.linePlacement != null ) {


### PR DESCRIPTION
Using the function  _InteriorPoint_ to render a label causes a NullPointerException if the calculated point is outside the map extent.  A null check was introduced to fix this problem on a very low level and to avoid further problems with other configurations.  