### PR TITLE
Fixed creation of gml time properties

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
@@ -36,6 +36,7 @@
 package org.deegree.feature.persistence.sql.rules;
 
 import static java.lang.Boolean.TRUE;
+import static org.deegree.commons.tom.gml.GMLObjectCategory.TIME_OBJECT;
 import static org.deegree.commons.utils.JDBCUtils.close;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.deegree.commons.xml.CommonNamespaces.XSI_PREFIX;
@@ -325,7 +326,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
         }
         for ( final TypedObjectNode particle : particles ) {
             if ( particle instanceof GenericXMLElement ) {
-                if ( pt instanceof ObjectPropertyType && particle instanceof TimeObject ) {
+                if ( pt instanceof ObjectPropertyType && TIME_OBJECT.equals( ( (ObjectPropertyType) pt ).getCategory() ) ) {
                     props.add( recreatePropertyFromGml( pt, (GenericXMLElement) particle ) );
                 } else {
                     GenericXMLElement xmlEl = (GenericXMLElement) particle;


### PR DESCRIPTION
A SQLFeatureStore configuration with a gml:TimePeriod results in empty properties in GetFeature-Response. Example for the configuration:  

**SQLFeatureStore**:

```
    <Complex path="app:period">
      <Complex path="gml:TimePeriod">
        <Primitive path="@gml:id" mapping="osm_timestamp_modified_id" />
        <Primitive path="gml:beginPosition" mapping="osm_timestamp" type="dateTime"/>
        <Primitive path="gml:endPosition" mapping="osm_timestamp_modified" type="dateTime"/>
      </Complex>
    </Complex>
```

**Application schema**:

```
  <element name="period" minOccurs="0" type="gml:TimePeriodPropertyType" />
```

**Service**:
DisableDynamicSchema = true is required to avoid an exception in DescribeFeatureTypes

```
<GMLFormat gmlVersion="GML_32">
    <MimeType>application/gml+xml; version=3.2</MimeType>
    <MimeType>text/xml; subtype=gml/3.2.1</MimeType>
    <MimeType>text/xml; subtype="gml/3.2.1"</MimeType>
    <GetFeatureResponse>
      <DisableDynamicSchema>true</DisableDynamicSchema> 
      <DisableStreaming>true</DisableStreaming>
    </GetFeatureResponse>
  </GMLFormat>
```

A GetFeature-Response contains empty period-Properties:

```
<app:period/>
```

This PR fix this problem. It improves #623 as the instanceof check is never applied cause there are no TimeObject particles created.
