### PR TITLE
Fixes several bugs concerning xlink:href attribute

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/GMLObjectNavigator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/xpath/GMLObjectNavigator.java
@@ -132,6 +132,15 @@ class GMLObjectNavigator extends DefaultNavigator {
                                                                            (GenericXMLElement) value );
                 return getAttributeAxisIterator( n );
             }
+            Map<QName, PrimitiveValue> attributes = ( (PropertyNode) node ).getValue().getAttributes();
+            if ( attributes != null ) {
+                List<AttributeNode<?>> attrNodes = new ArrayList<AttributeNode<?>>( attributes.size() );
+                for ( Entry<QName, PrimitiveValue> attribute : attributes.entrySet() ) {
+                    attrNodes.add( new AttributeNode<Property>( (PropertyNode) node, attribute.getKey(),
+                                                                attribute.getValue() ) );
+                }
+                return attrNodes.iterator();
+            }
         } else if ( node instanceof XMLElementNode<?> ) {
             org.deegree.commons.tom.ElementNode value = ( (XMLElementNode<?>) node ).getValue();
             Map<QName, PrimitiveValue> attributes = value.getAttributes();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -305,7 +305,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
                 writeAttributeWithNS( XSINS, "nil", "true" );
                 endEmptyElement();
             } else {
-                exportFeatureProperty( (FeaturePropertyType) pt, (Feature) value, resolveState );
+                exportFeatureProperty( (FeaturePropertyType) pt, (Feature) value, property.getAttributes(), resolveState );
             }
         } else if ( pt instanceof SimplePropertyType ) {
             if ( nilled ) {
@@ -608,13 +608,15 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
         return resolveState;
     }
 
-    private void exportFeatureProperty( FeaturePropertyType pt, Feature subFeature, GmlXlinkOptions resolveState )
+    private void exportFeatureProperty( FeaturePropertyType pt, Feature subFeature,
+                                        Map<QName, PrimitiveValue> attributes,
+                                        GmlXlinkOptions resolveState )
                             throws XMLStreamException, UnknownCRSException, TransformationException {
 
         QName propName = pt.getName();
         LOG.debug( "Exporting feature property '" + propName + "'" );
         if ( subFeature == null ) {
-            exportEmptyProperty( propName, null );
+            exportEmptyProperty( propName, attributes );
         } else if ( subFeature instanceof FeatureReference ) {
             exportFeatureProperty( pt, (FeatureReference) subFeature, resolveState, propName );
         } else {
@@ -738,7 +740,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
                 List<TypedObjectNode> children = xmlContent.getChildren();
                 if ( children != null && children.size() == 1 && children.get( 0 ) instanceof Feature ) {
                     LOG.debug( "Exporting as nested feature property." );
-                    exportFeatureProperty( (FeaturePropertyType) gmlPropertyDecl, (Feature) children.get( 0 ),
+                    exportFeatureProperty( (FeaturePropertyType) gmlPropertyDecl, (Feature) children.get( 0 ), null,
                                            resolveState );
                     return;
                 }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -140,6 +140,8 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 
     private static final QName XSI_NIL = new QName( XSINS, "nil", "xsi" );
 
+    private static final QName NIL_REASON = new QName( "nilReason" );
+    
     /**
      * Creates a new {@link GMLFeatureWriter} instance.
      *
@@ -295,23 +297,20 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
         // TODO check for GML 2 properties (gml:pointProperty, ...) and export
         // as "app:gml2PointProperty" for GML 3
         boolean nilled = false;
-        TypedObjectNode nil = property.getAttributes().get( XSI_NIL );
+        Map<QName, PrimitiveValue> attributes = property.getAttributes();
+        TypedObjectNode nil = attributes.get( XSI_NIL );
         if ( nil instanceof PrimitiveValue ) {
             nilled = Boolean.TRUE.equals( ( (PrimitiveValue) nil ).getValue() );
         }
         if ( pt instanceof FeaturePropertyType ) {
             if ( nilled ) {
-                writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
-                writeAttributeWithNS( XSINS, "nil", "true" );
-                endEmptyElement();
+                writeNilledElement( propName, attributes );
             } else {
-                exportFeatureProperty( (FeaturePropertyType) pt, (Feature) value, property.getAttributes(), resolveState );
+                exportFeatureProperty( (FeaturePropertyType) pt, (Feature) value, attributes, resolveState );
             }
         } else if ( pt instanceof SimplePropertyType ) {
             if ( nilled ) {
-                writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
-                writeAttributeWithNS( XSINS, "nil", "true" );
-                endEmptyElement();
+                writeNilledElement( propName, attributes );
             } else {
                 // must be a primitive value
                 PrimitiveValue pValue = (PrimitiveValue) value;
@@ -323,9 +322,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             }
         } else if ( pt instanceof GeometryPropertyType ) {
             if ( nilled ) {
-                writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
-                writeAttributeWithNS( XSINS, "nil", "true" );
-                endEmptyElement();
+                writeNilledElement( propName, attributes );
             } else if ( value == null ) {
                 writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
                 endEmptyElement();
@@ -348,7 +345,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
         } else if ( pt instanceof CodePropertyType ) {
             writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
             if ( nilled ) {
-                writeAttributeWithNS( XSINS, "nil", "true" );
+                writeNilAttributes( attributes );
             }
             CodeType codeType = (CodeType) value;
 
@@ -363,9 +360,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             writer.writeEndElement();
         } else if ( pt instanceof EnvelopePropertyType ) {
             if ( nilled ) {
-                writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
-                writeAttributeWithNS( XSINS, "nil", "true" );
-                endEmptyElement();
+                writeNilledElement( propName, attributes );
             } else {
                 writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
                 if ( value != null ) {
@@ -382,7 +377,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
             if ( GML_2 != version ) {
                 if ( nilled ) {
-                    writeAttributeWithNS( XSINS, "nil", "true" );
+                    writeNilAttributes( attributes );
                 }
                 writer.writeAttribute( "uom", length.getUomUri() );
             }
@@ -406,13 +401,13 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
                     writeAttributeWithNS( XLNNS, "href", stringOrRef.getRef() );
                 }
                 if ( nilled ) {
-                    writeAttributeWithNS( XSINS, "nil", "true" );
+                    writeNilAttributes( attributes );
                 }
                 endEmptyElement();
             } else {
                 writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
                 if ( nilled ) {
-                    writeAttributeWithNS( XSINS, "nil", "true" );
+                    writeNilAttributes( attributes );
                 }
 
                 if ( stringOrRef.getRef() != null ) {
@@ -425,8 +420,8 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             }
         } else if ( pt instanceof CustomPropertyType ) {
             writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
-            if ( property.getAttributes() != null ) {
-                for ( Entry<QName, PrimitiveValue> attr : property.getAttributes().entrySet() ) {
+            if ( attributes != null ) {
+                for ( Entry<QName, PrimitiveValue> attr : attributes.entrySet() ) {
                     QName attrKey = attr.getKey();
                     PrimitiveValue attrValue = attr.getValue();
                     if ( XSI_NIL.equals( attrKey ) )
@@ -443,9 +438,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
             writer.writeEndElement();
         } else if ( pt instanceof ArrayPropertyType ) {
             if ( nilled ) {
-                writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
-                writeAttributeWithNS( XSINS, "nil", "true" );
-                endEmptyElement();
+                writeNilledElement( propName, attributes );
             } else {
                 writeStartElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
                 export( property.getValue(), resolveState );
@@ -464,6 +457,22 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
         }
     }
 
+    private void writeNilledElement( QName propName, Map<QName, PrimitiveValue> attributes )
+                            throws XMLStreamException {
+        writeEmptyElementWithNS( propName.getNamespaceURI(), propName.getLocalPart() );
+        writeNilAttributes( attributes );
+        endEmptyElement();
+    }
+
+    private void writeNilAttributes( Map<QName, PrimitiveValue> attributes )
+                            throws XMLStreamException {
+        writeAttribute( writer, XSI_NIL, "true" );
+        PrimitiveValue value = attributes.get( NIL_REASON );
+        if ( value != null )
+            writeAttribute( writer, NIL_REASON, value.getAsText() );
+    }
+
+    
     private boolean excludeByTimeSliceFilter( Property property ) {
         final TimeSlice timeSlice = (TimeSlice) property.getValue();
         for ( final Filter timeSliceFilter : timeSliceFilters ) {

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/feature/CustomPropertiesGml32.xml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/feature/CustomPropertiesGml32.xml
@@ -1,0 +1,12 @@
+<gml:FeatureCollection xmlns:app="http://www.deegree.org/app" xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://www.deegree.org/app ../schema/CustomPropertiesGml32.xsd"
+                       gml:id="FC_1">
+  <gml:featureMember>
+    <app:ComplexFeature gml:id="CF_1">
+      <app:simple>abc</app:simple>
+      <app:type xlink:href="http://pathtoregistry/abc/code" />
+    </app:ComplexFeature>
+  </gml:featureMember>
+</gml:FeatureCollection>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/schema/CustomPropertiesGml32.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/schema/CustomPropertiesGml32.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:app="http://www.deegree.org/app" targetNamespace="http://www.deegree.org/app"
+        elementFormDefault="qualified">
+
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+  <element name="ComplexFeature" type="app:ComplexFeatureType" substitutionGroup="gml:AbstractFeature" />
+  <complexType name="ComplexFeatureType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="simple" type="string" minOccurs="0" maxOccurs="unbounded" />
+          <!-- reference to codelist as often seen in INSPIRE schemas -->
+          <element name="type" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -1159,10 +1159,12 @@ public class SQLFeatureStore implements FeatureStore {
             BlobMapping blobMapping = getSchema().getBlobMapping();
             FeatureBuilder builder = new FeatureBuilderBlob( this, blobMapping );
             List<String> columns = builder.getInitialSelectList();
-            wb = getWhereBuilderBlob( filter, conn );
-            final SQLExpression where = wb.getWhere();
-            LOG.debug( "WHERE clause: " + where );
-            String alias = wb.getAliasManager().getRootTableAlias();
+            if ( query.getPrefilterBBox() != null ) {
+                OperatorFilter bboxFilter = new OperatorFilter( query.getPrefilterBBox() );
+                wb = getWhereBuilderBlob( bboxFilter, conn );
+                LOG.debug( "WHERE clause: " + wb.getWhere() );
+            }
+            String alias = wb != null ? wb.getAliasManager().getRootTableAlias() : "X1";
 
             StringBuilder sql = new StringBuilder( "SELECT " );
             sql.append( columns.get( 0 ) );


### PR DESCRIPTION
This pull requests fixes several bugs concerning xlink:href attributes as primitive mapping instead of feature mapping. This is used in mappings for INSPIRE schemas if the xlink:href attribute contains codelists instead of feature references. 

Fixed bugs in detail:
* Fixes #875
   * Missing xlink:href attributes in WFS GetFeature response are fixed
*  Fixes #866
   * Missing nilReason attributes in WFS GetFeature response are fixed
* Fixes #587
   * Filtering of xlink:href in SLD or FeatureLayer configurations are applied in relational and blob mode

This pull requests reverts changes from pull request #527 in SQLFeatureStore. The changes in #527 result in empty GetFeature responses in case a SQLFeatureStore with blob mode is configured and the request contains a filter. The filter is applied to the database even if it is not a spatial filter. E.g: 
The filter
```
<fes:Filter>
  <fes:PropertyIsEqualTo>
    <fes:ValueReference>hy-p:type/@xlink:href</fes:ValueReference>
    <fes:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/culvert</fes:Literal>
  </fes:PropertyIsEqualTo>
</fes:Filter>
```
results in WHERE clause:
```
X1.gml_bounded_by = 'http://inspire.ec.europa.eu/codelist/CrossingTypeValue/culvert'
```

Fixes #573 as this is a collection of all the problems described above.