### PR TITLE
Fixing wps client bug: LiteralInputs don't have to have a DataType specified

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessDetails.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessDetails.java
@@ -310,10 +310,13 @@ public class ProcessDetails {
 
     private LiteralInputType parseLiteralData( OMElement input, CodeType id, LanguageString inputTitle,
                                                LanguageString inputAbstract, String minOccurs, String maxOccurs ) {
+        ValueWithRef dataType = null;
         OMElement omDataType = input.getFirstChildWithName( new QName( owsNS, "DataType" ) );
-        String dataTypeStr = omDataType.getText();
-        String dataTypeRefStr = omDataType.getAttributeValue( new QName( owsNS, "reference" ) );
-        ValueWithRef dataType = new ValueWithRef( dataTypeStr, dataTypeRefStr );
+        if(omDataType != null) {
+            String dataTypeStr = omDataType.getText();
+            String dataTypeRefStr = omDataType.getAttributeValue( new QName( owsNS, "reference" ) );
+            dataType = new ValueWithRef( dataTypeStr, dataTypeRefStr );
+        }
 
         XPath xpath = new XPath( "UOMs/Default/ows:UOM", nsContext );
         OMElement omDefaultUom = omResponse.getElement( input, xpath );


### PR DESCRIPTION
A WPS LiteralInput doesn't have to have a DataType specified, it's optional (see WPS 1.0.0 standard, Table 25, page 26). Until now, the deegree WPS client just assumes that the DataType is always specified, causing an exception if that's not the case.

This change fixes the bug.