### PR TITLE
WPS client: Use URIs in complex outputs as well as inputs

### DIFF
--- a/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/ExecuteBean.java
+++ b/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/ExecuteBean.java
@@ -126,7 +126,7 @@ public class ExecuteBean implements Serializable {
 
             ComplexOutput o = (ComplexOutput) exe.execute().get( outputTypes[0].getId().getCode(),
                                                                  outputTypes[0].getId().getCodeSpace() );
-            String link = o.getWebAccessibleURL().toExternalForm();
+            String link = o.getWebAccessibleURI().toASCIIString();
             LOG.debug( "Result can be found here: " + link );
             result = link;
         } catch ( Exception e ) {

--- a/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/WpsPrinterBean.java
+++ b/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/WpsPrinterBean.java
@@ -245,7 +245,7 @@ public class WpsPrinterBean implements Serializable {
                                                         ot.getDefaultFormat().getMimeType(), null, null );
                             ComplexOutput eo = (ComplexOutput) prepareExecution.execute().get( ot.getId().getCode(),
                                                                                                ot.getId().getCodeSpace() );
-                            overview = eo.getWebAccessibleURL().toExternalForm();
+                            overview = eo.getWebAccessibleURI().toASCIIString();
                         }
                     } catch ( Exception e ) {
                         FacesMessage fm = MessageUtils.getFacesMessage( FacesMessage.SEVERITY_ERROR,

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/output/ComplexOutput.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/output/ComplexOutput.java
@@ -37,7 +37,7 @@ package org.deegree.protocol.wps.client.output;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -61,7 +61,7 @@ public class ComplexOutput extends ExecutionOutput {
 
     private final ComplexFormat complexAttribs;
 
-    private final URL url;
+    private final URI uri;
 
     private final StreamBufferStore store;
 
@@ -70,8 +70,8 @@ public class ComplexOutput extends ExecutionOutput {
      * 
      * @param id
      *            output parameter identifier, must not be <code>null</code>
-     * @param url
-     *            web-accessible URL for accessing the resource, must not be <code>null</code>
+     * @param uri
+     *            web-accessible URI for accessing the resource, must not be <code>null</code>
      * @param mimeType
      *            mime type of the complex data, can be <code>null</code> (unspecified)
      * @param encoding
@@ -79,9 +79,9 @@ public class ComplexOutput extends ExecutionOutput {
      * @param schema
      *            XML schema of the complex data, can be <code>null</code> (unspecified)
      */
-    public ComplexOutput( CodeType id, URL url, String mimeType, String encoding, String schema ) {
+    public ComplexOutput( CodeType id, URI uri, String mimeType, String encoding, String schema ) {
         super( id );
-        this.url = url;
+        this.uri = uri;
         this.store = null;
         this.complexAttribs = new ComplexFormat( mimeType, null, schema );
     }
@@ -102,7 +102,7 @@ public class ComplexOutput extends ExecutionOutput {
      */
     public ComplexOutput( CodeType id, StreamBufferStore store, String mimeType, String encoding, String schema ) {
         super( id );
-        this.url = null;
+        this.uri = null;
         this.store = store;
         this.complexAttribs = new ComplexFormat( mimeType, encoding, schema );
     }
@@ -134,7 +134,7 @@ public class ComplexOutput extends ExecutionOutput {
         store.close();
         is.close();
         this.complexAttribs = new ComplexFormat( mimeType, encoding, schema );
-        this.url = null;
+        this.uri = null;
     }
 
     /**
@@ -147,16 +147,16 @@ public class ComplexOutput extends ExecutionOutput {
     }
 
     /**
-     * Returns the web-accessible URL for the complex data (as provided by the process).
+     * Returns the web-accessible URI for the complex data (as provided by the process).
      * <p>
      * This method is only applicable if the parameter has been requested as reference.
      * </p>
      * 
-     * @return the web-accessible URL, or <code>null</code> if the parameter has been returned in the response document
+     * @return the web-accessible URI, or <code>null</code> if the parameter has been returned in the response document
      *         or raw
      */
-    public URL getWebAccessibleURL() {
-        return url;
+    public URI getWebAccessibleURI() {
+        return uri;
     }
 
     /**
@@ -174,8 +174,8 @@ public class ComplexOutput extends ExecutionOutput {
                             throws XMLStreamException, IOException {
         XMLStreamReader xmlReader = null;
         XMLInputFactory inFactory = XMLInputFactory.newInstance();
-        if ( url != null ) {
-            xmlReader = inFactory.createXMLStreamReader( url.openStream() );
+        if ( uri != null ) {
+            xmlReader = inFactory.createXMLStreamReader( uri.toURL().openStream() );
         } else {
             xmlReader = inFactory.createXMLStreamReader( store.getInputStream() );
         }
@@ -200,8 +200,8 @@ public class ComplexOutput extends ExecutionOutput {
     public InputStream getAsBinaryStream()
                             throws IOException {
         InputStream is = null;
-        if ( url != null ) {
-            is = url.openStream();
+        if ( uri != null ) {
+            is = uri.toURL().openStream();
         } else {
             is = store.getInputStream();
         }

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/wps100/ExecuteResponse100Reader.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/wps100/ExecuteResponse100Reader.java
@@ -41,6 +41,8 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -174,7 +176,7 @@ public class ExecuteResponse100Reader {
                     String href = reader.getAttributeValue( null, "href" );
                     ComplexFormat attribs = parseComplexAttributes();
                     String mimeType = attribs.getMimeType();
-                    output = new ComplexOutput( id, new URL( href ), mimeType, attribs.getEncoding(),
+                    output = new ComplexOutput( id, new URI( href ), mimeType, attribs.getEncoding(),
                                                 attribs.getSchema() );
                     XMLStreamUtils.nextElement( reader );
                 }
@@ -187,7 +189,7 @@ public class ExecuteResponse100Reader {
                 XMLStreamUtils.nextElement( reader ); // </Output>
                 XMLStreamUtils.nextElement( reader );
             }
-        } catch ( MalformedURLException e ) {
+        } catch ( URISyntaxException e ) {
             e.printStackTrace();
         }
 


### PR DESCRIPTION
This extends #794 : now the WPS client outputs also use URI instead of URL.