### PR TITLE
Improve exception handling concerning bbox cache properties

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/BBoxTracker.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/BBoxTracker.java
@@ -45,7 +45,9 @@ import javax.xml.namespace.QName;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.feature.Feature;
 import org.deegree.geometry.Envelope;
+import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.GeometryTransformer;
+import org.deegree.geometry.SimpleGeometryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,6 +86,9 @@ public class BBoxTracker {
             }
             if ( bbox != null ) {
                 try {
+                    if ( bbox.getCoordinateSystem() == null ){
+                        bbox.setCoordinateSystem( storageSrs );
+                    }
                     if ( bbox.getCoordinateSystem() != null && !bbox.getCoordinateSystem().equals( storageSrs ) ) {
                         GeometryTransformer transformer = new GeometryTransformer( storageSrs );
                         bbox = transformer.transform( bbox );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/cache/BBoxPropertiesCache.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/cache/BBoxPropertiesCache.java
@@ -190,7 +190,7 @@ public class BBoxPropertiesCache implements BBoxCache {
     }
 
     private final String encodePropValue( Envelope env ) {
-        if ( env == null ) {
+        if ( env == null || env.getCoordinateSystem() == null ) {
             return "";
         }
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
This PR improves the exception handling concerning bbox cache properties in case the coordinate system of a geometry is not set.