### PR TITLE
Replaced WFS configuration option allowFeatureReferencesToDatastore by new idGenMode

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -202,6 +202,7 @@ import static org.deegree.protocol.wfs.WFSRequestType.ListStoredQueries;
 import static org.deegree.protocol.wfs.WFSRequestType.LockFeature;
 import static org.deegree.protocol.wfs.WFSRequestType.Transaction;
 import static org.deegree.protocol.wfs.getfeature.ResultType.HITS;
+import static org.deegree.services.jaxb.wfs.IdentifierGenerationOptionType.USE_EXISTING_RESOLVING_REFERENCES_INTERNALLY;
 
 /**
  * Implementation of the <a href="http://www.opengeospatial.org/standards/wfs">OpenGIS Web Feature Service</a> server
@@ -281,8 +282,9 @@ public class WebFeatureService extends AbstractOWS {
         EnableTransactions enableTransactions = jaxbConfig.getEnableTransactions();
         if ( enableTransactions != null ) {
             this.enableTransactions = enableTransactions.isValue();
-            this.idGenMode = parseIdGenMode( enableTransactions.getIdGen() );
-            this.allowFeatureReferencesToDatastore = enableTransactions.isAllowFeatureReferencesToDatastore();
+            IdentifierGenerationOptionType configuredIdGenMode = enableTransactions.getIdGen();
+            this.idGenMode = parseIdGenMode( configuredIdGenMode );
+            this.allowFeatureReferencesToDatastore = USE_EXISTING_RESOLVING_REFERENCES_INTERNALLY.equals( configuredIdGenMode );
         }
         if ( jaxbConfig.isEnableResponseBuffering() != null ) {
             disableBuffering = !jaxbConfig.isEnableResponseBuffering();
@@ -474,6 +476,7 @@ public class WebFeatureService extends AbstractOWS {
         case GENERATE_NEW: {
             return IDGenMode.GENERATE_NEW;
         }
+        case USE_EXISTING_RESOLVING_REFERENCES_INTERNALLY:
         case USE_EXISTING: {
             return IDGenMode.USE_EXISTING;
         }

--- a/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
+++ b/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
@@ -43,7 +43,6 @@
             <simpleContent>
               <extension base="boolean">
                 <attribute name="idGen" type="wfs:IdentifierGenerationOptionType" use="optional" default="GenerateNew" />
-                <attribute name="allowFeatureReferencesToDatastore" type="boolean" use="optional" default="false" />
               </extension>
             </simpleContent>
           </complexType>
@@ -273,6 +272,16 @@
         <annotation>
           <documentation>
             Indicates that the WFS will generate new and unique feature identifiers for inserted features.
+          </documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="UseExistingResolvingReferencesInternally">
+        <annotation>
+          <documentation>
+            Indicates that the WFS will not generate new feature identifiers for inserted features.
+            Instead, the WFS will use the identifier encoded in the feature. If a duplicate exists then the WFS will
+            raise an exception.
+            Furthermore it is allowed to insert features with references to already inserted features as well as features from the GML to insert.
           </documentation>
         </annotation>
       </enumeration>

--- a/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
+++ b/deegree-services/deegree-webservices-handbook/src/main/sphinx/webservices.rst
@@ -117,9 +117,10 @@ General options
 Transactions
 ^^^^^^^^^^^^
 
-By default, WFS-T requests will be rejected. Setting the ``EnableTransactions`` option to ``true`` will enable transaction support. This option has two optional attributes: ``allowFeatureReferencesToDatastore`` and ``idGenMode``. If ``allowFeatureReferencesToDatastore`` is true it is allowed to insert features with references to already inserted features, default is false. ``idGenMode`` controls how ids of inserted features (the values in the gml:id attribute) are treated. There are three id generation modes available:
+By default, WFS-T requests will be rejected. Setting the ``EnableTransactions`` option to ``true`` will enable transaction support. This option has the optional attribute ``idGenMode`` which controls how ids of inserted features (the values in the gml:id attribute) are treated. There are three id generation modes available:
 
 * **UseExisting**: The original gml:id values from the input are stored. This may lead to errors if the provided ids are already in use.
+* **UseExistingResolvingReferencesInternally**: Same as UseExisting, but it is allowed to insert features with references to already inserted features.
 * **GenerateNew** (default): New and unique ids are generated. References in the input GML (xlink:href) that point to a feature with an reassigned id are fixed as well, so reference consistency is maintained.
 * **ReplaceDuplicate**: The WFS will try to use the original gml:id values that have been provided in the input. In case a certain identifier already exists in the backend, a new and unique identifier will be generated. References in the input GML (xlink:href) that point to a feature with an reassigned id are fixed as well, so reference consistency is maintained.
 


### PR DESCRIPTION
Fixes #868 
The new idGenMode is named **UseExistingResolvingReferencesInternally**. Example:
````
<EnableTransactions idGen="UseExistingResolvingReferencesInternally" >true</EnableTransactions>
```