### PR TITLE
Fixes build issue on travis-ci missing access to oracle libraries

### DIFF
--- a/deegree-tools/pom.xml
+++ b/deegree-tools/pom.xml
@@ -90,9 +90,17 @@
   <modules>
     <module>deegree-tools-3d</module>
     <module>deegree-tools-base</module>
-    <module>deegree-tools-config</module>
     <module>deegree-tools-alkis</module>
     <module>deegree-tools-migration</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>oracle</id>
+      <modules>
+        <module>deegree-tools-config</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
Moved module  `deegree-tools-config`to Maven `oracle` profile.