### PR TITLE
Enhance WFS-T by being able to insert features that reference features which are already inserted

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/Features.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/Features.java
@@ -193,7 +193,7 @@ public class Features {
 
     /**
      * Determines all {@link Feature} and {@link Geometry} objects contained in the given {@link TypedObjectNode} and
-     * their ids.
+     * their ids. Does <code>not</code> include internal referenced {@link Feature}s.
      * 
      * @param node
      *            typed object node to be scanned, can be <code>null</code>
@@ -217,11 +217,15 @@ public class Features {
         } else if ( node instanceof org.deegree.commons.tom.Object ) {
             if ( node instanceof Reference<?> ) {
                 Reference<?> ref = (Reference<?>) node;
-                if ( ref.isResolved() ) {
-                    node = ( (Reference<?>) node ).getReferencedObject();
-                } else if ( node instanceof Reference<?> ) {
+                if ( ref.isResolved() && !ref.isInternalResolved() ) {
+                    node = ref.getReferencedObject();
+                } else {
                     try {
-                        node = ( (Reference<?>) node ).getReferencedObject();
+                        TypedObjectNode referencedObject = ref.getReferencedObject();
+                        if ( !ref.isInternalResolved() )
+                            node = referencedObject;
+                        else
+                            return;
                     } catch ( ReferenceResolvingException e ) {
                         LOG.warn( "Unable to resolve external reference '" + ref.getURI() + ". Ignoring." );
                         return;

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
@@ -147,6 +147,8 @@ public class GMLStreamReader {
 
     private boolean laxMode;
 
+    private GMLReferenceResolver internalResolver;
+
     /**
      * Creates a new {@link GMLStreamReader} instance.
      * 
@@ -249,6 +251,14 @@ public class GMLStreamReader {
      */
     public void setResolver( GMLReferenceResolver resolver ) {
         this.resolver = resolver;
+    }
+
+    public void setInternalResolver ( GMLReferenceResolver internalResolver ) {
+            this.internalResolver = internalResolver;
+    }
+
+    public GMLReferenceResolver getInternalResolver () {
+        return internalResolver;
     }
 
     /**

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -155,6 +155,8 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 
     protected static final QName XSI_NIL = new QName( XSINS, "nil", "xsi" );
 
+    private final GMLReferenceResolver internalResolver;
+
     // TODO should be final, but is currently modified by GMLFeatureReader
     protected AppSchema schema;
 
@@ -167,6 +169,7 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
     protected AbstractGMLObjectReader( GMLStreamReader gmlStreamReader ) {
         this.gmlStreamReader = gmlStreamReader;
         this.specialResolver = gmlStreamReader.getResolver();
+        this.internalResolver = gmlStreamReader.getInternalResolver();
         this.idContext = gmlStreamReader.getIdContext();
         // TODO
         this.schema = gmlStreamReader.getAppSchema();
@@ -322,9 +325,17 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
         if ( href != null ) {
             FeatureReference refFeature = null;
             if ( specialResolver != null ) {
-                refFeature = new FeatureReference( specialResolver, href, xmlStream.getSystemId() );
+                if( internalResolver == null ) {
+                    refFeature = new FeatureReference( specialResolver, href, xmlStream.getSystemId() );
+                } else {
+                    refFeature = new FeatureReference( specialResolver, internalResolver, href, xmlStream.getSystemId() );
+                }
             } else {
+                if( internalResolver == null ) {
                 refFeature = new FeatureReference( idContext, href, xmlStream.getSystemId() );
+                } else {
+                    refFeature = new FeatureReference( idContext, internalResolver, href, xmlStream.getSystemId() );
+                }
             }
             idContext.addReference( refFeature );
             List<TypedObjectNode> values = new ArrayList<TypedObjectNode>();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/reference/FeatureReference.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/reference/FeatureReference.java
@@ -40,7 +40,9 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
+import org.deegree.commons.tom.ReferenceResolvingException;
 import org.deegree.commons.tom.TypedObjectNode;
+import org.deegree.commons.tom.gml.GMLObject;
 import org.deegree.commons.tom.gml.GMLReference;
 import org.deegree.commons.tom.gml.GMLReferenceResolver;
 import org.deegree.commons.tom.gml.property.Property;
@@ -48,6 +50,9 @@ import org.deegree.feature.Feature;
 import org.deegree.feature.property.ExtraProps;
 import org.deegree.feature.types.FeatureType;
 import org.deegree.geometry.Envelope;
+import org.deegree.gml.schema.GMLSchemaInfoSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link GMLReference} that targets a {@link Feature}.
@@ -58,6 +63,10 @@ import org.deegree.geometry.Envelope;
  * @version $Revision$, $Date$
  */
 public class FeatureReference extends GMLReference<Feature> implements Feature {
+
+    private static final Logger LOG = LoggerFactory.getLogger( FeatureReference.class );
+
+    private final GMLReferenceResolver internalResolver;
 
     /**
      * Creates a new {@link FeatureReference} instance.
@@ -70,7 +79,24 @@ public class FeatureReference extends GMLReference<Feature> implements Feature {
      *            base URL for resolving the uri, may be <code>null</code> (no resolving of relative URLs)
      */
     public FeatureReference( GMLReferenceResolver resolver, String uri, String baseURL ) {
+        this( resolver, null, uri, baseURL );
+    }
+
+    /**
+     * Creates a new {@link FeatureReference} instance.
+     *
+     * @param resolver
+     *            used for resolving the reference, must not be <code>null</code>
+     * @param internalResolver
+     *            used for resolving references, may be <code>null</code>
+     * @param uri
+     *            the feature's uri, must not be <code>null</code>
+     * @param baseURL
+     *            base URL for resolving the uri, may be <code>null</code> (no resolving of relative URLs)
+     */
+    public FeatureReference( GMLReferenceResolver resolver, GMLReferenceResolver internalResolver, String uri, String baseURL ) {
         super( resolver, uri, baseURL );
+        this.internalResolver = internalResolver;
     }
 
     @Override
@@ -137,6 +163,19 @@ public class FeatureReference extends GMLReference<Feature> implements Feature {
     @Override
     public void setExtraProperties( ExtraProps extraProps ) {
         getReferencedObject().setExtraProperties( extraProps );
+    }
+
+    @Override
+    public synchronized Feature getReferencedObject()
+                            throws ReferenceResolvingException {
+        try {
+            return super.getReferencedObject();
+        } catch(ReferenceResolvingException e) {
+            GMLObject object = this.internalResolver.getObject( getURI(), getBaseURL() );
+            if ( object != null )
+                LOG.info( "Feature with uri {} could be resolved by the internal resolver.", getURI() );
+            return null;
+        }
     }
 
 }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/reference/FeatureReference.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/reference/FeatureReference.java
@@ -50,7 +50,6 @@ import org.deegree.feature.Feature;
 import org.deegree.feature.property.ExtraProps;
 import org.deegree.feature.types.FeatureType;
 import org.deegree.geometry.Envelope;
-import org.deegree.gml.schema.GMLSchemaInfoSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -170,7 +169,10 @@ public class FeatureReference extends GMLReference<Feature> implements Feature {
                             throws ReferenceResolvingException {
         try {
             return super.getReferencedObject();
-        } catch(ReferenceResolvingException e) {
+        } catch ( ReferenceResolvingException e ) {
+            if ( internalResolver == null ) {
+                throw e;
+            }
             GMLObject object = this.internalResolver.getObject( getURI(), getBaseURL() );
             if ( object != null )
                 LOG.info( "Feature with uri {} could be resolved by the internal resolver.", getURI() );

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
@@ -57,7 +57,7 @@ public class Reference<T extends Object> implements Object {
 
     private T object;
 
-    private ReferenceResolvingException exception;
+    protected ReferenceResolvingException exception;
 
     /**
      * Creates a new {@link Reference} instance.
@@ -104,6 +104,16 @@ public class Reference<T extends Object> implements Object {
      */
     public boolean isResolved() {
         return object != null;
+    }
+
+    /**
+     * Returns whether the reference has been resolved and is an internal reference.
+     *
+     * @return <code>true</code> if the reference is resolved is an internal reference, <code>false</code> if the
+     *         reference has not been resolved or is not internal
+     */
+    public boolean isInternalResolved() {
+        return false;
     }
 
     // TODO can we get rid of this method?

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
@@ -112,6 +112,15 @@ public class Reference<T extends Object> implements Object {
     }
 
     /**
+     * Returns the base URL for resolving the uri.
+     *
+     * @return base URL for resolving the uri, may be <code>null</code> (no resolving of relative URLs)
+     */
+    public String getBaseURL() {
+        return baseURL;
+    }
+
+    /**
      * Sets the referenced object.
      *
      * @param object

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
@@ -348,7 +348,8 @@ public class InsertRowManager {
                 Feature feature = (Feature) getPropValue( value );
                 if ( feature instanceof FeatureReference ) {
                     FeatureReference featureReference = (FeatureReference) feature;
-                    if ( ( featureReference.isLocal() || featureReference.isResolved() ) && featureReference.getReferencedObject() != null ) {
+                    if ( ( featureReference.isLocal() || featureReference.isResolved() )
+                         && !featureReference.isInternalResolved() ) {
                         subFeatureRow = lookupFeatureRow( feature.getId() );
                     }
                     // always use the uri if href is mapped explicitly

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
@@ -347,11 +347,12 @@ public class InsertRowManager {
                 String href = null;
                 Feature feature = (Feature) getPropValue( value );
                 if ( feature instanceof FeatureReference ) {
-                    if ( ( (FeatureReference) feature ).isLocal() || ( (FeatureReference) feature ).isResolved() ) {
+                    FeatureReference featureReference = (FeatureReference) feature;
+                    if ( ( featureReference.isLocal() || featureReference.isResolved() ) && featureReference.getReferencedObject() != null ) {
                         subFeatureRow = lookupFeatureRow( feature.getId() );
                     }
                     // always use the uri if href is mapped explicitly
-                    href = ( (FeatureReference) feature ).getURI();
+                    href = featureReference.getURI();
                     MappingExpression me = ( (FeatureMapping) mapping ).getHrefMapping();
                     if ( !( me instanceof DBField ) ) {
                         LOG.debug( "Skipping feature mapping (href). Not mapped to database column." );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -77,9 +77,11 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.deegree.commons.ows.exception.OWSException;
+import org.deegree.commons.tom.CombinedReferenceResolver;
 import org.deegree.commons.tom.ReferenceResolvingException;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.genericxml.GenericXMLElement;
+import org.deegree.commons.tom.gml.GMLReferenceResolver;
 import org.deegree.commons.tom.gml.property.Property;
 import org.deegree.commons.tom.gml.property.PropertyType;
 import org.deegree.commons.tom.ows.Version;
@@ -98,6 +100,8 @@ import org.deegree.feature.FeatureCollection;
 import org.deegree.feature.GenericFeatureCollection;
 import org.deegree.feature.persistence.FeatureStore;
 import org.deegree.feature.persistence.FeatureStoreException;
+import org.deegree.feature.persistence.FeatureStoreGMLIdResolver;
+import org.deegree.feature.persistence.FeatureStoreGmlIdentifierResolver;
 import org.deegree.feature.persistence.FeatureStoreTransaction;
 import org.deegree.feature.persistence.lock.Lock;
 import org.deegree.feature.persistence.lock.LockManager;
@@ -117,6 +121,7 @@ import org.deegree.gml.GMLStreamReader;
 import org.deegree.gml.GMLVersion;
 import org.deegree.gml.feature.GMLFeatureReader;
 import org.deegree.gml.reference.FeatureReference;
+import org.deegree.gml.reference.GmlDocumentIdContext;
 import org.deegree.protocol.wfs.transaction.ReleaseAction;
 import org.deegree.protocol.wfs.transaction.Transaction;
 import org.deegree.protocol.wfs.transaction.TransactionAction;
@@ -436,6 +441,7 @@ class TransactionHandler {
         // TODO determine correct schema
         AppSchema schema = service.getStores()[0].getSchema();
         GMLStreamReader gmlStream = GMLInputFactory.createGMLStreamReader( inputFormat, xmlStream );
+        gmlStream.setInternalResolver( new FeatureStoreGMLIdResolver( service.getStores()[0] )  );
         gmlStream.setApplicationSchema( schema );
         gmlStream.setDefaultCRS( defaultCRS );
 
@@ -466,7 +472,7 @@ class TransactionHandler {
         }
 
         // resolve local xlink references
-        gmlStream.getIdContext().resolveLocalRefs();
+        // gmlStream.getIdContext().resolveLocalRefs();
 
         return fc;
     }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -473,8 +473,7 @@ class TransactionHandler {
         }
 
         // resolve local xlink references
-        if ( !allowFeatureReferencesToDatastore )
-            gmlStream.getIdContext().resolveLocalRefs();
+        gmlStream.getIdContext().resolveLocalRefs();
 
         return fc;
     }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -256,6 +256,8 @@ public class WebFeatureService extends AbstractOWS {
 
     private boolean enableResponsePaging;
 
+    private boolean allowFeatureReferencesToDatastore = false;
+
     private OWSMetadataProvider mdProvider;
 
     public WebFeatureService( ResourceMetadata<OWS> metadata, Workspace workspace, Object jaxbConfig ) {
@@ -275,6 +277,7 @@ public class WebFeatureService extends AbstractOWS {
         if ( enableTransactions != null ) {
             this.enableTransactions = enableTransactions.isValue();
             this.idGenMode = parseIdGenMode( enableTransactions.getIdGen() );
+            this.allowFeatureReferencesToDatastore = enableTransactions.isAllowFeatureReferencesToDatastore();
         }
         if ( jaxbConfig.isEnableResponseBuffering() != null ) {
             disableBuffering = !jaxbConfig.isEnableResponseBuffering();
@@ -793,7 +796,7 @@ public class WebFeatureService extends AbstractOWS {
                 }
                 checkTransactionsEnabled( requestName );
                 Transaction transaction = TransactionKVPAdapter.parse( kvpParamsUC );
-                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response );
+                new TransactionHandler( this, service, transaction, idGenMode, allowFeatureReferencesToDatastore ).doTransaction( response );
                 break;
             default:
                 throw new RuntimeException( "Internal error: Unhandled request '" + requestName + "'." );
@@ -956,7 +959,7 @@ public class WebFeatureService extends AbstractOWS {
                 checkTransactionsEnabled( requestName );
                 TransactionXmlReader transactionReader = new TransactionXmlReaderFactory().createReader( xmlStream );
                 Transaction transaction = transactionReader.read( xmlStream );
-                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response );
+                new TransactionHandler( this, service, transaction, idGenMode, allowFeatureReferencesToDatastore ).doTransaction( response );
                 break;
             default:
                 throw new RuntimeException( "Internal error: Unhandled request '" + requestName + "'." );
@@ -1123,7 +1126,7 @@ public class WebFeatureService extends AbstractOWS {
                 checkTransactionsEnabled( requestName );
                 TransactionXmlReader transactionReader = new TransactionXmlReaderFactory().createReader( requestVersion );
                 Transaction transaction = transactionReader.read( bodyXmlStream );
-                new TransactionHandler( this, service, transaction, idGenMode ).doTransaction( response );
+                new TransactionHandler( this, service, transaction, idGenMode, allowFeatureReferencesToDatastore ).doTransaction( response );
                 break;
             default:
                 throw new RuntimeException( "Internal error: Unhandled request '" + requestName + "'." );

--- a/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
+++ b/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
@@ -43,6 +43,7 @@
             <simpleContent>
               <extension base="boolean">
                 <attribute name="idGen" type="wfs:IdentifierGenerationOptionType" use="optional" default="GenerateNew" />
+                <attribute name="allowFeatureReferencesToDatastore" type="boolean" use="optional" default="false" />
               </extension>
             </simpleContent>
           </complexType>

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -112,7 +112,7 @@ General options
 Transactions
 ^^^^^^^^^^^^
 
-By default, WFS-T requests will be rejected. Setting the ``EnableTransactions`` option to ``true`` will enable transaction support. This option has the optional attribute ``idGenMode`` which controls how ids of inserted features (the values in the gml:id attribute) are treated. There are three id generation modes available:
+By default, WFS-T requests will be rejected. Setting the ``EnableTransactions`` option to ``true`` will enable transaction support. This option has two optional attributes: ``allowFeatureReferencesToDatastore`` and ``idGenMode``. If ``allowFeatureReferencesToDatastore`` is true it is allowed to insert features with references to already inserted features, default is false. ``idGenMode`` controls how ids of inserted features (the values in the gml:id attribute) are treated. There are three id generation modes available:
 
 * **UseExisting**: The original gml:id values from the input are stored. This may lead to errors if the provided ids are already in use.
 * **GenerateNew** (default): New and unique ids are generated. References in the input GML (xlink:href) that point to a feature with an reassigned id are fixed as well, so reference consistency is maintained.


### PR DESCRIPTION
A new optional attributes can be configured in EnableTransactions element: allowFeatureReferencesToDatastore

If allowFeatureReferencesToDatastore is true it is allowed to insert features with references to already inserted features, default is false.

Solves issue #749.