### PR TITLE
CSW client: capability to send along custom http headers

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
@@ -141,6 +141,13 @@ public class OwsHttpClientImpl implements OwsHttpClient {
 
             query = new URI( sb.toString() );
             HttpGet httpGet = new HttpGet( query );
+
+            if ( headers != null ) {
+                for ( Entry<String, String> entry : headers.entrySet() ) {
+                    httpGet.addHeader( entry.getKey(), entry.getValue() );
+                }
+            }
+
             DefaultHttpClient httpClient = getInitializedHttpClient( endPoint );
             LOG.debug( "Performing GET request: " + query );
             HttpResponse httpResponse = httpClient.execute( httpGet );

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
@@ -166,6 +166,13 @@ public class OwsHttpClientImpl implements OwsHttpClient {
             InputStreamEntity entity = new InputStreamEntity( body.getInputStream(), (long) body.size() );
             entity.setContentType( contentType );
             httpPost.setEntity( entity );
+            
+            if ( headers != null ) {
+                for ( Entry<String, String> entry : headers.entrySet() ) {
+                    httpPost.addHeader( entry.getKey(), entry.getValue() );
+                }
+            }
+            
             HttpResponse httpResponse = httpClient.execute( httpPost );
             response = new OwsHttpResponseImpl( httpResponse, httpClient.getConnectionManager(), endPoint.toString() );
         } catch ( Throwable e ) {

--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/main/java/org/deegree/protocol/csw/client/CSWClient.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/main/java/org/deegree/protocol/csw/client/CSWClient.java
@@ -243,19 +243,27 @@ public class CSWClient extends AbstractOWSClient<CSWCapabilitiesAdapter> {
     }
 
     public MetadataRecord getIsoRecordById( String fileIdentifier )
-
                             throws IOException, OWSExceptionReport, XMLStreamException {
-        return getRecordById( fileIdentifier, "http://www.isotc211.org/2005/gmd" );
+        return getIsoRecordById( fileIdentifier, null );
+    }    
+    
+    public MetadataRecord getIsoRecordById( String fileIdentifier, Map<String, String> headers )
+                            throws IOException, OWSExceptionReport, XMLStreamException {
+        return getRecordById( fileIdentifier, "http://www.isotc211.org/2005/gmd", headers );
     }
 
     public MetadataRecord getRecordById( String fileIdentifier, String schema )
+                            throws IOException, OWSExceptionReport, XMLStreamException {
+        return getRecordById( fileIdentifier, schema, null );
+    }
 
+    public MetadataRecord getRecordById( String fileIdentifier, String schema, Map<String, String> headers )
                             throws IOException, OWSExceptionReport, XMLStreamException {
         URL endPoint = getGetUrl( "GetRecordById" );
 
         Map<String, String> params = getGetRecordByIdKvpParams( fileIdentifier, schema );
 
-        OwsHttpResponse response = httpClient.doGet( endPoint, params, null );
+        OwsHttpResponse response = httpClient.doGet( endPoint, params, headers );
 
         XMLStreamReader xmlStream = response.getAsXMLStream();
         XMLStreamUtils.skipStartDocument( xmlStream );

--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/main/java/org/deegree/protocol/csw/client/CSWClient.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/main/java/org/deegree/protocol/csw/client/CSWClient.java
@@ -185,6 +185,27 @@ public class CSWClient extends AbstractOWSClient<CSWCapabilitiesAdapter> {
         return this.getRecords( getRecords );
     }
 
+    public GetRecordsResponse getIsoRecords( int startPosition, int maxRecords, Filter constraint )
+                            throws XMLProcessingException, IOException, OWSExceptionReport, XMLStreamException {
+        return getIsoRecords( startPosition, maxRecords, constraint, null );
+    }
+    
+    public GetRecordsResponse getIsoRecords( int startPosition, int maxRecords, Filter constraint,
+                                             Map<String, String> headers )
+                            throws XMLProcessingException, IOException, OWSExceptionReport, XMLStreamException {
+        GetRecords getRecords = new GetRecords(
+                new Version( 2, 0, 2 ),
+                startPosition,
+                maxRecords,
+                "application/xml",
+                "http://www.isotc211.org/2005/gmd",
+                Collections.singletonList( new QName(CommonNamespaces.ISOAP10GMDNS, "MD_Metadata", CommonNamespaces.ISOAP10GMD_PREFIX ) ),
+                ResultType.results,
+                ReturnableElement.full,
+                constraint );
+        return this.getRecords( getRecords, headers );
+    }
+
     public GetRecordsResponse getRecords( int startPosition, int maxRecords, String outputFormat, String outputSchema,
                                           List<QName> typeNames, ResultType resultType,
                                           ReturnableElement elementSetName, Filter constraint )
@@ -196,6 +217,11 @@ public class CSWClient extends AbstractOWSClient<CSWCapabilitiesAdapter> {
 
     public GetRecordsResponse getRecords( GetRecords getRecords )
                             throws IOException, XMLProcessingException, OWSExceptionReport, XMLStreamException {
+        return getRecords( getRecords, null );
+    }
+
+    public GetRecordsResponse getRecords( GetRecords getRecords, Map<String, String> headers )
+                            throws IOException, XMLProcessingException, OWSExceptionReport, XMLStreamException {
 
         URL endPoint = getXMLPostUrl();
 
@@ -206,11 +232,10 @@ public class CSWClient extends AbstractOWSClient<CSWCapabilitiesAdapter> {
             xmlWriter.close();
             request.close();
         } catch ( Throwable t ) {
-            throw new RuntimeException( "Error creating XML request: " + getRecords );
+            throw new RuntimeException( "Error creating XML request: " + getRecords, t );
         }
-        OwsHttpResponse response = httpClient.doPost( endPoint, "text/xml", request, null );
+        OwsHttpResponse response = httpClient.doPost( endPoint, "text/xml", request, headers );
         return new GetRecordsResponse( response );
-
     }
 
     public List<MetadataRecord> getRecordById( List<String> fileIdentifiers ) {
@@ -274,7 +299,7 @@ public class CSWClient extends AbstractOWSClient<CSWCapabilitiesAdapter> {
             xmlWriter.close();
             request.close();
         } catch ( Throwable t ) {
-            throw new RuntimeException( "Error insering " + records.size() + " records" );
+            throw new RuntimeException( "Error insering " + records.size() + " records", t );
         }
         OwsHttpResponse response = httpClient.doPost( endPoint, "text/xml", request, null );
         return new TransactionResponse( response );

--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/test/java/org/deegree/protocol/csw/client/CSWClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/test/java/org/deegree/protocol/csw/client/CSWClientTest.java
@@ -1,0 +1,192 @@
+package org.deegree.protocol.csw.client;
+
+import static org.deegree.commons.xml.CommonNamespaces.APISO;
+import static org.deegree.commons.xml.CommonNamespaces.APISO_PREFIX;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+
+import org.deegree.commons.ows.metadata.OperationsMetadata;
+import org.deegree.commons.ows.metadata.ServiceIdentification;
+import org.deegree.commons.ows.metadata.ServiceProvider;
+import org.deegree.commons.ows.metadata.operation.Operation;
+import org.deegree.commons.ows.metadata.party.ContactInfo;
+import org.deegree.commons.ows.metadata.party.ResponsibleParty;
+import org.deegree.commons.tom.primitive.PrimitiveValue;
+import org.deegree.commons.utils.test.TestProperties;
+import org.deegree.filter.Expression;
+import org.deegree.filter.Filter;
+import org.deegree.filter.MatchAction;
+import org.deegree.filter.Operator;
+import org.deegree.filter.OperatorFilter;
+import org.deegree.filter.comparison.PropertyIsLike;
+import org.deegree.filter.expression.Literal;
+import org.deegree.filter.expression.ValueReference;
+import org.deegree.filter.logical.Or;
+import org.deegree.metadata.MetadataRecord;
+import org.deegree.protocol.csw.client.getrecords.GetRecordsResponse;
+import org.deegree.protocol.ows.exception.OWSExceptionReport;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * JUnit class tests the functionality of the CSW client.
+ * You need to set demo_csw_url in $HOME/.deegree-test.properties to a 
+ * CSW server getCapabilities URL for this test to work.
+ * 
+ * @author last edited by: $Author$
+ * 
+ * @version $Revision$, $Date$
+ */
+public class CSWClientTest {
+
+    @Test
+    public void testMetadata() throws OWSExceptionReport, XMLStreamException, IOException {
+
+        String demoCSWURL = TestProperties.getProperty( "demo_csw_url" );
+        Assume.assumeNotNull( demoCSWURL );
+        
+        URL serviceUrl = new URL( demoCSWURL );
+
+        CSWClient client = new CSWClient(serviceUrl);
+        Assert.assertNotNull( client );
+        
+        ServiceIdentification serviceId = client.getIdentification();
+        Assert.assertNotNull( serviceId );
+        Assert.assertEquals( 1 , serviceId.getTitles().size() );
+        Assert.assertNotNull( serviceId.getTitles().get( 0 ).getString() );
+        Assert.assertEquals( 1 , serviceId.getAbstracts().size() );
+        Assert.assertNotNull( serviceId.getAbstracts().get( 0 ).getString() );
+
+        Assert.assertEquals( "CSW" , serviceId.getServiceType().getCode() );
+        Assert.assertEquals( "2.0.2" , serviceId.getServiceTypeVersion().get( 0 ).toString() );
+        
+        ServiceProvider serviceProvider = client.getProvider();
+        Assert.assertNotNull( serviceProvider.getProviderName() );
+        Assert.assertNotNull( serviceProvider.getProviderSite() );
+
+        ResponsibleParty serviceContact = serviceProvider.getServiceContact();
+        Assert.assertNotNull( serviceContact.getIndividualName() );
+        Assert.assertNotNull( serviceContact.getPositionName() );
+
+        ContactInfo contactInfo = serviceContact.getContactInfo();
+        Assert.assertNotNull( contactInfo.getPhone().getVoice().get( 0 ) );
+        Assert.assertNotNull( contactInfo.getPhone().getFacsimile().get( 0 ) );
+        Assert.assertNotNull( contactInfo.getAddress().getDeliveryPoint().get( 0 ) );
+        Assert.assertNotNull( contactInfo.getAddress().getCity() );
+        Assert.assertNotNull( contactInfo.getAddress().getAdministrativeArea() );
+        Assert.assertNotNull( contactInfo.getAddress().getPostalCode() );
+        Assert.assertNotNull( contactInfo.getAddress().getCountry() );
+        Assert.assertNotNull( contactInfo.getAddress().getElectronicMailAddress().get( 0 ) );
+        Assert.assertNotNull( contactInfo.getHoursOfService() );
+        Assert.assertNotNull( contactInfo.getContactInstruction() );
+
+        Assert.assertNotNull( serviceContact.getRole().getCode() );
+        
+        OperationsMetadata opMetadata = client.getOperations();
+        Operation op; 
+        
+        op = opMetadata.getOperation("GetCapabilities"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
+        
+        op = opMetadata.getOperation("DescribeRecord"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
+        
+        op = opMetadata.getOperation("GetRecords"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
+        
+        op = opMetadata.getOperation("GetRecordById"); 
+        Assert.assertNotNull( op.getGetUrls().get( 0 ).toExternalForm() );
+        Assert.assertNotNull( op.getPostUrls().get( 0 ).toExternalForm() );
+
+        op = opMetadata.getOperation("Transaction"); 
+        Assert.assertNotNull(op);
+    }
+    
+    private Operator createPropertyLikeFilter(String propertyPrefix, String propertyName, String namespaceURI, String value) {
+        QName qname = new QName( namespaceURI, propertyName, propertyPrefix );
+        Expression param1 = new ValueReference( qname );
+        Expression param2 = new Literal<PrimitiveValue>( value );
+        Operator rootOperator = new PropertyIsLike( param1, param2, "*", ".", "!", false, MatchAction.ANY );        
+        return rootOperator;
+    }
+    
+    @Test
+    public void testGetIsoRecords() throws OWSExceptionReport, XMLStreamException, IOException {
+
+        String demoCSWURL = TestProperties.getProperty( "demo_csw_url" );
+        Assume.assumeNotNull( demoCSWURL );
+
+        URL serviceUrl = new URL( demoCSWURL );
+
+        CSWClient client = new CSWClient( serviceUrl );
+        Assert.assertNotNull( client );
+        
+        Operator titleFilter1 = createPropertyLikeFilter( APISO_PREFIX, "Title", APISO, "%e%" );       
+        Operator titleFilter2 = createPropertyLikeFilter( APISO_PREFIX, "Title", APISO, "%a%" );       
+        Operator titleFilter = new Or(titleFilter1, titleFilter2);
+        
+        int startPosition = 1;
+        int maxRecords = 20;
+        Filter constraint = new OperatorFilter(titleFilter);        
+        
+        GetRecordsResponse recordsResponse = client.getIsoRecords(startPosition, maxRecords, constraint);
+        Assert.assertNotNull( recordsResponse );        
+        Assert.assertTrue( maxRecords >= recordsResponse.getNumberOfRecordsReturned() );
+        Assert.assertTrue( recordsResponse.getNumberOfRecordsReturned() >= 1 );
+        Assert.assertTrue( recordsResponse.getNumberOfRecordsMatched() >= 1 );
+        
+        int recordsCounter = 0;
+        
+        Iterator<MetadataRecord> iter = recordsResponse.getRecords();
+        while(iter.hasNext()) {
+            MetadataRecord record = iter.next();
+            Assert.assertNotNull(record);
+            
+            System.out.println(String.format("%s * %s * %s * %s * %s",
+                    Arrays.toString(record.getTitle()), 
+                    record.getIdentifier(), record.getLanguage(), record.getModified(), record.getType()));
+
+            Assert.assertNotNull(record.getTitle()[0]);
+            Assert.assertNotNull(record.getAbstract()[0]);
+            Assert.assertNotNull(record.getIdentifier());
+            Assert.assertNotNull(record.getLanguage());
+            Assert.assertNotNull(record.getModified());
+            Assert.assertNotNull(record.getType());
+            
+            recordsCounter++;
+        }
+        
+        Assert.assertTrue(recordsCounter > 0);
+    }
+    
+    @Test
+    public void testHTTPHeaders() throws OWSExceptionReport, XMLStreamException, IOException {
+        String demoCSWURL = TestProperties.getProperty( "demo_csw_url" );
+        Assume.assumeNotNull( demoCSWURL );
+        URL serviceUrl = new URL( demoCSWURL );
+        CSWClient client = new CSWClient( serviceUrl );
+        Assert.assertNotNull( client );
+        
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put( "From", "somebody@somwhere.com" );
+        headers.put( "Warning", "199 Miscellaneous warning" );
+
+        GetRecordsResponse recordsResponse = client.getIsoRecords(1, 10, null, headers);
+        Assert.assertNotNull( recordsResponse );        
+        Assert.assertTrue( 10 >= recordsResponse.getNumberOfRecordsReturned() );
+        Assert.assertTrue( recordsResponse.getNumberOfRecordsReturned() >= 1 );
+        Assert.assertTrue( recordsResponse.getNumberOfRecordsMatched() >= 1 );
+    }
+}

--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/test/java/org/deegree/protocol/csw/client/CSWClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/src/test/java/org/deegree/protocol/csw/client/CSWClientTest.java
@@ -183,10 +183,15 @@ public class CSWClientTest {
         headers.put( "From", "somebody@somwhere.com" );
         headers.put( "Warning", "199 Miscellaneous warning" );
 
-        GetRecordsResponse recordsResponse = client.getIsoRecords(1, 10, null, headers);
-        Assert.assertNotNull( recordsResponse );        
+        GetRecordsResponse recordsResponse = client.getIsoRecords( 1, 10, null, headers );
+        Assert.assertNotNull( recordsResponse );
         Assert.assertTrue( 10 >= recordsResponse.getNumberOfRecordsReturned() );
         Assert.assertTrue( recordsResponse.getNumberOfRecordsReturned() >= 1 );
         Assert.assertTrue( recordsResponse.getNumberOfRecordsMatched() >= 1 );
+
+        String recordId = recordsResponse.getRecords().next().getIdentifier();
+        MetadataRecord singleRecord = client.getIsoRecordById( recordId, headers );
+        Assert.assertNotNull( singleRecord );
+        Assert.assertEquals( recordId, singleRecord.getIdentifier() );      
     }
 }


### PR DESCRIPTION
This enhancement adds the possibility to send custom HTTP headers along with the CSW client's GetRecords and GetRecordsById requests.