### PR TITLE
Fix WPS client to support xml sub-mimetypes like gml+xml

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/wps100/ExecuteResponse100Reader.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/wps100/ExecuteResponse100Reader.java
@@ -52,7 +52,6 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.commons.codec.binary.Base64;
-import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ows.CodeType;
 import org.deegree.commons.utils.io.StreamBufferStore;
 import org.deegree.commons.xml.XMLAdapter;
@@ -287,7 +286,8 @@ public class ExecuteResponse100Reader {
 
         StreamBufferStore tmpSink = new StreamBufferStore();
         try {
-            if ( attribs.getMimeType().startsWith( "text/xml" ) || attribs.getMimeType().startsWith( "application/xml" ) ) {
+            if ( attribs.getMimeType().matches( "^text/.*\\bxml\\b.*" ) || 
+                 attribs.getMimeType().matches( "^application/.*\\bxml\\b.*" ) ) {
                 XMLOutputFactory fac = XMLOutputFactory.newInstance();
                 fac.setProperty( XMLOutputFactory.IS_REPAIRING_NAMESPACES, true );
                 XMLStreamWriter xmlWriter = fac.createXMLStreamWriter( tmpSink, "UTF-8" );


### PR DESCRIPTION
When parsing complex WPS outputs, the client doesn't recognize mimetype "application/gml+xml" as an XML output and treats it as binary instead.

According to [MIME Media Types for GML](https://portal.opengeospatial.org/files/?artifact_id=37743), "application/gml+xml" is the mimetype for GML.

This change lets the client recognize all mimetypes as XML outputs that contain "xml" as a separate word .