### PR TITLE
Enhance SQLFeatureStoreConfigWriter to differentiate between feature and xlink:href mapping 

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
@@ -287,11 +287,8 @@ public class SQLFeatureStoreConfigWriter {
             }
             CompoundMapping compound = (CompoundMapping) particle;
             for ( Mapping childMapping : compound.getParticles() ) {
-                if ( propertiesWithPrimitiveHref != null
-                     && propertiesWithPrimitiveHref.contains( compound.getPath().getAsQName() ) )
-                    writeMapping( writer, childMapping, true );
-                else
-                    writeMapping( writer, childMapping, false );
+                boolean isChildHrefPrimitive = isHrefPrimitive( compound );
+                writeMapping( writer, childMapping, isChildHrefPrimitive );
             }
             writer.writeEndElement();
         } else {
@@ -323,4 +320,10 @@ public class SQLFeatureStoreConfigWriter {
         }
         return name.getLocalPart();
     }
+
+    private boolean isHrefPrimitive( CompoundMapping compound ) {
+        return propertiesWithPrimitiveHref != null
+               && propertiesWithPrimitiveHref.contains( compound.getPath().getAsQName() );
+    }
+
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
@@ -263,7 +263,7 @@ public class SQLFeatureStoreConfigWriter {
             FeatureMapping gm = (FeatureMapping) particle;
             if ( gm.getHrefMapping() != null && isHrefPrimitive ) {
                 writer.writeStartElement( CONFIG_NS, "Primitive" );
-                writer.writeAttribute( "path", particle.getPath().getAsText() );
+                writer.writeAttribute( "path", "@xlink:href" );
                 writer.writeAttribute( "mapping", gm.getHrefMapping().toString() );
                 writer.writeEndElement();
             } else {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
@@ -91,6 +91,8 @@ public class SQLFeatureStoreConfigWriter {
 
     private final MappedAppSchema schema;
 
+    private final List<QName> propertiesWithPrimitiveHref;
+
     /**
      * Creates a new {@link SQLFeatureStoreConfigWriter} instance.
      * 
@@ -98,7 +100,21 @@ public class SQLFeatureStoreConfigWriter {
      *            the mapped application schema to export, must not be <code>null</code>
      */
     public SQLFeatureStoreConfigWriter( MappedAppSchema schema ) {
+        this( schema, null );
+    }
+
+    /**
+     * Creates a new {@link SQLFeatureStoreConfigWriter} instance.
+     *
+     * @param schema
+     *            the mapped application schema to export, must not be <code>null</code>
+     * @param propertiesWithPrimitiveHref
+     *            list of properties which are written with primitive instead of feature mapping, is applied to all
+     *            properties of type {@link FeatureMapping}, may be <code>null</code>
+     */
+    public SQLFeatureStoreConfigWriter( MappedAppSchema schema, List<QName> propertiesWithPrimitiveHref ) {
         this.schema = schema;
+        this.propertiesWithPrimitiveHref = propertiesWithPrimitiveHref;
     }
 
     /**
@@ -211,13 +227,13 @@ public class SQLFeatureStoreConfigWriter {
         writer.writeEndElement();
 
         for ( Mapping particle : ftMapping.getMappings() ) {
-            writeMapping( writer, particle );
+            writeMapping( writer, particle, false );
         }
 
         writer.writeEndElement();
     }
 
-    private void writeMapping( XMLStreamWriter writer, Mapping particle )
+    private void writeMapping( XMLStreamWriter writer, Mapping particle, boolean isHrefPrimitive )
                             throws XMLStreamException {
 
         if ( particle instanceof PrimitiveMapping ) {
@@ -245,17 +261,24 @@ public class SQLFeatureStoreConfigWriter {
             writer.writeEndElement();
         } else if ( particle instanceof FeatureMapping ) {
             FeatureMapping gm = (FeatureMapping) particle;
-            writer.writeStartElement( CONFIG_NS, "Feature" );
-            writer.writeAttribute( "path", particle.getPath().getAsText() );
-            if ( particle.getJoinedTable() != null && !particle.getJoinedTable().isEmpty() ) {
-                writeJoinedTable( writer, particle.getJoinedTable().get( 0 ) );
-            }
-            if ( gm.getHrefMapping() != null ) {
-                writer.writeStartElement( CONFIG_NS, "Href" );
+            if ( gm.getHrefMapping() != null && isHrefPrimitive ) {
+                writer.writeStartElement( CONFIG_NS, "Primitive" );
+                writer.writeAttribute( "path", particle.getPath().getAsText() );
                 writer.writeAttribute( "mapping", gm.getHrefMapping().toString() );
                 writer.writeEndElement();
+            } else {
+                writer.writeStartElement( CONFIG_NS, "Feature" );
+                writer.writeAttribute( "path", particle.getPath().getAsText() );
+                if ( particle.getJoinedTable() != null && !particle.getJoinedTable().isEmpty() ) {
+                    writeJoinedTable( writer, particle.getJoinedTable().get( 0 ) );
+                }
+                if ( gm.getHrefMapping() != null ) {
+                    writer.writeStartElement( CONFIG_NS, "Href" );
+                    writer.writeAttribute( "mapping", gm.getHrefMapping().toString() );
+                    writer.writeEndElement();
+                }
+                writer.writeEndElement();
             }
-            writer.writeEndElement();
         } else if ( particle instanceof CompoundMapping ) {
             writer.writeStartElement( CONFIG_NS, "Complex" );
             writer.writeAttribute( "path", particle.getPath().getAsText() );
@@ -264,7 +287,11 @@ public class SQLFeatureStoreConfigWriter {
             }
             CompoundMapping compound = (CompoundMapping) particle;
             for ( Mapping childMapping : compound.getParticles() ) {
-                writeMapping( writer, childMapping );
+                if ( propertiesWithPrimitiveHref != null
+                     && propertiesWithPrimitiveHref.contains( compound.getPath().getAsQName() ) )
+                    writeMapping( writer, childMapping, true );
+                else
+                    writeMapping( writer, childMapping, false );
             }
             writer.writeEndElement();
         } else {

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/featurestores.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/featurestores.rst
@@ -571,6 +571,8 @@ In order to successfully create a mapping for a feature type from a GML applicat
 .. hint::
    The deegree project aims for a user-interface to help with all steps of creating mapping configurations. If you are interested in working on this (or funding it), don't hesitate to contact the project bodies.
 
+.. _anchor-mapping-rich-feature-types:
+
 """"""""""""""""""""""""""
 Mapping rich feature types
 """"""""""""""""""""""""""
@@ -686,6 +688,38 @@ Here is an overview on all options for ``<Feature>`` elements:
 +-----------------------+-------------+---------+------------------------------------------------------------------------------+
 | ``<Href>``            | 0..1        | Complex | Defines the column that stores the value for ``xlink:href``                  |
 +-----------------------+-------------+---------+------------------------------------------------------------------------------+
+
+.. _anchor-mapping-strategies-href-attributes:
+
+""""""""""""""""""""""""""""""""""""""""""""
+Mapping strategies for xlink:href attributes
+""""""""""""""""""""""""""""""""""""""""""""
+
+There are two different use cases when xlink:href attributes are used:
+
+* 1. Reference on other feature.
+* 2. xlink:href value is used as static value. For example, if a user wants to filter on INSPIRE codelists, filtering is executed on the value of xlink:href.
+
+Case 1. does not allow filtering on the value of xlink:href itself. Case 2. allows filtering on the static value of the xlink:href attribute but the linked feature is not resolved anymore.
+
+Those two cases can be realized by different mappings in SQL feature store configuration:
+
+* 1. Feature mapping is used:
+
+.. code-block:: xml
+
+    <Feature path=".">
+      <Join table="?" fromColumns="designationtype_designation_fk" toColumns="id"/>
+      <Href mapping="designationtype_designation_href"/>
+    </Feature>
+
+* 2. Primitive mapping is used:
+
+.. code-block:: xml
+
+    <Primitive path="@xlink:href" mapping="designationtype_designation_href"/>
+
+For more details see chapter :ref:`anchor-mapping-rich-feature-types`.
 
 """"""""""""""""""""""""""
 Changing the table context

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
@@ -220,6 +220,35 @@ filter operator handles it. In the concrete case this means a normalization of t
 
 .. tip:: Please note, the use of functions within PropertyIsLike filter operators is only possible with FE 2.0. This is the reason for the FE 2.0 notation.
 
+___________________________________________
+Filter expressions on xlink:href attributes
+___________________________________________
+
+There are two different use cases when xlink:href attributes are used in filter expressions:
+
+* 1. Reference on other feature.
+* 2. xlink:href value is used as static value. For example, if a user wants to filter on INSPIRE codelists, filtering is executed on the value of xlink:href.
+
+Case 1. does not allow filtering on the xlink:href value itself. Case 2. allows filtering on the static value of the xlink:href attribute but the linked feature is not resolved anymore.
+
+Those two cases can be realized by different mappings in SQL feature store configuration:
+
+* 1. Feature mapping is used:
+
+.. code-block:: xml
+
+    <Feature path=".">
+      <Join table="?" fromColumns="designationtype_designation_fk" toColumns="id"/>
+      <Href mapping="designationtype_designation_href"/>
+    </Feature>
+
+* 2. Primitive mapping is used:
+
+.. code-block:: xml
+
+    <Primitive path="@xlink:href" mapping="designationtype_designation_href"/>
+
+For more details see chapter :ref:`anchor-configuration-sqlfeaturestore`.
 
 ^^^^^^^^^^^^^^^^^^^
 Custom FE functions

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
@@ -224,7 +224,18 @@ ___________________________________________
 Filter expressions on xlink:href attributes
 ___________________________________________
 
-Filter expressions which filter on the static value of a xlink:href attribute itself just work if the feature store is configured a certain way. For example, this can be useful if a user wants to filter on INSPIRE codelists.
+Example for filtering on xlink:href attributes:
+
+.. code-block:: xml
+
+    <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <fes:PropertyIsEqualTo>
+        <fes:PropertyName>property/@xlink:href</fes:PropertyName>
+        <fes:Literal>100</fes:Literal>
+      </fes:PropertyIsEqualTo>
+    </fes:Filter>
+
+deegree applies the filter to the static value of the attribute. This just work if the feature store is configured a certain way. For example, this can be useful if a user wants to filter on INSPIRE codelists.
 
 Chapter :ref:`anchor-mapping-strategies-href-attributes` describes how the configuration of the feature store is done and provides further details regarding usage.
 

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
@@ -224,31 +224,9 @@ ___________________________________________
 Filter expressions on xlink:href attributes
 ___________________________________________
 
-There are two different use cases when xlink:href attributes are used in filter expressions:
+Filter expressions which filter on the static value of a xlink:href attribute itself just work if the feature store is configured a certain way. For example, this can be useful if a user wants to filter on INSPIRE codelists.
 
-* 1. Reference on other feature.
-* 2. xlink:href value is used as static value. For example, if a user wants to filter on INSPIRE codelists, filtering is executed on the value of xlink:href.
-
-Case 1. does not allow filtering on the xlink:href value itself. Case 2. allows filtering on the static value of the xlink:href attribute but the linked feature is not resolved anymore.
-
-Those two cases can be realized by different mappings in SQL feature store configuration:
-
-* 1. Feature mapping is used:
-
-.. code-block:: xml
-
-    <Feature path=".">
-      <Join table="?" fromColumns="designationtype_designation_fk" toColumns="id"/>
-      <Href mapping="designationtype_designation_href"/>
-    </Feature>
-
-* 2. Primitive mapping is used:
-
-.. code-block:: xml
-
-    <Primitive path="@xlink:href" mapping="designationtype_designation_href"/>
-
-For more details see chapter :ref:`anchor-configuration-sqlfeaturestore`.
+Chapter :ref:`anchor-mapping-strategies-href-attributes` describes how the configuration of the feature store is done and provides further details regarding usage.
 
 ^^^^^^^^^^^^^^^^^^^
 Custom FE functions

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/filterencoding.rst
@@ -235,7 +235,7 @@ Example for filtering on xlink:href attributes:
       </fes:PropertyIsEqualTo>
     </fes:Filter>
 
-deegree applies the filter to the static value of the attribute. This just work if the feature store is configured a certain way. For example, this can be useful if a user wants to filter on INSPIRE codelists.
+deegree applies the filter to the static value of the attribute. This just works if the feature store is configured a certain way. For example, this can be useful if a user wants to filter on INSPIRE codelists.
 
 Chapter :ref:`anchor-mapping-strategies-href-attributes` describes how the configuration of the feature store is done and provides further details regarding usage.
 


### PR DESCRIPTION
This enhancement allows to pass a list of properties to handle as primitive xlink:href mappings instead of feature mappings.
Furthermore the documentation was improved to explain the difference between xlink:href and feature mapping against the background of fiitering on xlink:href attributes.