### PR TITLE
Fixed example of the recode function

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/renderstyles.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/renderstyles.rst
@@ -887,7 +887,9 @@ For Interpolate only linear interpolation is currently supported.
 .. code-block:: xml
 
     <Recode xmlns:app="http://www.deegree.org/app" xmlns="http://www.opengis.net/se" fallbackValue="">
-      <LookupValue>app:code</LookupValue>
+      <LookupValue>
+	<ogc:PropertyName>app:code</ogc:PropertyName>
+      </LookupValue>
       <MapItem>
         <Data>1000</Data>
         <Value>water</Value>


### PR DESCRIPTION
The recode function in the deegree -webservices-handbook does not work as documented in the example. The example was fixed.