### PR TITLE
Method to create WPS client ExecutionResponse from status location URL

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessExecution.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessExecution.java
@@ -46,19 +46,13 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.namespace.QName;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ows.CodeType;
-import org.deegree.commons.xml.stax.XMLStreamUtils;
-import org.deegree.protocol.ows.exception.OWSExceptionReader;
 import org.deegree.protocol.ows.exception.OWSExceptionReport;
-import org.deegree.protocol.wps.WPSConstants;
 import org.deegree.protocol.wps.WPSConstants.ExecutionState;
 import org.deegree.protocol.wps.client.WPSClient;
 import org.deegree.protocol.wps.client.output.type.OutputType;
@@ -226,16 +220,8 @@ public class ProcessExecution extends AbstractProcessExecution {
             if ( statusLocation == null ) {
                 throw new RuntimeException( "Cannot update status. No statusLocation provided." );
             }
-            LOG.debug( "Polling response document from status location: " + statusLocation );
-            XMLInputFactory inFactory = XMLInputFactory.newInstance();
-            InputStream is = statusLocation.openStream();
-            XMLStreamReader xmlReader = inFactory.createXMLStreamReader( is );
-            XMLStreamUtils.nextElement( xmlReader );
-            if ( OWSExceptionReader.isExceptionReport( xmlReader.getName() ) ) {
-                throw OWSExceptionReader.parseExceptionReport( xmlReader );
-            }
-            ExecuteResponse100Reader reader = new ExecuteResponse100Reader( xmlReader );
-            lastResponse = reader.parse100();
+
+            lastResponse = ExecuteResponse100Reader.createExecutionResponseFromURL( statusLocation );
         }
         return lastResponse.getStatus().getState();
     }
@@ -327,7 +313,6 @@ public class ProcessExecution extends AbstractProcessExecution {
         XMLOutputFactory outFactory = XMLOutputFactory.newInstance();
 
         OutputStream os = conn.getOutputStream();
-        XMLInputFactory inFactory = XMLInputFactory.newInstance();
 
         if ( LOG.isDebugEnabled() ) {
             File logFile = File.createTempFile( "wpsclient", "request.xml" );
@@ -370,20 +355,9 @@ public class ProcessExecution extends AbstractProcessExecution {
         }
 
         // String outputContent = conn.getContentType();
-        // TODO determine XML reader encoding based on mime type
-        XMLStreamReader reader = inFactory.createXMLStreamReader( responseStream );
-        XMLStreamUtils.nextElement( reader );
-        if ( OWSExceptionReader.isExceptionReport( reader.getName() ) ) {
-            throw OWSExceptionReader.parseExceptionReport( reader );
-        }
-        if ( new QName( WPSConstants.WPS_100_NS, "ExecuteResponse" ).equals( reader.getName() ) ) {
-            ExecuteResponse100Reader responseReader = new ExecuteResponse100Reader( reader );
-            lastResponse = responseReader.parse100();
-            reader.close();
 
-        } else {
-            throw new RuntimeException( "Unexpected Execute response: root element is '" + reader.getName() + "'" );
-        }
+        lastResponse = ExecuteResponse100Reader.createExecutionResponseFromStream( responseStream );
+
         return lastResponse;
     }
 }

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
@@ -78,6 +78,8 @@ import org.deegree.protocol.wps.client.process.Process;
 import org.deegree.protocol.wps.client.process.ProcessExecution;
 import org.deegree.protocol.wps.client.process.RawProcessExecution;
 import org.deegree.protocol.wps.client.process.execute.ExecutionOutputs;
+import org.deegree.protocol.wps.client.process.execute.ExecutionResponse;
+import org.deegree.protocol.wps.client.wps100.ExecuteResponse100Reader;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -536,8 +538,21 @@ public class WPSClientTest {
         Assert.assertNotSame( ExecutionState.SUCCEEDED, execution.getState() );
         Assert.assertNotSame( ExecutionState.FAILED, execution.getState() );
 
+        URL url = execution.getStatusLocation();
+        Integer progress = new Integer(0);
+
         while ( ( execution.getState() ) != ExecutionState.SUCCEEDED ) {
             System.out.println( execution.getPercentCompleted() );
+
+            Assert.assertNotNull( execution.getPercentCompleted() );
+            Assert.assertTrue( progress <= execution.getPercentCompleted() );
+            Assert.assertTrue( execution.getPercentCompleted() <= 100 );
+            progress = execution.getPercentCompleted();
+
+            ExecutionResponse response = ExecuteResponse100Reader.createExecutionResponseFromURL( url );
+            Assert.assertNotNull( response );
+            Assert.assertTrue( progress <= response.getStatus().getPercentCompleted() );
+
             Thread.sleep( 500 );
         }
 


### PR DESCRIPTION
This implements the behaviour requested in issue #674:
Two (convenience) methods are added that generate an ExecutionResponse object (with execution status, percent complete, etc.) from a status location URL or stream.

To avoid code duplication, these methods are then used by ProcessExecution to parse execution responses as well.

The WPS client integration test is expanded to use the new methods.
