### PR TITLE
Fixes "Too many open files" in case external resources are not available

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLInputFactory.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLInputFactory.java
@@ -46,6 +46,7 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import org.apache.commons.io.IOUtils;
 import org.deegree.commons.proxy.ProxySettings;
 import org.deegree.commons.tom.gml.GMLObject;
 import org.deegree.commons.xml.stax.XMLStreamReaderWrapper;
@@ -106,9 +107,14 @@ public class GMLInputFactory {
 
         URLConnection conn = ProxySettings.openURLConnection( url );
         InputStream is = conn.getInputStream();
-        XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader( is );
-        // skip START_DOCUMENT event
-        xmlStream.nextTag();
-        return new GMLStreamReader( version, new XMLStreamReaderWrapper( xmlStream, url.toString() ) );
+        try {
+            XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader( is );
+            // skip START_DOCUMENT event
+            xmlStream.nextTag();
+            return new GMLStreamReader( version, new XMLStreamReaderWrapper( xmlStream, url.toString() ) );
+        } catch ( XMLStreamException | FactoryConfigurationError e ) {
+            IOUtils.closeQuietly( is );
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
If DisabledResources are disabled in the WFS configuration an error may occur during insert:

```
[13:05:23] ERROR: [AbstractOWS] An error occurred while trying to send an exception: java.io.FileNotFoundException: /usr/local/tomcat/webapps/deegree-webservices/WEB-INF/lib/deegree-services-wmts-3.4.1.jar (Too many open files)
java.lang.IllegalStateException: java.io.FileNotFoundException: /usr/local/tomcat/webapps/deegree-webservices/WEB-INF/lib/deegree-services-wmts-3.4.1.jar (Too many open files)
    at org.apache.catalina.webresources.AbstractSingleArchiveResourceSet.getArchiveEntry(AbstractSingleArchiveResourceSet.java:100)
    at org.apache.catalina.webresources.AbstractArchiveResourceSet.getResource(AbstractArchiveResourceSet.java:262)
    at org.apache.catalina.webresources.StandardRoot.getResourcesInternal(StandardRoot.java:327)

```

This PR closes the input stream if an error occurs.