### PR TITLE
WFS-T import leads to truncated values in string properties

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/XMLInputFactoryUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/XMLInputFactoryUtils.java
@@ -61,6 +61,7 @@ public class XMLInputFactoryUtils {
         XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 
         inputFactory.setProperty( XMLInputFactory.SUPPORT_DTD, false );
+	inputFactory.setProperty( XMLInputFactory.IS_COALESCING, true );
 
         return inputFactory;
     }


### PR DESCRIPTION
During parsing of GML being imported, string values may be split into different child elements. This leads to the behaviour that only one of those child elements is saved into database and thus just a truncated value is returned by services.

E.g. property gml:identifier with value ```https://test-request.test/test-path/featuretype-identifier/feature_71``` is part of the imported GML.
This value is parsed into two childs by GML parser:
* ```https://test-request.test/test-path/featuretype-identifier/feature_7```
* ```1```

Just the value ```1``` is saved into database.

This fix prevents splitting of string values during parsing of GML when XMLInputFactoryUtils is used and thus values are not truncated in database and service output.