### PR TITLE
Enabled support of FeatureCollections as FeatureTypes

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/DynamicFeatureType.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/DynamicFeatureType.java
@@ -179,6 +179,11 @@ public class DynamicFeatureType implements FeatureType {
     }
 
     @Override
+    public Feature newFeatureInstance( String fid, List<Property> props, ExtraProps extraProps ) {
+        return newFeature( fid, props, extraProps );
+    }
+
+    @Override
     public Feature newFeature( String fid, List<Property> props, ExtraProps extraProps ) {
         return new GenericFeature( this, fid, props, extraProps );
     }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/FeatureType.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/FeatureType.java
@@ -61,6 +61,19 @@ public interface FeatureType extends GMLObjectType {
     public GeometryPropertyType getDefaultGeometryPropertyDeclaration();
 
     /**
+     * Creates a new {@link Feature} instance (that is an insatnce of a {@link FeatureType}).
+     *
+     * @param fid
+     *            feature id, or null if the feature doesn't have an id
+     * @param props
+     *            properties
+     * @param extraProps
+     *            properties that are not defined by the {@link FeatureType} (e.g. rendering hints)
+     * @return a new <code>Feature</code> instance
+     */
+    public Feature newFeatureInstance( String fid, List<Property> props, ExtraProps extraProps );
+
+    /**
      * Creates a new {@link Feature} instance (that is of this type).
      * 
      * @param fid

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/GenericFeatureCollectionType.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/GenericFeatureCollectionType.java
@@ -76,6 +76,11 @@ public class GenericFeatureCollectionType extends GenericFeatureType implements 
     }
 
     @Override
+    public Feature newFeatureInstance( String fid, List<Property> props, ExtraProps extraProps ) {
+        return super.newFeature( fid, props, extraProps );
+    }
+
+    @Override
     public Feature newFeature( String fid, List<Property> props, ExtraProps extraProps ) {
         return new GenericFeatureCollection( this, fid, props, extraProps );
     }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/GenericFeatureType.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/GenericFeatureType.java
@@ -76,6 +76,11 @@ public class GenericFeatureType extends GenericGMLObjectType implements FeatureT
     }
 
     @Override
+    public Feature newFeatureInstance( String fid, List<Property> props, ExtraProps extraProps ) {
+        return newFeature( fid, props, extraProps );
+    }
+
+    @Override
     public Feature newFeature( String fid, List<Property> props, ExtraProps extraProps ) {
         return new GenericFeature( this, fid, props, extraProps );
     }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
@@ -284,7 +284,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
                                   + " are currently supported." );
                     }
                 }
-                feature = ft.newFeature( gmlId, props, null );
+                feature = ft.newFeatureInstance( gmlId, props, null );
                 if ( fs.getCache() != null ) {
                     fs.getCache().add( feature );
                 }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WfsFeatureStoreManager.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WfsFeatureStoreManager.java
@@ -241,7 +241,7 @@ public class WfsFeatureStoreManager {
                 LOG.error( msg );
                 throw new IllegalArgumentException( msg );
             }
-            for ( FeatureType ft : fs.getSchema().getFeatureTypes( null, false, false ) ) {
+            for ( FeatureType ft : fs.getSchema().getFeatureTypes( null, true, false ) ) {
                 if ( ft.getName().getNamespaceURI().equals( GMLNS )
                      || ft.getName().getNamespaceURI().equals( GML3_2_NS ) ) {
                     continue;


### PR DESCRIPTION
Currently, a FeatureType defined in the application schema and configured in SQLFeatureStore is not available (does not exist in capabilities, GetFeature is not supoorted, ...) if a property of Type AbstractFeatureMemberType is configured.
Example from http://www.locationframework.eu/schemas/AdministrativeUnits/1.0/AdministrativeUnits.xsd:

```
...
  <element name="AdministrativeUnit" substitutionGroup="au:AdministrativeUnit" type="elf-au:AdministrativeUnitType"/>
  <complexType name="AdministrativeUnitType">
...
          <element maxOccurs="unbounded" minOccurs="0" name="adminUnitArea">
            <annotation>
              <appinfo>
                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">elf-au:adminUnit</reversePropertyName>
              </appinfo>
            </annotation>
            <complexType>
              <complexContent>
                <extension base="gml:AbstractFeatureMemberType">
                  <sequence minOccurs="0">
                    <element ref="elf-au:AdministrativeUnitArea"/>
                  </sequence>
                  <attributeGroup ref="gml:AssociationAttributeGroup"/>
                </extension>
              </complexContent>
            </complexType>
          </element>
...
  </complexType>
...
```

The GML 3.2.1 specification (OGC 07-036) states in chapter 9.9.1 'GML feature collections' regarding AbstractFeatureMemberType:

```
A GML feature collection is any GML feature with a property element in its 
content model whose content model is derived by extension from 
gml:AbstractFeatureMemberType (see 9.9.2).
```

 deegree recognized FeatureType AdministrativeUnit as FeatureCollection as expected.
But deegree does not allow FeatureCollections as FeatureTypes.

In WFS 2.0.0 (OGC 09-025r1) specification there is no exclusion of FeatureCollections being FeatureTypes. Chapter 8.3.4 'FeatureTypeList section' says:

```
The wfs:FeatureTypeList element shall contain a list of feature types, 
subtyped from gml:AbstractFeatureType, that a WFS offers.

...

The wfs:FeatureTypeList element shall contain one wfs:FeatureType element 
for each feature type that the service offers. The element contains 
metadata about the feature type.
```

This fix enables that FeatureCollections are provided as FeatureTypes as well.
In case of the mentioned example above, the FeatureType AdministrativeUnit is now provided by deegree.

Fixes #746.