### PR TITLE
Fixed exception of WFS if geometry operand is not a geometry property for result type hits

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -743,6 +743,8 @@ public class SQLFeatureStore implements FeatureStore {
                 rs.next();
                 hits = rs.getInt( 1 );
             }
+        } catch( InvalidParameterValueException e ){
+            throw e;
         } catch ( Exception e ) {
             String msg = "Error performing hits query by operator filter: " + e.getMessage();
             LOG.error( msg, e );


### PR DESCRIPTION
This pull request enhances PR #719 which has already been merged.

Previously, if a WFS was requested with result type hits and there is a geometry operand which is not a geometry property status code 500 was still returned.

This pull request fixes the behaviour and corrects the exception to InvalidParameterValue for the case resultType=hits by passing the exception (explanation why InvalidParameterValue is correct can be found in #719).