### PR TITLE
Fixed unexpected GetMap responses from remote WMS

### DIFF
--- a/deegree-layers/deegree-layers-remotewms/src/main/java/org/deegree/layer/persistence/remotewms/RemoteWMSLayer.java
+++ b/deegree-layers/deegree-layers-remotewms/src/main/java/org/deegree/layer/persistence/remotewms/RemoteWMSLayer.java
@@ -24,6 +24,8 @@ import org.deegree.layer.persistence.remotewms.jaxb.RequestOptionsType.Parameter
 import org.deegree.protocol.wms.client.WMSClient;
 import org.deegree.protocol.wms.ops.GetFeatureInfo;
 import org.deegree.protocol.wms.ops.GetMap;
+import org.deegree.style.StyleRef;
+import org.deegree.style.se.unevaluated.Style;
 import org.slf4j.Logger;
 
 /**
@@ -165,6 +167,14 @@ class RemoteWMSLayer extends AbstractLayer {
                                                  query.getHeight(), query.getX(), query.getY(), query.getEnvelope(),
                                                  crs, query.getFeatureCount() );
         return new RemoteWMSLayerData( client, gfi, extraParams );
+    }
+
+    @Override
+    public boolean isStyleApplicable( StyleRef style ) {
+        if ( "default".equals( style.getName() ) ) {
+            return true;
+        }
+        return resolveStyleRef( style ) != null;
     }
 
 }


### PR DESCRIPTION
Configuring the WMS [1]  as a remote service leads to unexpected (empty) GetMap responses. in the theme configuration the layers are merged into one Theme:

```
    <Theme>
      <Identifier>ALK</Identifier>
      <d:Title>ALK (B1 - B6)</d:Title>
      <Layer>adv_alkis_tatsaechliche_nutzung</Layer>
      <Layer>adv_alkis_gewaesser</Layer>
      <Layer>adv_alkis_vegetation</Layer>
      <Layer>adv_alkis_verkehr</Layer>
      <Layer>adv_alkis_siedlung</Layer>
      <Layer>adv_alkis_gesetzl_festlegungen</Layer>
      <Layer>adv_alkis_bodensch</Layer>
      <Layer>adv_alkis_oeff_rechtl_sonst_festl</Layer>
      <Layer>adv_alkis_weiteres</Layer>
      <Layer>adv_alkis_bauw_einricht</Layer>
      <Layer>adv_alkis_gebaeude</Layer>
      <Layer>adv_alkis_flurstuecke</Layer>
    </Theme>
```

The service contains layers 
1. with three style "Farbe", "Gelb" and "Grau" (e.g. "adv_alkis_gebaeude")  and
1.  with the same styles but inherited by the parent layer  (e.g "adv_alkis_gewaesser"). 

Requesting the layer `ALK` with style `default` leads to
 1. not requested layers in case with the three styles
 1. the expected results in case of the layers with inherited styles

The reason for this is the following method:
https://github.com/deegree/deegree3/blob/8c9568a708a0980472ddd07127cb5419dc71e946/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/AbstractLayer.java#L96-L103

In case 2. (no styles are available cause the inheritance is not considered) this results in true, in case 1. to false.

This fix overwrites the method isStyleApplicable in RemoteWMSLayer to return true in case the default layer is requested. This makes the handling of a default style mandatory for the remote WMS layer. This should be ok as described in WMS 1.3.0 spec:
> If the server advertises several styles for a layer, and the client sends a request for the default style, the choice of which style to use as default is at the discretion of the server. The ordering of styles in the service metadata does not indicate which is the default.

[1] www.wms.nrw.de/geobasis/wms_nw_alkis?service=WMS&request=GetCapabilities
