### PR TITLE
Avoid usage of default namespace in curve.xml

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
@@ -1,6 +1,6 @@
-<gml:Curve xmlns:gml="http://www.opengis.net/gml" 
+<gml:Curve xmlns:gml="http://www.opengis.net/gml"
            srsName="EPSG:4326"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
   <gml:segments>
     <gml:Arc interpolation="circularArc3Points">

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/resources/org/deegree/protocol/wps/client/curve.xml
@@ -1,11 +1,13 @@
-<Curve gml:id="C1" xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:4326"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
-  <segments>
-    <Arc interpolation="circularArc3Points">
-      <posList srsName="EPSG:4326">2 0 0 2 -2 0</posList>
-    </Arc>
-    <LineStringSegment interpolation="linear">
-      <posList srsName="EPSG:4326">-2 0 0 -2 2 0</posList>
-    </LineStringSegment>
-  </segments>
-</Curve>
+<gml:Curve xmlns:gml="http://www.opengis.net/gml" 
+           srsName="EPSG:4326"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+  <gml:segments>
+    <gml:Arc interpolation="circularArc3Points">
+      <gml:posList srsName="EPSG:4326">2 0 0 2 -2 0</gml:posList>
+    </gml:Arc>
+    <gml:LineStringSegment interpolation="linear">
+      <gml:posList srsName="EPSG:4326">-2 0 0 -2 2 0</gml:posList>
+    </gml:LineStringSegment>
+  </gml:segments>
+</gml:Curve>


### PR DESCRIPTION
Fixing bug #772: Avoid usage of default namespace in curve.xml