### PR TITLE
Bugfix for #848: Ensure unambigous results when determining feature type from id

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/ArrayUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/ArrayUtils.java
@@ -38,11 +38,7 @@ package org.deegree.commons.utils;
 import static java.lang.Double.parseDouble;
 import static java.lang.Float.parseFloat;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.StringTokenizer;
+import java.util.*;
 
 /**
  * This is a collection of some methods that work with arrays and lists, like join or removeAll. It is complementary to
@@ -339,4 +335,19 @@ public class ArrayUtils {
         return fs;
     }
 
+    /**
+     * Sorts all strings by length, descending
+     *
+     * @param strings array of non-null strings, but strings can be empty
+     */
+    public static void sortByLengthDescending( String[] strings ) {
+        Arrays.sort( strings, new Comparator<String>() {
+            @Override
+            public int compare( String o1, String o2 ) {
+                int len1 = o1.length();
+                int len2 = o2.length();
+                return ( len1 > len2 ? -1 : ( len1 == len2 ? 0 : 1 ) );
+            }
+        } );
+    }
 }

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/utils/ArrayUtilsTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/utils/ArrayUtilsTest.java
@@ -35,29 +35,26 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.commons.utils;
 
-import static org.deegree.commons.utils.ArrayUtils.join;
-import static org.deegree.commons.utils.ArrayUtils.removeAll;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
+import static org.deegree.commons.utils.ArrayUtils.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
- * 
- * 
  * @author <a href="mailto:tonnhofer@lat-lon.de">Oliver Tonnhofer</a>
  * @author last edited by: $Author$
- * 
  * @version $Revision$, $Date$
- * 
  */
