### PR TITLE
Fixed broken characters caused by the deegree console

### DIFF
--- a/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/filter/InputFileFilter.java
+++ b/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/filter/InputFileFilter.java
@@ -72,6 +72,7 @@ public class InputFileFilter implements Filter {
                 request = new InputFileWrapper( httpRequest );
             }
         }
+        request.setCharacterEncoding( "UTF-8" );
         chain.doFilter( request, response );
     }
 


### PR DESCRIPTION
Previously, special characters in configuration files were broken after editing and saving with the deegree console. This PR sets UTF-8 explicitly as character encoding to avoid broken characters.

PR for 3.4: #790