### PR TITLE
Fixed Transactions requests with SOAP encoding  

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/XMLStreamUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/XMLStreamUtils.java
@@ -76,6 +76,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.apache.axiom.om.OMElement;
 import org.apache.xerces.parsers.DOMParser;
 import org.deegree.commons.utils.ArrayUtils;
 import org.deegree.commons.utils.io.StreamBufferStore;
@@ -882,6 +883,20 @@ public class XMLStreamUtils {
         Document doc = parser.getDocument();
         store.close();
         return doc;
+    }
+
+    /**
+     * Creates a {@link XMLStreamReader} out of an {@link OMElement}
+     *
+     * @param omElement the omElement to convert, never <code>null</code>
+     * @return the omElement as {@link XMLStreamReader} the START_DOCUMENT node is skipped, never <code>null</code>
+     * @throws XMLStreamException if an error occurred creating the {@link XMLStreamReader}
+     */
+    public static XMLStreamReader getAsXmlStrem( OMElement omElement )
+                            throws XMLStreamException {
+        XMLStreamReader bodyXmlStream = omElement.getXMLStreamReaderWithoutCaching();
+        skipStartDocument( bodyXmlStream );
+        return bodyXmlStream;
     }
 
     /**

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -765,7 +765,6 @@ class TransactionHandler {
         xmlWriter.writeEndElement(); // wfs:Status
         xmlWriter.writeEndElement(); // wfs:TransactionResult
         xmlWriter.writeEndElement(); // wfs:WFS_TransactionResult
-        xmlWriter.writeEndDocument();
         xmlWriter.flush();
     }
 
@@ -822,7 +821,6 @@ class TransactionHandler {
         }
 
         xmlWriter.writeEndElement();
-        xmlWriter.writeEndDocument();
         xmlWriter.flush();
     }
 
@@ -851,7 +849,6 @@ class TransactionHandler {
         writeActionResults200( xmlWriter, "ReplaceResults", replaced );
 
         xmlWriter.writeEndElement();
-        xmlWriter.writeEndDocument();
         xmlWriter.flush();
     }
 

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -1001,7 +1001,7 @@ public class WebFeatureService extends AbstractOWS {
             }
 
             OMElement body = soapDoc.getBody().getFirstElement().cloneOMElement();
-            XMLStreamReader bodyXmlStream = body.getXMLStreamReaderWithoutCaching();
+            XMLStreamReader bodyXmlStream = XMLStreamUtils.getAsXmlStrem( body );
 
             String requestName = body.getLocalName();
             WFSRequestType requestType = getRequestTypeByName( requestName );


### PR DESCRIPTION
This PR fixes an exception thrown cause of an unexpected event type of the XMLStreamReader by skipping the START_DOCUMENT.

Previously the following exception was thrown:
```
<soapenv:Envelope xsi:schemaLocation="http://schemas.xmlsoap.org/soap/envelope http://schemas.xmlsoap.org/soap/envelope" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <soapenv:Body>
      <soapenv:Fault>
         <faultcode>Sender</faultcode>
         <faultstring>Required type START_ELEMENT, actual type START_DOCUMENT</faultstring>
         <detail>
            <ows:ExceptionReport xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="2.0.0" xmlns:ows="http://www.opengis.net/ows/1.1">
               <ows:Exception exceptionCode="NoApplicableCode">
                  <ows:ExceptionText>Required type START_ELEMENT, actual type START_DOCUMENT</ows:ExceptionText>
               </ows:Exception>
            </ows:ExceptionReport>
         </detail>
      </soapenv:Fault>
   </soapenv:Body>
</soapenv:Envelope>
```

Request:
```
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
  <soapenv:Body>
  <wfs:Transaction version="2.0.0" service="WFS" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/fes/2.0 http://schemas.opengis.net/filter/2.0/filter.xsd" xmlns:app="http://www.deegree.org/app" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <wfs:Delete typeName="app:osm_protected_area">
    <fes:Filter>
      <fes:ResourceId rid="osm_protected_area_34"/>
    </fes:Filter>
  </wfs:Delete>
</wfs:Transaction>
  </soapenv:Body>
</soapenv:Envelope>
```

Furthermore the following exception was fixed, thrown as response of a transation request: 

```
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.0"
	xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
	<ows:Exception exceptionCode="InvalidRequest">
		<ows:ExceptionText>java.lang.NullPointerException</ows:ExceptionText>
	</ows:Exception>
</ows:ExceptionReport>
```

This root cause was an already closed writer during the attempt to write the closing soap envelope elements. 