### PR TITLE
Fixed XSLT transformation in GetFeatureInfo request if GML contains a xsi:nil property 

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -427,7 +427,12 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
             if ( property.getAttributes() != null ) {
                 for ( Entry<QName, PrimitiveValue> attr : property.getAttributes().entrySet() ) {
-                    writeAttribute( writer, attr.getKey(), attr.getValue().getAsText() );
+                    QName attrKey = attr.getKey();
+                    PrimitiveValue attrValue = attr.getValue();
+                    if ( XSI_NIL.equals( attrKey ) )
+                        writeAttributeWithNS( attrKey.getNamespaceURI(), attrKey.getLocalPart(), attrValue.getAsText() );
+                    else
+                        writeAttribute( writer, attrKey, attrValue.getAsText() );
                 }
             }
             if ( property.getChildren() != null ) {


### PR DESCRIPTION
Fix for #781.
The exception occurred cause of a missing namespace of the attribute `xsi:nil`. This is fixed by a adding special handling of `xsi:nil`and writing the attribute with namespace. 
