### PR TITLE
Changed maven build to produce no output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk8
-install: "travis_retry mvn install -Pintegration-tests -DskipTests=true -B -V"
-script: "travis_retry mvn verify -Pintegration-tests -B -V"
+install: "travis_retry mvn install -Pintegration-tests -DskipTests=true -B -V -C -q"
+script: "travis_retry mvn verify -Pintegration-tests -B -V -C -q"
 env: MAVEN_OPTS="-XX:MaxPermSize=256m"
 cache:
   directories:


### PR DESCRIPTION
Current builds on Travis-ci either reached 50 minutes timeout or log output reached maximum of 4MB log output (see https://docs.travis-ci.com/user/common-build-problems/#log-length-exceeded).
This change is setting maven output to quiet using the `-q` option and add the `-C` option to check the checksums strictly.