### PR TITLE
Fixed parsing of multiple type names from GET GetFeature request if filter is null

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/query/kvp/QueryKVPAdapter.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/query/kvp/QueryKVPAdapter.java
@@ -409,10 +409,7 @@ public class QueryKVPAdapter extends AbstractWFSRequestKVPAdapter {
         } else if ( !typeNamesList.isEmpty() ) {
             if ( bbox != null ) {
                 for ( int i = 0; i < numQueries; i++ ) {
-                    TypeName[] typeNames = new TypeName[0];
-                    if ( !typeNamesList.isEmpty() ) {
-                        typeNames = typeNamesList.get( i );
-                    }
+                    TypeName[] typeNames = typeNamesList.get( i );
                     ICRS srsName = null;
                     if ( !srsNames.isEmpty() ) {
                         srsName = srsNames.get( i );
@@ -425,7 +422,10 @@ public class QueryKVPAdapter extends AbstractWFSRequestKVPAdapter {
                     if ( !sortByList.isEmpty() ) {
                         sortBy = sortByList.get( i );
                     }
-                    queries.add( new BBoxQuery( null, typeNames, null, srsName, projectionClauses, sortBy, bbox ) );
+                    for ( TypeName typeName : typeNames ) {
+                        queries.add( new BBoxQuery( null, new TypeName[] { typeName }, null, srsName,
+                                                    projectionClauses, sortBy, bbox ) );
+                    }
                 }
             } else {
                 for ( int i = 0; i < numQueries; i++ ) {
@@ -433,10 +433,7 @@ public class QueryKVPAdapter extends AbstractWFSRequestKVPAdapter {
                     if ( !filterList.isEmpty() ) {
                         filter = filterList.get( i );
                     }
-                    TypeName[] typeNames = new TypeName[0];
-                    if ( !typeNamesList.isEmpty() ) {
-                        typeNames = typeNamesList.get( i );
-                    }
+                    TypeName[] typeNames = typeNamesList.get( i );
                     ICRS srsName = null;
                     if ( !srsNames.isEmpty() ) {
                         srsName = srsNames.get( i );
@@ -449,7 +446,14 @@ public class QueryKVPAdapter extends AbstractWFSRequestKVPAdapter {
                     if ( !sortByList.isEmpty() ) {
                         sortBy = sortByList.get( i );
                     }
-                    queries.add( new FilterQuery( null, typeNames, null, srsName, projectionClauses, sortBy, filter ) );
+                    if ( filter == null ) {
+                        for ( TypeName typeName : typeNames ){
+                            queries.add( new FilterQuery( null, new TypeName[] { typeName }, null, srsName,
+                                                          projectionClauses, sortBy, null ) );    
+                        }
+                    } else {
+                        queries.add( new FilterQuery( null, typeNames, null, srsName, projectionClauses, sortBy, filter ) );
+                    }
                 }
             }
         }


### PR DESCRIPTION
This allows GetFeature (GET) requests with multiple typenames. Previously the request was interpreted as Join.

Fixes #666  