### PR TITLE
Update dependencies with known vulnerabilities

### DIFF
--- a/deegree-spring/pom.xml
+++ b/deegree-spring/pom.xml
@@ -20,7 +20,7 @@
 
 	<properties>
 		<deegree.module.status>ok</deegree.module.status>
-		<spring.version>3.2.15.RELEASE</spring.version>
+		<spring.version>3.2.18.RELEASE</spring.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.8.3</version>
+        <version>1.9.3</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -494,13 +494,13 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>el-api</artifactId>
-        <version>6.0.36</version>
+        <version>6.0.53</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>jsp-api</artifactId>
-        <version>6.0.36</version>
+        <version>6.0.53</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -665,7 +665,7 @@
       <dependency>
         <groupId>xalan</groupId>
         <artifactId>serializer</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1174,7 +1174,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>1.3.1</version>
+            <version>3.1.1</version>
             <reportSets>
               <reportSet>
                 <reports>


### PR DESCRIPTION
The OSWAP Maven Plugin has detected known vulnerabilities in used dependencies. This PR fixes some of them by upgrading to more recent versions.