### PR TITLE
Improves the rendering of labels in polygons

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/GeometryClipper.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/GeometryClipper.java
@@ -49,6 +49,7 @@ import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometries;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryFactory;
+import org.deegree.geometry.multi.MultiPoint;
 import org.deegree.geometry.multi.MultiPolygon;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
@@ -73,9 +74,12 @@ import java.util.List;
  */
 class GeometryClipper {
 
+    private final Envelope viewPort;
+
     private final Polygon clippingArea;
 
     GeometryClipper( final Envelope viewPort, final int width ) {
+        this.viewPort = viewPort;
         this.clippingArea = calculateClippingArea( viewPort, width );
     }
 
@@ -99,6 +103,37 @@ class GeometryClipper {
      * @return the clipped geometry or the original geometry if the geometry lays completely in the drawing area.
      */
     Geometry clipGeometry( final Geometry geom ) {
+        return clipGeometry( geom, clippingArea );
+    }
+
+    /**
+     * Calculates the points inside the geometry and inside the view port. First the passed geometry is clipped
+     * by the view port. A multipolygon may result. For each of the polygon in this multipolygon one interior point
+     * is created
+     *
+     * @param geom to create labels for, must not be <code>null</code> and in the same CRS as the viewPort
+     * @return a MultiPoint with all calculated labels
+     */
+    MultiPoint calculateInteriorPoints( final Geometry geom ) {
+        if ( geom == null )
+            return null;
+        Geometry clippedGeometry = clipGeometry( geom, viewPort );
+        List<Point> points = new ArrayList<Point>();
+        if ( clippedGeometry != null && clippedGeometry instanceof DefaultSurface ) {
+            points.add( ( (DefaultSurface) clippedGeometry ).getInteriorPoint() );
+        }
+        if ( clippedGeometry != null && clippedGeometry instanceof MultiPolygon ) {
+            for ( Polygon p : ( (MultiPolygon) clippedGeometry ) ) {
+                if ( p instanceof DefaultSurface ) {
+                    points.add( ( (DefaultSurface) p ).getInteriorPoint() );
+                }
+            }
+        }
+        return new GeometryFactory().createMultiPoint( null, geom.getCoordinateSystem(), points );
+    }
+
+
+    Geometry clipGeometry( final Geometry geom, Geometry clippingArea ) {
         if ( clippingArea != null && !clippingArea.contains( geom ) ) {
             try {
                 Geometry clippedGeometry = clippingArea.getIntersection( geom );
@@ -113,7 +148,7 @@ class GeometryClipper {
                 if ( isInvertedOrientation( jtsOrig ) ) {
                     return clippedGeometry;
                 }
-                
+
                 return fixOrientation( clippedGeometry, clippedGeometry.getCoordinateSystem() );
             } catch ( UnsupportedOperationException e ) {
                 // use original geometry if intersection not supported by JTS
@@ -121,28 +156,6 @@ class GeometryClipper {
             }
         }
         return geom;
-    }
-
-    Geometry calculateInteriorPoints( final Geometry geom ) {
-        if( geom == null )
-            return null;
-        try {
-            List<Point> points = new ArrayList<Point>();
-            if ( geom != null && geom instanceof DefaultSurface ) {
-                points.add( ( (DefaultSurface) geom ).getInteriorPoint() );
-            }
-            if ( geom != null && geom instanceof MultiPolygon ) {
-                for ( Polygon p : ( (MultiPolygon) geom ) ) {
-                    if ( p instanceof DefaultSurface ) {
-                        points.add( ( (DefaultSurface) p ).getInteriorPoint() );
-                    }
-                }
-            }
-           return new GeometryFactory().createMultiPoint( null, geom.getCoordinateSystem(), points );
-        } catch ( UnsupportedOperationException e ) {
-            // use original geometry if intersection not supported by JTS
-            return geom;
-        }
     }
 
     /**

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DLabelRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DLabelRenderer.java
@@ -65,10 +65,7 @@ import org.deegree.geometry.multi.MultiCurve;
 import org.deegree.geometry.multi.MultiGeometry;
 import org.deegree.geometry.multi.MultiLineString;
 import org.deegree.geometry.multi.MultiPoint;
-import org.deegree.geometry.primitive.Curve;
-import org.deegree.geometry.primitive.GeometricPrimitive;
-import org.deegree.geometry.primitive.Point;
-import org.deegree.geometry.primitive.Surface;
+import org.deegree.geometry.primitive.*;
 import org.deegree.rendering.r2d.strokes.OffsetStroke;
 import org.deegree.rendering.r2d.strokes.TextStroke;
 import org.deegree.style.styling.TextStyling;
@@ -76,22 +73,21 @@ import org.slf4j.Logger;
 
 /**
  * Responsible for creating and rendering of labels. Based on Java2DTextRenderer
- * 
+ *
  * @author Florian Bingel
  * @author last edited by: $Author: stranger $
- * 
  * @version $Revision: $, $Date: $
  */
 public class Java2DLabelRenderer implements LabelRenderer {
 
     static final Logger LOG = getLogger( Java2DLabelRenderer.class );
-    
+
     private Java2DRenderer renderer;
 
     private RendererContext context;
-    
+
     private Java2DTextRenderer textRenderer;
-    
+
     private ArrayList<Label> labelList;
 
     public Java2DLabelRenderer( Java2DRenderer renderer, Java2DTextRenderer textRenderer ) {
@@ -100,7 +96,7 @@ public class Java2DLabelRenderer implements LabelRenderer {
         this.textRenderer = textRenderer;
         labelList = new ArrayList<Label>();
     }
-    
+
     @Override
     public void createLabel( TextStyling styling, String text, Collection<Geometry> geoms ) {
         for ( Geometry g : geoms ) {
@@ -109,7 +105,7 @@ public class Java2DLabelRenderer implements LabelRenderer {
     }
 
     @Override
-    public void createLabel( TextStyling styling, String text, Geometry geom ) {        
+    public void createLabel( TextStyling styling, String text, Geometry geom ) {
         if ( geom == null ) {
             LOG.debug( "Trying to render null geometry." );
         }
@@ -123,12 +119,12 @@ public class Java2DLabelRenderer implements LabelRenderer {
     }
 
     @Override
-    public List<Label> getLabels(){
+    public List<Label> getLabels() {
         return labelList;
     }
-    
+
     private void handleGeometryTypes( TextStyling styling, String text, Font font, Geometry geom ) {
-        if( geom == null ) {
+        if ( geom == null ) {
             LOG.warn( "null geometry cannot be handled." );
             return;
         }
@@ -138,10 +134,11 @@ public class Java2DLabelRenderer implements LabelRenderer {
             textRenderer.render( styling, font, text, (Surface) geom );
         } else if ( geom instanceof Curve && styling.linePlacement != null ) {
             textRenderer.render( styling, font, text, (Curve) geom );
+        } else if ( geom instanceof Polygon && styling.auto ) {
+            handlePolygonWithAutoPlacement( styling, font, text, (Polygon) geom );
         } else if ( geom instanceof GeometricPrimitive ) {
             labelList.add( createLabel( styling, font, text, geom.getCentroid() ) );
-        }
-        else if ( geom instanceof MultiPoint ) {
+        } else if ( geom instanceof MultiPoint ) {
             handleMultiGeometry( styling, text, font, (MultiPoint) geom );
         } else if ( geom instanceof MultiCurve<?> && styling.linePlacement != null ) {
             handleMultiGeometry( styling, text, font, (MultiCurve<?>) geom );
@@ -156,16 +153,16 @@ public class Java2DLabelRenderer implements LabelRenderer {
     }
 
     private <T extends Geometry> ArrayList<Label> handleMultiGeometry( TextStyling styling, String text, Font font,
-                                                           MultiGeometry<T> geom ) {
+                                                                       MultiGeometry<T> geom ) {
         ArrayList<Label> list = new ArrayList<Label>();
         for ( T g : geom ) {
             handleGeometryTypes( styling, text, font, g );
         }
         return list;
     }
-    
+
     @Override
-    public Label createLabel( TextStyling styling, Font font, String text, Point p ){
+    public Label createLabel( TextStyling styling, Font font, String text, Point p ) {
 
         TextLayout layout;
         synchronized ( FontRenderContext.class ) {
@@ -175,54 +172,68 @@ public class Java2DLabelRenderer implements LabelRenderer {
             FontRenderContext frc = renderer.graphics.getFontRenderContext();
             layout = new TextLayout( text, font, frc );
         }
-        
-        Point2D.Double origin = (Point2D.Double) renderer.worldToScreen.transform( new Point2D.Double( p.get0(), p.get1() ),null );
-        Label aLable = new Label(layout,styling,font,text,origin,context);
-        
-        return aLable;
+
+        Point2D.Double origin = (Point2D.Double) renderer.worldToScreen.transform(
+                                new Point2D.Double( p.get0(), p.get1() ), null );
+        return new Label( layout, styling, font, text, origin, context );
     }
-    
+
     @Override
-    public void render( ) {
-        for( Label l : labelList){
+    public void render() {
+        for ( Label l : labelList ) {
             render( l );
         }
         labelList = null;
     }
-    
+
     @Override
     public void render( List<Label> pLabels ) {
-           for( Label l : pLabels){
-               render( l );
-           }
+        for ( Label l : pLabels ) {
+            render( l );
+        }
     }
-    
+
     @Override
     public void render( Label pLabel ) {
 
         renderer.graphics.setFont( pLabel.getFont() );
         AffineTransform transform = renderer.graphics.getTransform();
-        renderer.graphics.rotate( toRadians( pLabel.getStyling().rotation ), pLabel.getOrigin().x, pLabel.getOrigin().y );
-
+        renderer.graphics.rotate( toRadians( pLabel.getStyling().rotation ), pLabel.getOrigin().x,
+                                  pLabel.getOrigin().y );
 
         if ( pLabel.getStyling().halo != null ) {
             context.fillRenderer.applyFill( pLabel.getStyling().halo.fill, pLabel.getStyling().uom );
 
-            BasicStroke stroke = new BasicStroke( round( 2 * context.uomCalculator.considerUOM( pLabel.getStyling().halo.radius,
-                                                                                                pLabel.getStyling().uom ) ),
-                                                  CAP_BUTT, JOIN_ROUND );
+            BasicStroke stroke = new BasicStroke(
+                                    round( 2 * context.uomCalculator.considerUOM( pLabel.getStyling().halo.radius,
+                                                                                  pLabel.getStyling().uom ) ),
+                                    CAP_BUTT, JOIN_ROUND );
             renderer.graphics.setStroke( stroke );
-            renderer.graphics.draw( pLabel.getLayout().getOutline( getTranslateInstance( pLabel.getDrawPosition().x, pLabel.getDrawPosition().y ) ) );
+            renderer.graphics.draw( pLabel.getLayout().getOutline(
+                                    getTranslateInstance( pLabel.getDrawPosition().x, pLabel.getDrawPosition().y ) ) );
         }
 
         //LOG.debug("LabelRender w:" + pLabel.getLayout().getBounds().getWidth() + "   h: "+pLabel.getLayout().getBounds().getHeight()+"   x: "+pLabel.getDrawPosition().x + "   y: "+pLabel.getDrawPosition().y);
         renderer.graphics.setStroke( new BasicStroke() );
 
         context.fillRenderer.applyFill( pLabel.getStyling().fill, pLabel.getStyling().uom );
-        pLabel.getLayout().draw( renderer.graphics, (float) pLabel.getDrawPosition().x, (float) pLabel.getDrawPosition().y );
+        pLabel.getLayout().draw( renderer.graphics, (float) pLabel.getDrawPosition().x,
+                                 (float) pLabel.getDrawPosition().y );
 
         renderer.graphics.setTransform( transform );
     }
-    
+
+    private void handlePolygonWithAutoPlacement( TextStyling styling, Font font, String text, Polygon geom ) {
+        Geometry transformedGeom = renderer.rendererContext.geomHelper.transform( geom );
+        Geometry clippedGeometry = renderer.rendererContext.clipper.clipGeometry( transformedGeom );
+        Geometry points = renderer.rendererContext.clipper.calculateInteriorPoints( clippedGeometry );
+        if ( geom == null )
+            return;
+        if ( points instanceof MultiPoint ) {
+            handleMultiGeometry( styling, text, font, (MultiGeometry) points );
+        } else {
+            handleGeometryTypes( styling, text, font, points.getCentroid() );
+        }
+    }
 
 }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DLabelRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DLabelRenderer.java
@@ -225,15 +225,10 @@ public class Java2DLabelRenderer implements LabelRenderer {
 
     private void handlePolygonWithAutoPlacement( TextStyling styling, Font font, String text, Polygon geom ) {
         Geometry transformedGeom = renderer.rendererContext.geomHelper.transform( geom );
-        Geometry clippedGeometry = renderer.rendererContext.clipper.clipGeometry( transformedGeom );
-        Geometry points = renderer.rendererContext.clipper.calculateInteriorPoints( clippedGeometry );
+        MultiPoint points = renderer.rendererContext.clipper.calculateInteriorPoints( transformedGeom );
         if ( geom == null )
             return;
-        if ( points instanceof MultiPoint ) {
-            handleMultiGeometry( styling, text, font, (MultiGeometry) points );
-        } else {
-            handleGeometryTypes( styling, text, font, points.getCentroid() );
-        }
+        handleMultiGeometry( styling, text, font, (MultiGeometry) points );
     }
 
 }


### PR DESCRIPTION
If the requested bounding box in a GetMap request splits the geometry feature into a multpolygon  (e.g. a 'banana'-geometry into the two ends of the 'banana') the label is rendered in the center of the original geometry, which may be somewhere outside the geometry (e.g. between the two ends of the 'banana').

This pull requests fixes this by calculating points into the visible parts of the geometry in the map  if **auto="true"** is configured.

Example 

```
<?xml version="1.0" encoding="UTF-8"?>
<FeatureTypeStyle
    version="1.1.0"
    xmlns="http://www.opengis.net/se"
    xmlns:wupp="http://www.deegree.org/app"
    xmlns:ogc="http://www.opengis.net/ogc"
    xmlns:sed="http://www.deegree.org/se"
    xmlns:deegreeogc="http://www.deegree.org/ogc"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd http://www.deegree.org/se http://schemas.deegree.org/se/1.1.0/Symbolizer-deegree.xsd">
    ...
    <Rule>
        <TextSymbolizer>
            <Label>
                <ogc:PropertyName>app:label</ogc:PropertyName>
            </Label>
            <Font>
                <SvgParameter name="font-family">Arial</SvgParameter>
            </Font>  
                         <LabelPlacement>
                <PointPlacement  auto="true">
                    <Displacement>
                        <DisplacementX>0</DisplacementX>
                        <DisplacementY>0</DisplacementY>
                    </Displacement>
                    <Rotation>0</Rotation>
                </PointPlacement>
            </LabelPlacement> 
            ...
        </TextSymbolizer>
        ...
    </Rule>
</FeatureTypeStyle>

```
