### PR TITLE
Fixed removal of deactivated resources from deegree console

### DIFF
--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/Config.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/Config.java
@@ -115,6 +115,7 @@ public class Config implements Comparable<Config>, Serializable {
         try {
             getWorkspace().destroy( metadata.getIdentifier() );
             getWorkspace().getLocationHandler().deactivate( metadata.getLocation() );
+            getWorkspace().add( metadata.getLocation() );
             List<ResourceMetadata<?>> list = new ArrayList<ResourceMetadata<?>>();
             WorkspaceUtils.collectDependents( list, getWorkspace().getDependencyGraph().getNode( metadata.getIdentifier() ) );
             for ( ResourceMetadata<?> md : list ) {


### PR DESCRIPTION
Resolves  #750

Previously, when resource was deactivated via deegree console it disappeared until workspace reload was executed.

Fix adds the resource to ResourceManager again after it has been destroyed. Due to this the resource is still displayed in the deegree console after is is was deactivated (no reload necessary).

This fix is more a workaround as the OGCFrontController (for service resource; corresponding classes exist for other resources) should check if a resource has the state deactivated and skip the resource if this is the case. The destroying of the resource may become obsolete when this check is implemented.