-public class ArrayToolsTest {
+public class ArrayUtilsTest {
 
     /**
-     * Test method for {@link org.deegree.commons.utils.ArrayUtils#join(String delimiter, String... strings )}.
+     * Test method for {@link org.deegree.commons.utils.ArrayUtils#join(String delimiter, String... strings)}.
      */
     @Test
     public void testJoin() {
@@ -68,7 +65,7 @@ public class ArrayToolsTest {
     }
 
     /**
-     * Test method for {@link org.deegree.commons.utils.ArrayUtils#join(String, List)}.
+     * Test method for {@link org.deegree.commons.utils.ArrayUtils#join(String, Collection)}.
      */
     @Test
     public void testJoinList() {
@@ -85,7 +82,7 @@ public class ArrayToolsTest {
     }
 
     /**
-     * Test method for {@link org.deegree.commons.utils.ArrayUtils#join(String delimiter, int[] values )}.
+     * Test method for {@link org.deegree.commons.utils.ArrayUtils#join(String delimiter, int[] values)}.
      */
     @Test
     public void testjoinInts() {
@@ -113,5 +110,13 @@ public class ArrayToolsTest {
         for ( int i = 0; i < expected.length; i++ ) {
             assertEquals( expected[i], actual[i] );
         }
+    }
+
+    @Test
+    public void sortStringsByLength() throws Exception {
+        String[] strings = { "a", "ccc", "bb" };
+        sortByLengthDescending( strings );
+
+        assertArrayEquals( strings, new String[] { "ccc", "bb", "a" } );
     }
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/IdAnalyzer.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/IdAnalyzer.java
@@ -59,6 +59,9 @@ public class IdAnalyzer {
 
     private final Map<String, FeatureType> prefixToFt = new HashMap<String, FeatureType>();
 
+    // this is used to match ids, so the best match (with the longest identical prefix) is found first
+    private final String [] prefixKeysSortedByLengthDesc;
+
     private final MappedAppSchema schema;
 
     /**
@@ -80,6 +83,8 @@ public class IdAnalyzer {
                 }
             }
         }
+        prefixKeysSortedByLengthDesc = prefixToFt.keySet().toArray( new String[0] );
+        sortByLengthDescending( prefixKeysSortedByLengthDesc );
     }
 
     /**
@@ -95,9 +100,7 @@ public class IdAnalyzer {
     }
 
     private FeatureType getFeatureType( String featureOrGeomId ) {
-        String[] prefixKeys = prefixToFt.keySet().toArray( new String[0] );
-        sortByLengthDescending( prefixKeys );
-        for ( String prefix : prefixKeys ) {
+        for ( String prefix : prefixKeysSortedByLengthDesc ) {
             if ( featureOrGeomId.startsWith( prefix ) ) {
                 return prefixToFt.get( prefix );
             }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/IdAnalyzer.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/IdAnalyzer.java
@@ -41,10 +41,10 @@ import org.deegree.feature.types.FeatureType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.deegree.commons.utils.ArrayUtils.sortByLengthDescending;
 
 /**
  * Helper class for analyzing if a given feature or geometry id can be attributed to a certain feature type.
@@ -96,7 +96,7 @@ public class IdAnalyzer {
 
     private FeatureType getFeatureType( String featureOrGeomId ) {
         String[] prefixKeys = prefixToFt.keySet().toArray( new String[0] );
-        orderByLengthDescending( prefixKeys );
+        sortByLengthDescending( prefixKeys );
         for ( String prefix : prefixKeys ) {
             if ( featureOrGeomId.startsWith( prefix ) ) {
                 return prefixToFt.get( prefix );
@@ -120,14 +120,4 @@ public class IdAnalyzer {
         throw new IllegalArgumentException( errorMsg.toString() );
     }
 
-    public static void orderByLengthDescending( String[] strings ) {
-        Arrays.sort( strings, new Comparator<String>() {
-            @Override
-            public int compare( String o1, String o2 ) {
-                int len1 = o1.length();
-                int len2 = o2.length();
-                return ( len1 > len2 ? -1 : ( len1 == len2 ? 0 : 1 ) );
-            }
-        } );
-    }
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/id/IdAnalyzerTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/id/IdAnalyzerTest.java
@@ -1,0 +1,105 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree
+ Copyright (C) 2001-2017 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit GmbH -
+ and others
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ e-mail: info@deegree.org
+ website: http://www.deegree.org/
+----------------------------------------------------------------------------*/
+package org.deegree.feature.persistence.sql.id;
+
+import org.deegree.commons.jdbc.SQLIdentifier;
+import org.deegree.commons.jdbc.TableName;
+import org.deegree.commons.tom.gml.GMLObjectType;
+import org.deegree.commons.tom.gml.property.PropertyType;
+import org.deegree.commons.tom.primitive.BaseType;
+import org.deegree.commons.utils.Pair;
+import org.deegree.feature.persistence.sql.FeatureTypeMapping;
+import org.deegree.feature.persistence.sql.MappedAppSchema;
+import org.deegree.feature.persistence.sql.rules.Mapping;
+import org.deegree.feature.types.FeatureType;
+import org.deegree.feature.types.GenericFeatureType;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.xml.namespace.QName;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class IdAnalyzerTest {
+
+    private static final String FEATURE_NAME = "NAME";
+    private static final String PREFIX = "p";
+
+    private IdAnalyzer idAnalyzer;
+
+    @Before
+    public void setUp() throws Exception {
+        idAnalyzer = new IdAnalyzer( createMappedAppSchemaMock() );
+    }
+
+    @Test
+    public void usingSingleLetterPrefixResultsToCorrectFeatureName() throws Exception {
+        IdAnalysis analysis = idAnalyzer.analyze( PREFIX + FEATURE_NAME );
+        assertEquals( analysis.getIdKernels()[0], FEATURE_NAME );
+    }
+
+    @Test
+    public void usingDoubleLetterPrefixResultsToCorrectFeatureName() throws Exception {
+        IdAnalysis analysis = idAnalyzer.analyze( PREFIX + PREFIX + FEATURE_NAME );
+        assertEquals( analysis.getIdKernels()[0], FEATURE_NAME );
+    }
+
+    private MappedAppSchema createMappedAppSchemaMock() {
+        QName featureA = new QName( "A" );
+        QName featureB = new QName( "B" );
+        return new MappedAppSchema(
+                new FeatureType[]{
+                        new GenericFeatureType( featureA, Collections.<PropertyType>emptyList(), false ),
+                        new GenericFeatureType( featureB, Collections.<PropertyType>emptyList(), false )
+                },
+                Collections.<FeatureType, FeatureType>emptyMap(),
+                Collections.<String, String>emptyMap(),
+                null,
+                new FeatureTypeMapping[]{
+                        createFeatureTypeMapping( featureA, PREFIX ),
+                        createFeatureTypeMapping( featureB, ( PREFIX + PREFIX ) )
+                },
+                null,
+                null,
+                null,
+                true,
+                null,
+                Collections.<GMLObjectType>emptyList(),
+                Collections.<GMLObjectType, GMLObjectType>emptyMap()
+        );
+    }
+
+    private FeatureTypeMapping createFeatureTypeMapping( QName featureName, String prefix ) {
+        return new FeatureTypeMapping( featureName,
+                new TableName( "TABLE_" + featureName.getLocalPart() + "_IDENTIFIER" ),
+                new FIDMapping( prefix, ",", Collections.<Pair<SQLIdentifier, BaseType>>emptyList(), null ),
+                Collections.<Mapping>emptyList() );
+    }
+
+}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/id/IdAnalyzerTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/id/IdAnalyzerTest.java
@@ -1,12 +1,9 @@
 /*----------------------------------------------------------------------------
- This file is part of deegree
+ This file is part of deegree, http://deegree.org/
  Copyright (C) 2001-2017 by:
  - Department of Geography, University of Bonn -
  and
  - lat/lon GmbH -
- and
- - grit GmbH -
- and others
 
  This library is free software; you can redistribute it and/or modify it under
  the terms of the GNU Lesser General Public License as published by the Free
@@ -22,14 +19,31 @@
 
  Contact information:
 
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
  e-mail: info@deegree.org
- website: http://www.deegree.org/
-----------------------------------------------------------------------------*/
+ ----------------------------------------------------------------------------*/
 package org.deegree.feature.persistence.sql.id;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.namespace.QName;
 
 import org.deegree.commons.jdbc.SQLIdentifier;
 import org.deegree.commons.jdbc.TableName;
-import org.deegree.commons.tom.gml.GMLObjectType;
 import org.deegree.commons.tom.gml.property.PropertyType;
 import org.deegree.commons.tom.primitive.BaseType;
 import org.deegree.commons.utils.Pair;
@@ -38,68 +52,82 @@ import org.deegree.feature.persistence.sql.MappedAppSchema;
 import org.deegree.feature.persistence.sql.rules.Mapping;
 import org.deegree.feature.types.FeatureType;
 import org.deegree.feature.types.GenericFeatureType;
-import org.junit.Before;
 import org.junit.Test;
 
-import javax.xml.namespace.QName;
-import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
-
+/**
+ * {@link IdAnalyzer} tests for checking the correct deriving of a feature type from a feature id.
+ */
 public class IdAnalyzerTest {
-
-    private static final String FEATURE_NAME = "NAME";
-    private static final String PREFIX = "p";
 
     private IdAnalyzer idAnalyzer;
 
-    @Before
-    public void setUp() throws Exception {
-        idAnalyzer = new IdAnalyzer( createMappedAppSchemaMock() );
+    @Test
+    public void analyzeFeatureIds() {
+        idAnalyzer = setupAnalyzerScenario( "APP_FEATURE1_", "APP_FEATURE2_", "APP_FEATURE3_" );
+        assertEquals( "APP_FEATURE1_", analyzeFeatureType( "APP_FEATURE1_1" ) );
+        assertEquals( "APP_FEATURE2_", analyzeFeatureType( "APP_FEATURE2_1" ) );
+        assertEquals( "APP_FEATURE3_", analyzeFeatureType( "APP_FEATURE3_1" ) );
     }
 
     @Test
-    public void usingSingleLetterPrefixResultsToCorrectFeatureName() throws Exception {
-        IdAnalysis analysis = idAnalyzer.analyze( PREFIX + FEATURE_NAME );
-        assertEquals( analysis.getIdKernels()[0], FEATURE_NAME );
+    public void analyzeGeometryIds() {
+        idAnalyzer = setupAnalyzerScenario( "APP_FEATURE1_", "APP_FEATURE2_", "APP_FEATURE3_" );
+        assertEquals( "APP_FEATURE1_", analyzeFeatureType( "APP_FEATURE1_1_APP_GEOM" ) );
+        assertEquals( "APP_FEATURE2_", analyzeFeatureType( "APP_FEATURE2_1_APP_GEOM" ) );
+        assertEquals( "APP_FEATURE3_", analyzeFeatureType( "APP_FEATURE3_1_APP_GEOM" ) );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void analyzeNoMatch() {
+        idAnalyzer = setupAnalyzerScenario( "APP_FEATURE_" );
+        analyzeFeatureType( "BPP_FEATURE_1" );
     }
 
     @Test
-    public void usingDoubleLetterPrefixResultsToCorrectFeatureName() throws Exception {
-        IdAnalysis analysis = idAnalyzer.analyze( PREFIX + PREFIX + FEATURE_NAME );
-        assertEquals( analysis.getIdKernels()[0], FEATURE_NAME );
+    public void analyzeFeatureIdMultiplePrefixMatches() {
+        // these tests used to fail with Java 8 (see https://github.com/deegree/deegree3/issues/848)
+        idAnalyzer = setupAnalyzerScenario( "APP_FEATURE_", "APP_FEATURE_X_" );
+        assertEquals( "APP_FEATURE_X_", analyzeFeatureType( "APP_FEATURE_X_1" ) );
+        // actual production case that used to fail
+        idAnalyzer = setupAnalyzerScenario( "IMRO_GEOMETRIESTRUCTUURVISIEOBJECT_", "IMRO_GEOMETRIESTRUCTUURVISIEOBJECT_P_" );
+        assertEquals( "IMRO_GEOMETRIESTRUCTUURVISIEOBJECT_P_", analyzeFeatureType( "IMRO_GEOMETRIESTRUCTUURVISIEOBJECT_P_1" ) );
     }
 
-    private MappedAppSchema createMappedAppSchemaMock() {
-        QName featureA = new QName( "A" );
-        QName featureB = new QName( "B" );
-        return new MappedAppSchema(
-                new FeatureType[]{
-                        new GenericFeatureType( featureA, Collections.<PropertyType>emptyList(), false ),
-                        new GenericFeatureType( featureB, Collections.<PropertyType>emptyList(), false )
-                },
-                Collections.<FeatureType, FeatureType>emptyMap(),
-                Collections.<String, String>emptyMap(),
-                null,
-                new FeatureTypeMapping[]{
-                        createFeatureTypeMapping( featureA, PREFIX ),
-                        createFeatureTypeMapping( featureB, ( PREFIX + PREFIX ) )
-                },
-                null,
-                null,
-                null,
-                true,
-                null,
-                Collections.<GMLObjectType>emptyList(),
-                Collections.<GMLObjectType, GMLObjectType>emptyMap()
-        );
+    private String analyzeFeatureType( final String fid ) {
+        return idAnalyzer.analyze( fid ).getFeatureType().getName().getLocalPart();
     }
 
-    private FeatureTypeMapping createFeatureTypeMapping( QName featureName, String prefix ) {
-        return new FeatureTypeMapping( featureName,
-                new TableName( "TABLE_" + featureName.getLocalPart() + "_IDENTIFIER" ),
-                new FIDMapping( prefix, ",", Collections.<Pair<SQLIdentifier, BaseType>>emptyList(), null ),
-                Collections.<Mapping>emptyList() );
+    private IdAnalyzer setupAnalyzerScenario( final String... idPrefixes ) {
+        final FeatureType[] fts = new FeatureType[idPrefixes.length];
+        final FeatureTypeMapping[] ftMappings = new FeatureTypeMapping[idPrefixes.length];
+        int i = 0;
+        for ( final String idPrefix : idPrefixes ) {
+            fts[i] = buildFeatureType( idPrefix );
+            ftMappings[i] = buildFeatureTypeMapping( fts[i], idPrefix );
+            i++;
+        }
+        final MappedAppSchema schema = new MappedAppSchema( fts, null, null, null, ftMappings, null, null, null, false,
+                                                            null, null, null );
+        return new IdAnalyzer( schema );
     }
 
+    private FeatureType buildFeatureType( final String localName ) {
+        return new GenericFeatureType( buildQName( localName ), Collections.<PropertyType> emptyList(), false );
+    }
+
+    private FeatureTypeMapping buildFeatureTypeMapping( final FeatureType ft, final String fidPrefix ) {
+        final FIDMapping fidMapping = buildFidMapping( fidPrefix );
+        return new FeatureTypeMapping( ft.getName(), new TableName( ft.getName().getLocalPart() ), fidMapping,
+                                       Collections.<Mapping> emptyList() );
+    }
+
+    private FIDMapping buildFidMapping( final String fidPrefix ) {
+        final List<Pair<SQLIdentifier, BaseType>> fidColumns = new ArrayList<Pair<SQLIdentifier, BaseType>>();
+        fidColumns.add( new Pair<SQLIdentifier, BaseType>( new SQLIdentifier( "id" ), BaseType.INTEGER ) );
+        return new FIDMapping( fidPrefix, "_", fidColumns, null );
+    }
+
+    private QName buildQName( final String localPart ) {
+        return new QName( "http://www.deegree.org/app", localPart, "app" );
+    }
 }


### PR DESCRIPTION
This is a bugfix for #848:

* Ensures that the feature id match is always based on the longest matching prefix
* Includes tests