### PR TITLE
Fixed path to metadata example url

### DIFF
--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/webservices/ServiceConfig.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/webservices/ServiceConfig.java
@@ -45,7 +45,7 @@ import org.deegree.workspace.ResourceMetadata;
 
 public class ServiceConfig extends Config {
 
-    private static final URL METADATA_EXAMPLE_URL = ServicesBean.class.getResource( "/META-INF/schemas/services/metadata/3.2.0/example.xml" );
+    private static final URL METADATA_EXAMPLE_URL = ServicesBean.class.getResource( "/META-INF/schemas/services/metadata/3.4.0/example.xml" );
 
     public ServiceConfig( ResourceMetadata<?> metadata, ResourceManager<?> resourceManager ) {
         super( metadata, resourceManager, "/console/webservices/index", true );


### PR DESCRIPTION
Resolves #712

Fixed path to metadata example URL. Now, new metadata for a service can be created via deegree console.
Previously, a NullPointerException occured as documented in #712.