### PR TITLE
Updated enforcer plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,13 +320,14 @@
             <goals>
               <goal>enforce</goal>
             </goals>
+            <phase>initialize</phase>
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.0.5</version>
+                  <version>[3.5.0,3.6)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>1.8</version>
+                  <version>[1.8,1.9)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Updated enforcer plugin configuration to check for Maven version 3.5+ and Java version 1.8+. Now build fails in case the required versions are not present.

Previously we haven't make use of the enforcer plugin during travis-ci and Jenkins build to ensure maven und java versions. As a preparation for upcoming releases of maven and java (11 release will come soon) now the versions are checked and MUST prerequisites.

Requires an update of wiki page https://github.com/deegree/deegree3/wiki/Building-deegree3 as well.