### PR TITLE
3.4 Fix compability issues with jdk6

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/stream/EmptyFeatureInputStream.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/stream/EmptyFeatureInputStream.java
@@ -32,7 +32,9 @@ public class EmptyFeatureInputStream implements FeatureInputStream {
 
     @Override
     public Iterator<Feature> iterator() {
-        return Collections.emptyIterator();
+        //TODO Use proper Java 1.7 API if JDK 6 is dropped
+        //return Collections.emptyIterator();
+        return Collections.<Feature>emptyList().iterator();
     }
 
 }


### PR DESCRIPTION
In an previous pull request java 1.7 or newer api was used this pull requests fixed that.

http://download.deegree.org/documentation/3.4-RC2/html/installation.html#f1