### PR TITLE
Fix bug in WPS client: LiteralInputType is missing DefaultValue property

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/input/type/LiteralInputType.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/input/type/LiteralInputType.java
@@ -55,6 +55,8 @@ public class LiteralInputType extends InputType {
 
     private ValueWithRef dataType;
 
+    private String defaultValue;
+
     private ValueWithRef defaultUom;
 
     private ValueWithRef[] supportedUoms;
@@ -69,7 +71,7 @@ public class LiteralInputType extends InputType {
 
     private boolean anyValue;
 
-    private ValueWithRef reference;
+    private ValueWithRef valuesReference;
 
     /**
      * Creates a new {@link LiteralInputType} instance.
@@ -85,20 +87,21 @@ public class LiteralInputType extends InputType {
      * @param allowedValues
      * @param range
      * @param anyValue
-     * @param reference
+     * @param valuesReference
      */
     public LiteralInputType( CodeType id, LanguageString inputTitle, LanguageString inputAbstract, String minOccurs,
-                             String maxOccurs, ValueWithRef dataType, ValueWithRef defaultUom,
+                             String maxOccurs, ValueWithRef dataType, String defaultValue, ValueWithRef defaultUom,
                              ValueWithRef[] supportedUoms, String[] allowedValues, Range[] range, boolean anyValue,
                              ValueWithRef reference ) {
         super( id, inputTitle, inputAbstract, minOccurs, maxOccurs );
         this.dataType = dataType;
+        this.defaultValue = defaultValue;
         this.defaultUom = defaultUom;
         this.supportedUoms = supportedUoms;
         this.allowedValues = allowedValues;
         this.range = range;
         this.anyValue = anyValue;
-        this.reference = reference;
+        this.valuesReference = reference;
     }
 
     @Override
@@ -159,5 +162,24 @@ public class LiteralInputType extends InputType {
      */
     public boolean isAnyValue() {
         return anyValue;
+    }
+
+    /**
+     * Returns the default value for the literal input as a String.
+     * 
+     * @return Default value for the literal input.
+     */
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * Returns the values reference that references an externally defined finite set of values and ranges for the
+     * literal input.
+     * 
+     * @return Values reference for the literal input.
+     */
+    public ValueWithRef getValuesReference() {
+        return valuesReference;
     }
 }

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessDetails.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessDetails.java
@@ -315,6 +315,9 @@ public class ProcessDetails {
         String dataTypeRefStr = omDataType.getAttributeValue( new QName( owsNS, "reference" ) );
         ValueWithRef dataType = new ValueWithRef( dataTypeStr, dataTypeRefStr );
 
+        OMElement omDefaultValue = input.getFirstChildWithName( new QName( null, "DefaultValue" ) );
+        String defaultValue = omDefaultValue == null ? null : omDefaultValue.getText();
+
         XPath xpath = new XPath( "UOMs/Default/ows:UOM", nsContext );
         OMElement omDefaultUom = omResponse.getElement( input, xpath );
         ValueWithRef defaultUom = null;
@@ -382,8 +385,8 @@ public class ProcessDetails {
         if ( rangeList != null ) {
             rangeArray = rangeList.toArray( new Range[rangeList.size()] );
         }
-        return new LiteralInputType( id, inputTitle, inputAbstract, minOccurs, maxOccurs, dataType, defaultUom,
-                                     supportedUom, valuesArray, rangeArray, anyValue, valuesRef );
+        return new LiteralInputType( id, inputTitle, inputAbstract, minOccurs, maxOccurs, dataType, defaultValue,
+                                     defaultUom, supportedUom, valuesArray, rangeArray, anyValue, valuesRef );
     }
 
     private InputType parseComplexData( OMElement input, CodeType id, LanguageString inputTitle,

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
@@ -622,4 +622,32 @@ public class WPSClientTest {
         execution.executeAsync();
         Assert.assertTrue(execution.getState() != ExecutionState.SUCCEEDED); // we shouldn't arrive here
     }
+
+    @Test
+    public void testProcessDescriptionWithDefaultValue()
+                            throws OWSExceptionReport, IOException {
+
+        String demoWPSURL = TestProperties.getProperty( "demo_wps_url2" );
+        String demoWPSProcessorName = TestProperties.getProperty( "demo_wps_def_processor" );
+        Assume.assumeNotNull( demoWPSURL );
+        Assume.assumeNotNull( demoWPSProcessorName );
+
+        WPSClient wpsClient = new WPSClient( new URL( demoWPSURL ) );
+
+        org.deegree.protocol.wps.client.process.Process p1 = wpsClient.getProcess( demoWPSProcessorName );
+
+        Assert.assertNotNull( p1 );
+
+        boolean foundDefaultValue = false;
+
+        for ( InputType inputType : p1.getInputTypes() ) {
+            if ( inputType instanceof LiteralInputType ) {
+                LiteralInputType literal = (LiteralInputType) inputType;
+                if ( literal.getDefaultValue() != null )
+                    foundDefaultValue = true;
+            }
+        }
+
+        Assert.assertTrue( "Could not find default value for any of the literal inputs", foundDefaultValue );
+    }
 }


### PR DESCRIPTION
This request fixes a bug in the WPS client:
Currently, LiteralInputType doesn't handle a literal input's default value which can be announced by a WPS server with the `<DefaultValue>` tag in the ProcessDescriptions, see Web Processing Service standard version 1.0.0, Table 25 (page 26).

This fix adds a property for it to LiteralInputType and adapts ProcessDetails to parse it from the ProcessDescriptions. 
It also adds an optional unit test that is run if demo_wps_url2 and demo_wps_def_processor are set in .deegree-test.properties. These values have to refer to a processor that has at least one default value for a literal input, e.g. http://www.zoo-project.org/cgi-bin/zoo_loader.cgi?Service=WPS&Version=1.0.0&Request=GetCapabilities and raster-tools-src.cgi-env.Gdal_Warp
