### PR TITLE
Fix MappingContextManager to evaluate maxLength correctly

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
@@ -113,12 +113,15 @@ class MappingContextManager {
             id = prefix + "_" + name;
         }
         if ( id.length() >= maxColumnLengthInChararacters ) {
-            String suffix = "_" + ( this.id++ );
+            String idAsString = Integer.toString( this.id++ );
+            String suffix = "_" + idAsString;
             int delta = id.length() - maxColumnLengthInChararacters;
             int substringUntilPos = id.length() - delta - suffix.length();
-            if ( substringUntilPos > 0 ) {
+            if ( substringUntilPos >= 0 ) {
                 String substring = id.substring( 0, substringUntilPos );
                 id = substring + suffix;
+            } else if ( maxColumnLengthInChararacters == idAsString.length() ) {
+                id = idAsString;
             } else {
                 id = UUID.randomUUID().toString().substring( 0, maxColumnLengthInChararacters );
             }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
@@ -72,7 +72,7 @@ class MappingContextManager {
      * @param maxColumnLengthInChararacters
      *            max length of column names in characters. If -1 the default value (64) is used.
      * @param usePrefix
-     *            <code>null</code> if the column name should contain the xml prefix, <code>false</code> otherwise
+     *            <code>true</code> if the column name should contain the xml prefix, <code>false</code> otherwise
      */
     MappingContextManager( Map<String, String> nsToPrefix, int maxColumnLengthInChararacters, boolean usePrefix ) {
         this.nsToPrefix = nsToPrefix;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
@@ -54,7 +54,7 @@ class MappingContextManager {
 
     private static Logger LOG = LoggerFactory.getLogger( MappingContextManager.class );
 
-    private int maxLength;
+    private int maxColumnLengthInChararacters;
 
     private int id = 0;
 
@@ -64,9 +64,18 @@ class MappingContextManager {
 
     private final boolean usePrefix;
 
-    MappingContextManager( Map<String, String> nsToPrefix, int maxLength, boolean usePrefix ) {
+    /**
+     * @param nsToPrefix
+     *            contains the mapping of namespaces to prefixes to create column names, may be empty but never
+     *            <code>null</code>
+     * @param maxColumnLengthInChararacters
+     *            max length of column names in characters. If -1 the default value (64) is used.
+     * @param usePrefix
+     *            <code>null</code> if the column name should contain the xml prefix, <code>false</code> otherwise
+     */
+    MappingContextManager( Map<String, String> nsToPrefix, int maxColumnLengthInChararacters, boolean usePrefix ) {
         this.nsToPrefix = nsToPrefix;
-        this.maxLength = maxLength == -1 ? 64 : maxLength;
+        this.maxColumnLengthInChararacters = maxColumnLengthInChararacters == -1 ? 64 : maxColumnLengthInChararacters;
         this.usePrefix = usePrefix;
     }
 
@@ -102,8 +111,8 @@ class MappingContextManager {
         if ( !prefix.isEmpty() ) {
             id = prefix + "_" + name;
         }
-        if ( id.length() >= maxLength ) {
-            String substring = id.substring( 0, maxLength - 6 );
+        if ( id.length() >= maxColumnLengthInChararacters ) {
+            String substring = id.substring( 0, maxColumnLengthInChararacters - 6 );
             id = substring + "_" + ( this.id++ );
         }
         return id;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
@@ -36,6 +36,7 @@
 package org.deegree.feature.persistence.sql.mapper;
 
 import java.util.Map;
+import java.util.UUID;
 
 import javax.xml.namespace.QName;
 
@@ -112,8 +113,15 @@ class MappingContextManager {
             id = prefix + "_" + name;
         }
         if ( id.length() >= maxColumnLengthInChararacters ) {
-            String substring = id.substring( 0, maxColumnLengthInChararacters - 6 );
-            id = substring + "_" + ( this.id++ );
+            String suffix = "_" + ( this.id++ );
+            int delta = id.length() - maxColumnLengthInChararacters;
+            int substringUntilPos = id.length() - delta - suffix.length();
+            if ( substringUntilPos > 0 ) {
+                String substring = id.substring( 0, substringUntilPos );
+                id = substring + suffix;
+            } else {
+                id = UUID.randomUUID().toString().substring( 0, maxColumnLengthInChararacters );
+            }
         }
         return id;
     }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/MappingContextManagerTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/MappingContextManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 public class MappingContextManagerTest {
 
     @Test
-    public void columnLength()
+    public void columnName_InLength()
                             throws Exception {
         MappingContextManager mappingContextManager = new MappingContextManager(
                                                                                  Collections.<String, String> emptyMap(),
@@ -27,22 +27,60 @@ public class MappingContextManagerTest {
 
         MappingContext shortName = mappingContextManager.mapOneToOneElement( parent, new QName( "sn" ) );
         assertThat( shortName.getColumn(), is( "parent_sn" ) );
+    }
+
+    @Test
+    public void columnName_NotInLength_1()
+                            throws Exception {
+        MappingContextManager mappingContextManager = new MappingContextManager(
+                                                                                 Collections.<String, String> emptyMap(),
+                                                                                 10, false );
+        MappingContext mappingContext = mappingContextManager.newContext( new QName( "first" ), "id" );
+        MappingContext parent = mappingContextManager.mapOneToOneElement( mappingContext, new QName( "parent" ) );
+
         createMappings( mappingContextManager, parent, "100" );
 
         MappingContext columnLongerWithSmallId = mappingContextManager.mapOneToOneElement( parent, new QName( "longer" ) );
         // parent_longer, last id = 100
         assertThat( columnLongerWithSmallId.getColumn().length(), is( 10 ) );
         assertThat( columnLongerWithSmallId.getColumn(), is( "parent_101" ) );
+    }
+
+    @Test
+    public void columnName_NotInLength_2()
+                            throws Exception {
+        MappingContextManager mappingContextManager = new MappingContextManager(
+                                                                                 Collections.<String, String> emptyMap(),
+                                                                                 10, false );
+        MappingContext mappingContext = mappingContextManager.newContext( new QName( "first" ), "id" );
+        MappingContext parent = mappingContextManager.mapOneToOneElement( mappingContext, new QName( "parent" ) );
 
         createMappings( mappingContextManager, parent, "1000000" );
-        // parent_longer, last id = 1000000
+
         MappingContext columnLongerWithLargeId = mappingContextManager.mapOneToOneElement( parent, new QName( "longer" ) );
+        // parent_longer, last id = 1000000
         assertThat( columnLongerWithLargeId.getColumn().length(), is( 10 ) );
         assertThat( columnLongerWithLargeId.getColumn(), is( "pa_1000001" ) );
     }
 
     @Test
-    public void columnLengthVerySmall() {
+    public void columnName_LengthExactlyTheId()
+                            throws Exception {
+        MappingContextManager mappingContextManager = new MappingContextManager(
+                                                                                 Collections.<String, String> emptyMap(),
+                                                                                 3, false );
+        MappingContext mappingContext = mappingContextManager.newContext( new QName( "first" ), "id" );
+        MappingContext parent = mappingContextManager.mapOneToOneElement( mappingContext, new QName( "parent" ) );
+
+        createMappings( mappingContextManager, parent, "99" );
+        // parent_longer, last id = 100
+        MappingContext columnLongerWithLargeId = mappingContextManager.mapOneToOneElement( parent, new QName( "longer" ) );
+        assertThat( columnLongerWithLargeId.getColumn().length(), is( 3 ) );
+        assertThat( columnLongerWithLargeId.getColumn(), is( "100" ) );
+    }
+
+    @Test
+    public void columnName_MaxVerySmall() {
         MappingContextManager mappingContextManager = new MappingContextManager(
                                                                                  Collections.<String, String> emptyMap(),
                                                                                  1, false );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/MappingContextManagerTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/MappingContextManagerTest.java
@@ -1,0 +1,66 @@
+package org.deegree.feature.persistence.sql.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class MappingContextManagerTest {
+
+    @Test
+    public void columnLength()
+                            throws Exception {
+        MappingContextManager mappingContextManager = new MappingContextManager(
+                                                                                 Collections.<String, String> emptyMap(),
+                                                                                 10, false );
+        MappingContext mappingContext = mappingContextManager.newContext( new QName( "first" ), "id" );
+
+        MappingContext parent = mappingContextManager.mapOneToOneElement( mappingContext, new QName( "parent" ) );
+        assertThat( parent.getColumn(), is( "parent" ) );
+
+        MappingContext shortName = mappingContextManager.mapOneToOneElement( parent, new QName( "sn" ) );
+        assertThat( shortName.getColumn(), is( "parent_sn" ) );
+        createMappings( mappingContextManager, parent, "100" );
+
+        MappingContext columnLongerWithSmallId = mappingContextManager.mapOneToOneElement( parent, new QName( "longer" ) );
+        // parent_longer, last id = 100
+        assertThat( columnLongerWithSmallId.getColumn().length(), is( 10 ) );
+        assertThat( columnLongerWithSmallId.getColumn(), is( "parent_101" ) );
+
+        createMappings( mappingContextManager, parent, "1000000" );
+        // parent_longer, last id = 1000000
+        MappingContext columnLongerWithLargeId = mappingContextManager.mapOneToOneElement( parent, new QName( "longer" ) );
+        assertThat( columnLongerWithLargeId.getColumn().length(), is( 10 ) );
+        assertThat( columnLongerWithLargeId.getColumn(), is( "pa_1000001" ) );
+    }
+
+    @Test
+    public void columnLengthVerySmall() {
+        MappingContextManager mappingContextManager = new MappingContextManager(
+                                                                                 Collections.<String, String> emptyMap(),
+                                                                                 1, false );
+        MappingContext mappingContext = mappingContextManager.newContext( new QName( "first" ), "id" );
+
+        createMappings( mappingContextManager, mappingContext, "9" );
+        MappingContext first = mappingContextManager.mapOneToOneElement( mappingContext, new QName( "first" ) );
+        assertThat( first.getColumn().length(), is( 1 ) );
+    }
+
+    private void createMappings( MappingContextManager mappingContextManager, MappingContext mappingContext,
+                                 String idOfLastMapping ) {
+        int indexOfMapping = 1;
+        MappingContext newMappingContext;
+        do {
+            newMappingContext = mappingContextManager.mapOneToOneElement( mappingContext,
+                                                                          new QName( "map" + indexOfMapping++ ) );
+        } while ( !newMappingContext.getColumn().endsWith( idOfLastMapping ) );
+    }
+
+}


### PR DESCRIPTION
Previously, the maxLength set in MappingContextManager was not evaluated correctly leading to column names exceeding the length set by this parameter.
Issue was reported in https://github.com/deegree/deegree3/issues/827.

This fix enables that the column names are always truncated to the length specified by maxLength.