### PR TITLE
Upgrade JTS from version 1.13 to 1.16.0

### DIFF
--- a/deegree-core/deegree-core-filterfunctions/pom.xml
+++ b/deegree-core/deegree-core-filterfunctions/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>deegree-core-base</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/geometry/GeometryFromWKT.java
+++ b/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/geometry/GeometryFromWKT.java
@@ -55,7 +55,7 @@ import org.deegree.geometry.io.WKTReader;
 import org.deegree.workspace.Workspace;
 import org.slf4j.Logger;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * 

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -48,8 +48,8 @@
       <artifactId>commons-math</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.vividsolutions</groupId>
-      <artifactId>jts</artifactId>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
     </dependency>
     <dependency>
       <groupId>net.postgis</groupId>

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/Geometries.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/Geometries.java
@@ -219,7 +219,7 @@ public class Geometries {
      */
     public static Geometry copyDeep( Geometry geom ) {
         // TODO implement this without JTS
-        com.vividsolutions.jts.geom.Geometry jtsGeom = ( (AbstractDefaultGeometry) geom ).getJTSGeometry();
+        org.locationtech.jts.geom.Geometry jtsGeom = ( (AbstractDefaultGeometry) geom ).getJTSGeometry();
         return ( (AbstractDefaultGeometry) geom ).createFromJTS( jtsGeom, geom.getCoordinateSystem() );
     }
 

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKBReader.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKBReader.java
@@ -43,8 +43,8 @@ import org.deegree.geometry.Geometry;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.primitive.DefaultPoint;
 
-import com.vividsolutions.jts.io.InputStreamInStream;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.InputStreamInStream;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * Reads {@link Geometry} objects encoded as Well-Known Binary (WKB).
@@ -63,15 +63,15 @@ public class WKBReader {
 
     public static Geometry read( byte[] wkb, ICRS crs )
                             throws ParseException {
-        // com.vividsolutions.jts.io.WKBReader() is not thread safe        
-        return defaultGeom.createFromJTS( new com.vividsolutions.jts.io.WKBReader().read( wkb ), crs );
+        // org.locationtech.jts.io.WKBReader() is not thread safe
+        return defaultGeom.createFromJTS( new org.locationtech.jts.io.WKBReader().read( wkb ), crs );
     }
 
     public static Geometry read( InputStream is, ICRS crs )
                             throws IOException, ParseException {
-        // com.vividsolutions.jts.io.WKBReader() is not thread safe
+        // org.locationtech.jts.io.WKBReader() is not thread safe
         return defaultGeom.createFromJTS(
-                                          new com.vividsolutions.jts.io.WKBReader().read( new InputStreamInStream( is ) ),
+                                          new org.locationtech.jts.io.WKBReader().read( new InputStreamInStream( is ) ),
                                           crs );
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKBWriter.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKBWriter.java
@@ -43,8 +43,8 @@ import org.deegree.geometry.refs.GeometryReference;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.primitive.DefaultPoint;
 
-import com.vividsolutions.jts.io.OutputStreamOutStream;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.OutputStreamOutStream;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * Writes {@link Geometry} objects encoded as Well-Known Binary (WKB).
@@ -66,16 +66,16 @@ public class WKBWriter {
         if ( geom instanceof GeometryReference ) {
             geom = ( (GeometryReference<Geometry>) geom ).getReferencedObject();
         }
-        // com.vividsolutions.jts.io.WKBWriter is not thread safe
+        // org.locationtech.jts.io.WKBWriter is not thread safe
         int dim = geom.getCoordinateDimension();
-        return new com.vividsolutions.jts.io.WKBWriter(dim).write( ( (AbstractDefaultGeometry) geom ).getJTSGeometry() );
+        return new org.locationtech.jts.io.WKBWriter(dim).write( ( (AbstractDefaultGeometry) geom ).getJTSGeometry() );
     }
 
     public static void write( Geometry geom, OutputStream os )
                             throws IOException, ParseException {
-        // com.vividsolutions.jts.io.WKBWriter is not thread safe
+        // org.locationtech.jts.io.WKBWriter is not thread safe
         //TODO: test for dimentionality here aswell?
-        new com.vividsolutions.jts.io.WKBWriter().write( ( (AbstractDefaultGeometry) geom ).getJTSGeometry(),
+        new org.locationtech.jts.io.WKBWriter().write( ( (AbstractDefaultGeometry) geom ).getJTSGeometry(),
                                                          new OutputStreamOutStream( os ) );
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKTReader.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKTReader.java
@@ -44,7 +44,7 @@ import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.geometry.Geometry;
 import org.postgis.binary.BinaryWriter;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * Reads {@link Geometry} objects encoded as Well-Known Text (WKT).

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/GeometryLinearizer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/GeometryLinearizer.java
@@ -53,7 +53,7 @@ import org.deegree.geometry.primitive.Surface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vividsolutions.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPoint;
 
 /**
  * Provides methods for creating linearized versions of {@link Geometry} objects.

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/SurfaceLinearizer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/SurfaceLinearizer.java
@@ -48,7 +48,7 @@ import org.deegree.geometry.primitive.patches.SurfacePatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vividsolutions.jts.geom.LinearRing;
+import org.locationtech.jts.geom.LinearRing;
 
 /**
  * Provides methods for the linearization of planar surfaces, i.e. {@link PolygonPatch}es and {@link Polygon}s.

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/points/Points.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/points/Points.java
@@ -39,7 +39,7 @@ package org.deegree.geometry.points;
 import org.deegree.geometry.primitive.LineString;
 import org.deegree.geometry.primitive.Point;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequence;
 
 /**
  * Encapsulates a sequence of {@link Point}s that each may be uniquely identifiable or not.

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/AbstractDefaultGeometry.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/AbstractDefaultGeometry.java
@@ -71,7 +71,7 @@ import org.deegree.geometry.standard.primitive.DefaultPolygon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequence;
 
 /**
  * Abstract base class for the default {@link Geometry} implementation.
@@ -96,7 +96,7 @@ public abstract class AbstractDefaultGeometry implements Geometry {
     /**
      * Used to built JTS geometries.
      */
-    protected final static com.vividsolutions.jts.geom.GeometryFactory jtsFactory = new com.vividsolutions.jts.geom.GeometryFactory();
+    protected final static org.locationtech.jts.geom.GeometryFactory jtsFactory = new org.locationtech.jts.geom.GeometryFactory();
 
     /** Geometry identifier. */
     protected String id;
@@ -111,7 +111,7 @@ public abstract class AbstractDefaultGeometry implements Geometry {
     protected PrecisionModel pm;
 
     // contains an equivalent (or best-fit) JTS geometry object
-    protected com.vividsolutions.jts.geom.Geometry jtsGeometry;
+    protected org.locationtech.jts.geom.Geometry jtsGeometry;
 
     protected Envelope env;
 
@@ -245,21 +245,21 @@ public abstract class AbstractDefaultGeometry implements Geometry {
         if ( crs == null ) {
             crs = geometry.getCoordinateSystem();
         }
-        com.vividsolutions.jts.geom.Geometry jtsGeom = jtsGeoms.first.intersection( jtsGeoms.second );
+        org.locationtech.jts.geom.Geometry jtsGeom = jtsGeoms.first.intersection( jtsGeoms.second );
         return createFromJTS( jtsGeom, crs );
     }
 
     @Override
     public Geometry getUnion( Geometry geometry ) {
         JTSGeometryPair jtsGeoms = JTSGeometryPair.createCompatiblePair( this, geometry );
-        com.vividsolutions.jts.geom.Geometry jtsGeom = jtsGeoms.first.union( jtsGeoms.second );
+        org.locationtech.jts.geom.Geometry jtsGeom = jtsGeoms.first.union( jtsGeoms.second );
         return createFromJTS( jtsGeom, crs );
     }
 
     @Override
     public Geometry getDifference( Geometry geometry ) {
         JTSGeometryPair jtsGeoms = JTSGeometryPair.createCompatiblePair( this, geometry );
-        com.vividsolutions.jts.geom.Geometry jtsGeom = jtsGeoms.first.difference( jtsGeoms.second );
+        org.locationtech.jts.geom.Geometry jtsGeom = jtsGeoms.first.difference( jtsGeoms.second );
         return createFromJTS( jtsGeom, crs );
     }
 
@@ -267,20 +267,20 @@ public abstract class AbstractDefaultGeometry implements Geometry {
     public Geometry getBuffer( Measure distance ) {
         // TODO get double in CoordinateSystem units
         double crsDistance = distance.getValueAsDouble();
-        com.vividsolutions.jts.geom.Geometry jtsGeom = getJTSGeometry().buffer( crsDistance );
+        org.locationtech.jts.geom.Geometry jtsGeom = getJTSGeometry().buffer( crsDistance );
         return createFromJTS( jtsGeom, crs );
     }
 
     @Override
     public Geometry getConvexHull() {
-        com.vividsolutions.jts.geom.Geometry jtsGeom = getJTSGeometry().convexHull();
+        org.locationtech.jts.geom.Geometry jtsGeom = getJTSGeometry().convexHull();
         return createFromJTS( jtsGeom, crs );
     }
 
     @Override
     public Envelope getEnvelope() {
         if ( env == null ) {
-            com.vividsolutions.jts.geom.Envelope jtsEnvelope = getJTSGeometry().getEnvelopeInternal();
+            org.locationtech.jts.geom.Envelope jtsEnvelope = getJTSGeometry().getEnvelopeInternal();
             Point min = new DefaultPoint( null, crs, pm, new double[] { jtsEnvelope.getMinX(), jtsEnvelope.getMinY() } );
             Point max = new DefaultPoint( null, crs, pm, new double[] { jtsEnvelope.getMaxX(), jtsEnvelope.getMaxY() } );
             env = new DefaultEnvelope( null, crs, pm, min, max );
@@ -293,14 +293,14 @@ public abstract class AbstractDefaultGeometry implements Geometry {
      * 
      * @return an equivalent (or best-fit) JTS geometry
      */
-    public com.vividsolutions.jts.geom.Geometry getJTSGeometry() {
+    public org.locationtech.jts.geom.Geometry getJTSGeometry() {
         if ( jtsGeometry == null ) {
             jtsGeometry = buildJTSGeometry();
         }
         return jtsGeometry;
     }
 
-    protected com.vividsolutions.jts.geom.Geometry buildJTSGeometry() {
+    protected org.locationtech.jts.geom.Geometry buildJTSGeometry() {
         throw new UnsupportedOperationException( "#buildJTSGeometry() is not implemented for "
                                                  + this.getClass().getName() );
     }
@@ -342,28 +342,28 @@ public abstract class AbstractDefaultGeometry implements Geometry {
      *         geometry, or null if the given geometry is an empty collection
      */
     @SuppressWarnings("unchecked")
-    public AbstractDefaultGeometry createFromJTS( com.vividsolutions.jts.geom.Geometry jtsGeom, ICRS crs ) {
+    public AbstractDefaultGeometry createFromJTS( org.locationtech.jts.geom.Geometry jtsGeom, ICRS crs ) {
 
         AbstractDefaultGeometry geom = null;
         if ( jtsGeom.isEmpty() ) {
             return null;
         }
-        if ( jtsGeom instanceof com.vividsolutions.jts.geom.Point ) {
-            com.vividsolutions.jts.geom.Point jtsPoint = (com.vividsolutions.jts.geom.Point) jtsGeom;
+        if ( jtsGeom instanceof org.locationtech.jts.geom.Point ) {
+            org.locationtech.jts.geom.Point jtsPoint = (org.locationtech.jts.geom.Point) jtsGeom;
             if ( Double.isNaN( jtsPoint.getCoordinate().z ) ) {
                 geom = new DefaultPoint( null, crs, pm, new double[] { jtsPoint.getX(), jtsPoint.getY() } );
             } else {
                 geom = new DefaultPoint( null, crs, pm, new double[] { jtsPoint.getX(), jtsPoint.getY(),
                                                                       jtsPoint.getCoordinate().z } );
             }
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.LinearRing ) {
-            com.vividsolutions.jts.geom.LinearRing jtsLinearRing = (com.vividsolutions.jts.geom.LinearRing) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.LinearRing ) {
+            org.locationtech.jts.geom.LinearRing jtsLinearRing = (org.locationtech.jts.geom.LinearRing) jtsGeom;
             geom = new DefaultLinearRing( null, crs, pm, getAsPoints( jtsLinearRing.getCoordinateSequence(), crs ) );
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.LineString ) {
-            com.vividsolutions.jts.geom.LineString jtsLineString = (com.vividsolutions.jts.geom.LineString) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.LineString ) {
+            org.locationtech.jts.geom.LineString jtsLineString = (org.locationtech.jts.geom.LineString) jtsGeom;
             geom = new DefaultLineString( null, crs, pm, getAsPoints( jtsLineString.getCoordinateSequence(), crs ) );
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.Polygon ) {
-            com.vividsolutions.jts.geom.Polygon jtsPolygon = (com.vividsolutions.jts.geom.Polygon) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.Polygon ) {
+            org.locationtech.jts.geom.Polygon jtsPolygon = (org.locationtech.jts.geom.Polygon) jtsGeom;
             Points exteriorPoints = getAsPoints( jtsPolygon.getExteriorRing().getCoordinateSequence(), crs );
             LinearRing exteriorRing = new DefaultLinearRing( null, crs, pm, exteriorPoints );
             List<Ring> interiorRings = new ArrayList<Ring>( jtsPolygon.getNumInteriorRing() );
@@ -372,8 +372,8 @@ public abstract class AbstractDefaultGeometry implements Geometry {
                 interiorRings.add( new DefaultLinearRing( null, crs, pm, interiorPoints ) );
             }
             geom = new DefaultPolygon( null, crs, pm, exteriorRing, interiorRings );
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.MultiPoint ) {
-            com.vividsolutions.jts.geom.MultiPoint jtsMultiPoint = (com.vividsolutions.jts.geom.MultiPoint) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.MultiPoint ) {
+            org.locationtech.jts.geom.MultiPoint jtsMultiPoint = (org.locationtech.jts.geom.MultiPoint) jtsGeom;
             if ( jtsMultiPoint.getNumGeometries() > 0 ) {
                 List<Point> members = new ArrayList<Point>( jtsMultiPoint.getNumGeometries() );
                 for ( int i = 0; i < jtsMultiPoint.getNumGeometries(); i++ ) {
@@ -381,8 +381,8 @@ public abstract class AbstractDefaultGeometry implements Geometry {
                 }
                 geom = new DefaultMultiPoint( null, crs, pm, members );
             }
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.MultiLineString ) {
-            com.vividsolutions.jts.geom.MultiLineString jtsMultiLineString = (com.vividsolutions.jts.geom.MultiLineString) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.MultiLineString ) {
+            org.locationtech.jts.geom.MultiLineString jtsMultiLineString = (org.locationtech.jts.geom.MultiLineString) jtsGeom;
             if ( jtsMultiLineString.getNumGeometries() > 0 ) {
                 List<LineString> members = new ArrayList<LineString>( jtsMultiLineString.getNumGeometries() );
                 for ( int i = 0; i < jtsMultiLineString.getNumGeometries(); i++ ) {
@@ -391,8 +391,8 @@ public abstract class AbstractDefaultGeometry implements Geometry {
                 }
                 geom = new DefaultMultiLineString( null, crs, pm, members );
             }
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.MultiPolygon ) {
-            com.vividsolutions.jts.geom.MultiPolygon jtsMultiPolygon = (com.vividsolutions.jts.geom.MultiPolygon) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.MultiPolygon ) {
+            org.locationtech.jts.geom.MultiPolygon jtsMultiPolygon = (org.locationtech.jts.geom.MultiPolygon) jtsGeom;
             if ( jtsMultiPolygon.getNumGeometries() > 0 ) {
                 List<Polygon> members = new ArrayList<Polygon>( jtsMultiPolygon.getNumGeometries() );
                 for ( int i = 0; i < jtsMultiPolygon.getNumGeometries(); i++ ) {
@@ -400,8 +400,8 @@ public abstract class AbstractDefaultGeometry implements Geometry {
                 }
                 geom = new DefaultMultiPolygon( null, crs, pm, members );
             }
-        } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.GeometryCollection ) {
-            com.vividsolutions.jts.geom.GeometryCollection jtsGeometryCollection = (com.vividsolutions.jts.geom.GeometryCollection) jtsGeom;
+        } else if ( jtsGeom instanceof org.locationtech.jts.geom.GeometryCollection ) {
+            org.locationtech.jts.geom.GeometryCollection jtsGeometryCollection = (org.locationtech.jts.geom.GeometryCollection) jtsGeom;
             if ( jtsGeometryCollection.getNumGeometries() > 0 ) {
                 List<Geometry> members = new ArrayList<Geometry>( jtsGeometryCollection.getNumGeometries() );
                 for ( int i = 0; i < jtsGeometryCollection.getNumGeometries(); i++ ) {

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/DefaultEnvelope.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/DefaultEnvelope.java
@@ -49,7 +49,7 @@ import org.deegree.geometry.standard.primitive.DefaultPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vividsolutions.jts.geom.LinearRing;
+import org.locationtech.jts.geom.LinearRing;
 
 /**
  * Default implementation of {@link Envelope}.
@@ -202,7 +202,7 @@ public class DefaultEnvelope extends AbstractDefaultGeometry implements Envelope
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.Polygon buildJTSGeometry() {
+    protected org.locationtech.jts.geom.Polygon buildJTSGeometry() {
         Points points = new PackedPoints( crs, new double[] { min.get0(), min.get1(), max.get0(), min.get1(),
                                                              max.get0(), max.get1(), min.get0(), max.get1(),
                                                              min.get0(), min.get1() }, 2 );

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/JTSGeometryPair.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/JTSGeometryPair.java
@@ -38,7 +38,7 @@ package org.deegree.geometry.standard;
 
 import org.deegree.commons.utils.Pair;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 /**
  * Stores a pair of JTS geometries.

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/composite/DefaultCompositeCurve.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/composite/DefaultCompositeCurve.java
@@ -57,7 +57,7 @@ import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.points.PointsPoints;
 import org.deegree.geometry.standard.primitive.DefaultLineString;
 
-import com.vividsolutions.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiLineString;
 
 /**
  * Default implementation of {@link CompositeCurve}.
@@ -146,10 +146,10 @@ public class DefaultCompositeCurve extends AbstractDefaultGeometry implements Co
 
     @Override
     protected MultiLineString buildJTSGeometry() {
-        com.vividsolutions.jts.geom.LineString [] jtsMembers = new com.vividsolutions.jts.geom.LineString[size()];
+        org.locationtech.jts.geom.LineString [] jtsMembers = new org.locationtech.jts.geom.LineString[size()];
         int i = 0;
         for ( Curve geometry : memberCurves ) {
-            jtsMembers[i++] = (com.vividsolutions.jts.geom.LineString) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            jtsMembers[i++] = (org.locationtech.jts.geom.LineString) getAsDefaultGeometry( geometry ).getJTSGeometry();
         }
         return jtsFactory.createMultiLineString( jtsMembers );
     }    

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/composite/DefaultCompositeGeometry.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/composite/DefaultCompositeGeometry.java
@@ -47,7 +47,7 @@ import org.deegree.geometry.precision.PrecisionModel;
 import org.deegree.geometry.primitive.GeometricPrimitive;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 
-import com.vividsolutions.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryCollection;
 
 /**
  * Default implementation of {@link CompositeGeometry}.
@@ -182,7 +182,7 @@ public class DefaultCompositeGeometry extends AbstractDefaultGeometry implements
 
     @Override
     protected GeometryCollection buildJTSGeometry() {
-        com.vividsolutions.jts.geom.Geometry[] jtsMembers = new com.vividsolutions.jts.geom.Geometry[size()];
+        org.locationtech.jts.geom.Geometry[] jtsMembers = new org.locationtech.jts.geom.Geometry[size()];
         int i = 0;
         for ( Geometry geometry : memberPrimitives ) {
             jtsMembers[i++] = getAsDefaultGeometry( geometry ).getJTSGeometry();

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/composite/DefaultCompositeSurface.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/composite/DefaultCompositeSurface.java
@@ -129,11 +129,11 @@ public class DefaultCompositeSurface extends AbstractDefaultGeometry implements 
 
     
     @Override
-    protected com.vividsolutions.jts.geom.MultiPolygon buildJTSGeometry() {
-        com.vividsolutions.jts.geom.Polygon [] jtsMembers = new com.vividsolutions.jts.geom.Polygon[size()];
+    protected org.locationtech.jts.geom.MultiPolygon buildJTSGeometry() {
+        org.locationtech.jts.geom.Polygon [] jtsMembers = new org.locationtech.jts.geom.Polygon[size()];
         int i = 0;
         for ( Surface geometry : memberSurfaces ) {
-            jtsMembers[i++] = (com.vividsolutions.jts.geom.Polygon) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            jtsMembers[i++] = (org.locationtech.jts.geom.Polygon) getAsDefaultGeometry( geometry ).getJTSGeometry();
         }
         return jtsFactory.createMultiPolygon( jtsMembers );
     }    

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiCurve.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiCurve.java
@@ -42,8 +42,8 @@ import org.deegree.geometry.multi.MultiCurve;
 import org.deegree.geometry.precision.PrecisionModel;
 import org.deegree.geometry.primitive.Curve;
 
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
 
 /**
  * Default implementation of {@link MultiCurve}.

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiGeometry.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiGeometry.java
@@ -47,7 +47,7 @@ import org.deegree.geometry.multi.MultiGeometry;
 import org.deegree.geometry.precision.PrecisionModel;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 
-import com.vividsolutions.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryCollection;
 
 /**
  * Default implementation of {@link MultiGeometry}.
@@ -92,7 +92,7 @@ public class DefaultMultiGeometry<T extends Geometry> extends AbstractDefaultGeo
 
     @Override
     protected GeometryCollection buildJTSGeometry() {
-        com.vividsolutions.jts.geom.Geometry[] jtsMembers = new com.vividsolutions.jts.geom.Geometry[size()];
+        org.locationtech.jts.geom.Geometry[] jtsMembers = new org.locationtech.jts.geom.Geometry[size()];
         int i = 0;
         for ( Geometry geometry : members ) {
             jtsMembers[i++] = getAsDefaultGeometry( geometry ).getJTSGeometry();

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiLineString.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiLineString.java
@@ -84,11 +84,11 @@ public class DefaultMultiLineString extends DefaultMultiGeometry<LineString> imp
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.MultiLineString buildJTSGeometry() {
-        com.vividsolutions.jts.geom.LineString[] jtsMembers = new com.vividsolutions.jts.geom.LineString[size()];
+    protected org.locationtech.jts.geom.MultiLineString buildJTSGeometry() {
+        org.locationtech.jts.geom.LineString[] jtsMembers = new org.locationtech.jts.geom.LineString[size()];
         int i = 0;
         for ( Curve geometry : members ) {
-            jtsMembers[i++] = (com.vividsolutions.jts.geom.LineString) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            jtsMembers[i++] = (org.locationtech.jts.geom.LineString) getAsDefaultGeometry( geometry ).getJTSGeometry();
         }
         return jtsFactory.createMultiLineString( jtsMembers );
     }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiPoint.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiPoint.java
@@ -78,11 +78,11 @@ public class DefaultMultiPoint extends DefaultMultiGeometry<Point> implements Mu
     }
     
     @Override
-    protected com.vividsolutions.jts.geom.MultiPoint buildJTSGeometry() {
-        com.vividsolutions.jts.geom.Point [] jtsMembers = new com.vividsolutions.jts.geom.Point[size()];
+    protected org.locationtech.jts.geom.MultiPoint buildJTSGeometry() {
+        org.locationtech.jts.geom.Point [] jtsMembers = new org.locationtech.jts.geom.Point[size()];
         int i = 0;
         for ( Point geometry : members ) {
-            jtsMembers[i++] = (com.vividsolutions.jts.geom.Point) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            jtsMembers[i++] = (org.locationtech.jts.geom.Point) getAsDefaultGeometry( geometry ).getJTSGeometry();
         }
         return jtsFactory.createMultiPoint( jtsMembers );
     }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiPolygon.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiPolygon.java
@@ -90,11 +90,11 @@ public class DefaultMultiPolygon extends DefaultMultiGeometry<Polygon> implement
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.MultiPolygon buildJTSGeometry() {
-        com.vividsolutions.jts.geom.Polygon[] jtsMembers = new com.vividsolutions.jts.geom.Polygon[size()];
+    protected org.locationtech.jts.geom.MultiPolygon buildJTSGeometry() {
+        org.locationtech.jts.geom.Polygon[] jtsMembers = new org.locationtech.jts.geom.Polygon[size()];
         int i = 0;
         for ( Surface geometry : members ) {
-            jtsMembers[i++] = (com.vividsolutions.jts.geom.Polygon) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            jtsMembers[i++] = (org.locationtech.jts.geom.Polygon) getAsDefaultGeometry( geometry ).getJTSGeometry();
         }
         return jtsFactory.createMultiPolygon( jtsMembers );
     }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiSurface.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiSurface.java
@@ -78,11 +78,11 @@ public class DefaultMultiSurface extends DefaultMultiGeometry<Surface> implement
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.MultiPolygon buildJTSGeometry() {
-        com.vividsolutions.jts.geom.Polygon[] jtsMembers = new com.vividsolutions.jts.geom.Polygon[size()];
+    protected org.locationtech.jts.geom.MultiPolygon buildJTSGeometry() {
+        org.locationtech.jts.geom.Polygon[] jtsMembers = new org.locationtech.jts.geom.Polygon[size()];
         int i = 0;
         for ( Surface geometry : members ) {
-            jtsMembers[i++] = (com.vividsolutions.jts.geom.Polygon) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            jtsMembers[i++] = (org.locationtech.jts.geom.Polygon) getAsDefaultGeometry( geometry ).getJTSGeometry();
         }
         return jtsFactory.createMultiPolygon( jtsMembers );
     }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/JTSPoints.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/JTSPoints.java
@@ -44,9 +44,9 @@ import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.standard.primitive.DefaultPoint;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 /**
  * {@link Points} implementation based on a JTS coordinate sequence.
@@ -211,6 +211,11 @@ public class JTSPoints implements Points {
 
     @Override
     public Object clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CoordinateSequence copy() {
         throw new UnsupportedOperationException();
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PackedPoints.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PackedPoints.java
@@ -43,8 +43,9 @@ import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.standard.primitive.DefaultPoint;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 /**
  * {@link Points} implementation based on a coordinate array.
@@ -208,6 +209,11 @@ public class PackedPoints implements Points {
 
     @Override
     public Object clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CoordinateSequence copy() {
         throw new UnsupportedOperationException();
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsArray.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsArray.java
@@ -42,8 +42,9 @@ import java.util.NoSuchElementException;
 import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Point;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 /**
  * <code>Array</code>-based {@link Points} implementation that allows to hold identifiable {@link Point} objects (with
@@ -201,5 +202,10 @@ public class PointsArray implements Points {
     @Override
     public Object clone() {
         return new PointsArray( Arrays.copyOf( points, points.length ) );
+    }
+
+    @Override
+    public CoordinateSequence copy() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsList.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsList.java
@@ -43,8 +43,9 @@ import org.deegree.commons.tom.Reference;
 import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Point;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 /**
  * <code>List</code>-based {@link Points} implementation that allows to hold identifiable {@link Point} objects (with id
@@ -203,6 +204,11 @@ public class PointsList implements Points {
     @Override
     public Object clone() {
         return new PointsList( new ArrayList<Point>( points ) );
+    }
+
+    @Override
+    public CoordinateSequence copy() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsPoints.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsPoints.java
@@ -43,8 +43,9 @@ import java.util.NoSuchElementException;
 import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Point;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 /**
  * {@link Points} implementation that aggregates the members from a sequence of {@link Points} objects.
@@ -215,6 +216,11 @@ public class PointsPoints implements Points {
 
     @Override
     public Object clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CoordinateSequence copy() {
         throw new UnsupportedOperationException();
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsSubsequence.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsSubsequence.java
@@ -42,8 +42,9 @@ import java.util.NoSuchElementException;
 import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Point;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 
 /**
  * {@link Points} implementation that aggregates the members from a sequence of {@link Points} objects.
@@ -187,6 +188,11 @@ public class PointsSubsequence implements Points {
 
     @Override
     public Object clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CoordinateSequence copy() {
         throw new UnsupportedOperationException();
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultCurve.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultCurve.java
@@ -60,7 +60,7 @@ import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.points.PointsPoints;
 import org.deegree.geometry.standard.points.PointsSubsequence;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Coordinate;
 
 /**
  * Default implementation of {@link Curve}.
@@ -109,7 +109,7 @@ public class DefaultCurve extends AbstractDefaultGeometry implements Curve {
     @Override
     public Measure getLength( Unit requestedUnit ) {
         // TODO respect requested unit
-        double length = ( (com.vividsolutions.jts.geom.LineString) getJTSGeometry() ).getLength();
+        double length = ( (org.locationtech.jts.geom.LineString) getJTSGeometry() ).getLength();
         return new Measure( Double.toString( length ), null );
     }
 
@@ -178,7 +178,7 @@ public class DefaultCurve extends AbstractDefaultGeometry implements Curve {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.LineString buildJTSGeometry() {
+    protected org.locationtech.jts.geom.LineString buildJTSGeometry() {
         CurveLinearizer linearizer = new CurveLinearizer( new GeometryFactory() );
         // TODO how to provide a linearization criterion?
         LinearizationCriterion crit = new NumPointsCriterion( 100 );

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultLineString.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultLineString.java
@@ -95,7 +95,7 @@ public class DefaultLineString extends DefaultCurve implements LineString {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.LineString buildJTSGeometry() {
+    protected org.locationtech.jts.geom.LineString buildJTSGeometry() {
         return jtsFactory.createLineString( singleSegment.getControlPoints() );
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultLinearRing.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultLinearRing.java
@@ -97,7 +97,7 @@ public class DefaultLinearRing extends DefaultRing implements LinearRing {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.LinearRing buildJTSGeometry() {
+    protected org.locationtech.jts.geom.LinearRing buildJTSGeometry() {
         return jtsFactory.createLinearRing( controlPoints );
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultOrientableCurve.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultOrientableCurve.java
@@ -270,7 +270,7 @@ public class DefaultOrientableCurve extends AbstractDefaultGeometry implements O
     }
 
     @Override
-    public com.vividsolutions.jts.geom.Geometry getJTSGeometry() {
+    public org.locationtech.jts.geom.Geometry getJTSGeometry() {
         // TODO Auto-generated method stub
         return null;
     }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultOrientableSurface.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultOrientableSurface.java
@@ -247,7 +247,7 @@ public class DefaultOrientableSurface extends AbstractDefaultGeometry implements
     }
 
     @Override
-    public com.vividsolutions.jts.geom.Geometry getJTSGeometry() {
+    public org.locationtech.jts.geom.Geometry getJTSGeometry() {
         // TODO Auto-generated method stub
         return null;
     }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultPoint.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultPoint.java
@@ -43,7 +43,7 @@ import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.DefaultEnvelope;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Coordinate;
 
 /**
  * Default implementation of {@link Point}.
@@ -158,7 +158,7 @@ public class DefaultPoint extends AbstractDefaultGeometry implements Point {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.Point buildJTSGeometry() {
+    protected org.locationtech.jts.geom.Point buildJTSGeometry() {
         Coordinate coords = null;
         if ( coordinates.length == 2 ) {
             coords = new Coordinate( coordinates[0], coordinates[1] );

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultPolygon.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultPolygon.java
@@ -48,7 +48,7 @@ import org.deegree.geometry.primitive.Ring.RingType;
 import org.deegree.geometry.primitive.patches.PolygonPatch;
 import org.deegree.geometry.standard.surfacepatches.DefaultPolygonPatch;
 
-import com.vividsolutions.jts.geom.LinearRing;
+import org.locationtech.jts.geom.LinearRing;
 
 /**
  * Default implementation of {@link Polygon}.
@@ -129,7 +129,7 @@ public class DefaultPolygon extends DefaultSurface implements Polygon {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.Geometry buildJTSGeometry() {
+    protected org.locationtech.jts.geom.Geometry buildJTSGeometry() {
         LinearRing shell = (LinearRing) getAsDefaultGeometry( exteriorRing ).getJTSGeometry();
         LinearRing[] holes = null;
         if ( interiorRings != null ) {

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultRing.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultRing.java
@@ -63,7 +63,7 @@ import org.deegree.geometry.primitive.segments.LineStringSegment;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 import org.deegree.geometry.standard.points.PointsPoints;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Coordinate;
 
 /**
  * Default implementation of {@link Ring}.
@@ -184,7 +184,7 @@ public class DefaultRing extends AbstractDefaultGeometry implements Ring {
     @Override
     public Measure getLength( Unit requestedUnit ) {
         // TODO respect requested unit
-        double length = ( (com.vividsolutions.jts.geom.LineString) getJTSGeometry() ).getLength();
+        double length = ( (org.locationtech.jts.geom.LineString) getJTSGeometry() ).getLength();
         return new Measure( Double.toString( length ), null );
     }
 
@@ -236,7 +236,7 @@ public class DefaultRing extends AbstractDefaultGeometry implements Ring {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.LinearRing buildJTSGeometry() {
+    protected org.locationtech.jts.geom.LinearRing buildJTSGeometry() {
         CurveLinearizer linearizer = new CurveLinearizer( new GeometryFactory() );
         // TODO how to determine a feasible linearization criterion?
         LinearizationCriterion crit = new NumPointsCriterion( 100 );

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultSurface.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultSurface.java
@@ -53,9 +53,9 @@ import org.deegree.geometry.primitive.patches.PolygonPatch;
 import org.deegree.geometry.primitive.patches.SurfacePatch;
 import org.deegree.geometry.standard.AbstractDefaultGeometry;
 
-import com.vividsolutions.jts.algorithm.InteriorPointArea;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.LinearRing;
+import org.locationtech.jts.algorithm.InteriorPointArea;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LinearRing;
 
 /**
  * Default implementation of {@link Surface}.
@@ -161,7 +161,7 @@ public class DefaultSurface extends AbstractDefaultGeometry implements Surface {
     }
 
     @Override
-    protected com.vividsolutions.jts.geom.Geometry buildJTSGeometry() {
+    protected org.locationtech.jts.geom.Geometry buildJTSGeometry() {
 
         if ( patches.size() < 1 || !( patches.get( 0 ) instanceof PolygonPatch ) ) {
             throw new IllegalArgumentException( Messages.getMessage( "SURFACE_NOT_EQUIVALENT_TO_POLYGON" ) );

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/GeometryValidator.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/GeometryValidator.java
@@ -72,13 +72,13 @@ import org.deegree.geometry.validation.event.RingNotClosed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vividsolutions.jts.algorithm.CGAlgorithms;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.operation.IsSimpleOp;
+import org.locationtech.jts.algorithm.CGAlgorithms;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.operation.IsSimpleOp;
 
 /**
  * Performs topological validation of {@link Geometry} objects.
@@ -361,7 +361,7 @@ public class GeometryValidator {
             LOG.debug( "Surface patch. Validating spatial relations between exterior ring and interior rings." );
             for ( int ringIdx = 0; ringIdx < interiorJTSRings.size(); ringIdx++ ) {
                 LinearRing interiorJTSRing = interiorJTSRings.get( ringIdx );
-                com.vividsolutions.jts.geom.Geometry intersection = interiorJTSRing.intersection( exteriorJTSRing );
+                org.locationtech.jts.geom.Geometry intersection = interiorJTSRing.intersection( exteriorJTSRing );
                 if ( !intersection.isEmpty() ) {
                     LOG.debug( "Exterior ring intersects interior ring." );
                     Point location = getPoint( intersection.getCoordinate(), null );
@@ -400,7 +400,7 @@ public class GeometryValidator {
                     }
                     LinearRing interior1JTSRing = interiorJTSRings.get( ring1Idx );
                     LinearRing interior2JTSRing = interiorJTSRings.get( ring2Idx );
-                    com.vividsolutions.jts.geom.Geometry intersection = interior1JTSRing.intersection( interior2JTSRing );
+                    org.locationtech.jts.geom.Geometry intersection = interior1JTSRing.intersection( interior2JTSRing );
                     if ( !intersection.isEmpty() ) {
                         LOG.debug( "Interior ring intersects interior ring." );
                         Point location = getPoint( intersection.getCoordinate(), null );
@@ -433,7 +433,7 @@ public class GeometryValidator {
         return isValid;
     }
 
-    private boolean isSinglePoint( com.vividsolutions.jts.geom.Geometry intersection ) {
+    private boolean isSinglePoint( org.locationtech.jts.geom.Geometry intersection ) {
         System.out.println (intersection);
         if ( intersection.getNumGeometries() != 1 ) {
             return false;

--- a/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization/CurveLinearizerTest.java
+++ b/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization/CurveLinearizerTest.java
@@ -62,12 +62,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.impl.CoordinateArraySequence;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * Tests for {@link CurveLinearizer}.

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
@@ -35,6 +35,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/test/java/org/deegree/protocol/wps/client/WPSClientTest.java
@@ -35,8 +35,8 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.protocol.wps.client;
 
-import static com.vividsolutions.jts.io.gml2.GMLConstants.GML_NAMESPACE;
-import static com.vividsolutions.jts.io.gml2.GMLConstants.GML_PREFIX;
+import static org.locationtech.jts.io.gml2.GMLConstants.GML_NAMESPACE;
+import static org.locationtech.jts.io.gml2.GMLConstants.GML_PREFIX;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;

--- a/deegree-core/deegree-core-rendering-2d/pom.xml
+++ b/deegree-core/deegree-core-rendering-2d/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>jai-mlibwrapper</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/GeometryClipper.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/GeometryClipper.java
@@ -140,8 +140,8 @@ class GeometryClipper {
                 if ( clippedGeometry == null ) {
                     return null;
                 }
-                com.vividsolutions.jts.geom.Geometry jtsOrig = ( (AbstractDefaultGeometry) geom ).getJTSGeometry();
-                com.vividsolutions.jts.geom.Geometry jtsClipped = ( (AbstractDefaultGeometry) clippedGeometry ).getJTSGeometry();
+                org.locationtech.jts.geom.Geometry jtsOrig = ( (AbstractDefaultGeometry) geom ).getJTSGeometry();
+                org.locationtech.jts.geom.Geometry jtsClipped = ( (AbstractDefaultGeometry) clippedGeometry ).getJTSGeometry();
                 if ( jtsOrig == jtsClipped ) {
                     return geom;
                 }
@@ -168,24 +168,24 @@ class GeometryClipper {
      * @param   jtsGeom   JTS Geometry to be evaluated
      * @return  boolean   true if (first) Geometry is Polygon with CW external ring, false otherwise
      */
-    private boolean isInvertedOrientation( com.vividsolutions.jts.geom.Geometry jtsGeom ) {
-        com.vividsolutions.jts.geom.Polygon poly = null;
+    private boolean isInvertedOrientation( org.locationtech.jts.geom.Geometry jtsGeom ) {
+        org.locationtech.jts.geom.Polygon poly = null;
         try {
-            if ( jtsGeom instanceof com.vividsolutions.jts.geom.GeometryCollection && //
-                 ( (com.vividsolutions.jts.geom.GeometryCollection) jtsGeom ).getNumGeometries() > 0 ) {
-                com.vividsolutions.jts.geom.Geometry firstGeom;
-                firstGeom = ( (com.vividsolutions.jts.geom.GeometryCollection) jtsGeom ).getGeometryN( 0 );
-                if ( firstGeom instanceof com.vividsolutions.jts.geom.Polygon ) {
-                    poly = (com.vividsolutions.jts.geom.Polygon) firstGeom;
+            if ( jtsGeom instanceof org.locationtech.jts.geom.GeometryCollection && //
+                 ( (org.locationtech.jts.geom.GeometryCollection) jtsGeom ).getNumGeometries() > 0 ) {
+                org.locationtech.jts.geom.Geometry firstGeom;
+                firstGeom = ( (org.locationtech.jts.geom.GeometryCollection) jtsGeom ).getGeometryN( 0 );
+                if ( firstGeom instanceof org.locationtech.jts.geom.Polygon ) {
+                    poly = (org.locationtech.jts.geom.Polygon) firstGeom;
                 }
-            } else if ( jtsGeom instanceof com.vividsolutions.jts.geom.Polygon ) {
-                poly = (com.vividsolutions.jts.geom.Polygon) jtsGeom;
+            } else if ( jtsGeom instanceof org.locationtech.jts.geom.Polygon ) {
+                poly = (org.locationtech.jts.geom.Polygon) jtsGeom;
             }
         
             //TRICKY check if polygon exterior is CW
             if ( poly != null ) {
-                com.vividsolutions.jts.geom.Coordinate[] coords = poly.getExteriorRing().getCoordinates();
-                if ( !com.vividsolutions.jts.algorithm.CGAlgorithms.isCCW( coords ) ) {
+                org.locationtech.jts.geom.Coordinate[] coords = poly.getExteriorRing().getCoordinates();
+                if ( !org.locationtech.jts.algorithm.CGAlgorithms.isCCW( coords ) ) {
                     return true;
                 }
             }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/OrientationFixer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/OrientationFixer.java
@@ -41,7 +41,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.rendering.r2d;
 
-import static com.vividsolutions.jts.algorithm.CGAlgorithms.isCCW;
+import static org.locationtech.jts.algorithm.CGAlgorithms.isCCW;
 import static org.deegree.geometry.primitive.GeometricPrimitive.PrimitiveType.Surface;
 import static org.deegree.geometry.primitive.Ring.RingType.LinearRing;
 import static org.deegree.geometry.primitive.Surface.SurfaceType.Polygon;
@@ -63,8 +63,8 @@ import org.deegree.geometry.standard.multi.DefaultMultiPolygon;
 import org.deegree.geometry.standard.multi.DefaultMultiSurface;
 import org.deegree.geometry.standard.primitive.DefaultPolygon;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LinearRing;
 
 /**
  * Responsible for fixing geometry orientation (ring orientations of polygons).

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/labelplacement/PointLabelPositionOptions.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/labelplacement/PointLabelPositionOptions.java
@@ -45,8 +45,8 @@ import org.deegree.style.styling.TextStyling;
 import org.deegree.style.utils.UomCalculator;
 import org.slf4j.Logger;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Polygon;
 
 
 /**
@@ -64,7 +64,7 @@ public class PointLabelPositionOptions {
 
     
     private static final Logger LOG = getLogger( PointLabelPositionOptions.class );
-    protected final static com.vividsolutions.jts.geom.GeometryFactory jtsFactory = new com.vividsolutions.jts.geom.GeometryFactory();
+    protected final static org.locationtech.jts.geom.GeometryFactory jtsFactory = new org.locationtech.jts.geom.GeometryFactory();
     
     /**
      * Some constants, describing the 8 possible positions of the label and their qualities.

--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/GeometryClipperTest.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/GeometryClipperTest.java
@@ -49,7 +49,7 @@ import org.deegree.geometry.io.WKTReader;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * Test cases for {@link GeometryClipper}.

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
@@ -59,6 +59,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
@@ -832,7 +832,7 @@ public class SDOGeometryConverter {
         return elem_info;
     }
 
-    private void addCoordinate( List<Point> pnts, ICRS crs, com.vividsolutions.jts.geom.Coordinate coord ) {
+    private void addCoordinate( List<Point> pnts, ICRS crs, org.locationtech.jts.geom.Coordinate coord ) {
         if ( Double.isNaN( coord.z ) ) {
             pnts.add( _gf.createPoint( null, coord.x, coord.y, crs ) );
         } else {
@@ -841,59 +841,59 @@ public class SDOGeometryConverter {
     }
 
     private int buildJTSGeometry( List<Triplet> info, List<Point> pnts, ICRS crs,
-                                  com.vividsolutions.jts.geom.Geometry geom ) {
+                                  org.locationtech.jts.geom.Geometry geom ) {
         int gtyp = SDOGTypeTT.UNKNOWN;
 
-        if ( geom instanceof com.vividsolutions.jts.geom.Point ) {
-            buildJTSPoint( info, pnts, crs, (com.vividsolutions.jts.geom.Point) geom );
+        if ( geom instanceof org.locationtech.jts.geom.Point ) {
+            buildJTSPoint( info, pnts, crs, (org.locationtech.jts.geom.Point) geom );
             gtyp = SDOGTypeTT.POINT;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.LinearRing ) {
-            buildJTSLineString( info, pnts, crs, (com.vividsolutions.jts.geom.LineString) geom,
+        } else if ( geom instanceof org.locationtech.jts.geom.LinearRing ) {
+            buildJTSLineString( info, pnts, crs, (org.locationtech.jts.geom.LineString) geom,
                                 SDOEType.POLYGON_RING_EXTERIOR );
             gtyp = SDOGTypeTT.POLYGON;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.LineString ) {
-            buildJTSLineString( info, pnts, crs, (com.vividsolutions.jts.geom.LineString) geom, SDOEType.LINESTRING );
+        } else if ( geom instanceof org.locationtech.jts.geom.LineString ) {
+            buildJTSLineString( info, pnts, crs, (org.locationtech.jts.geom.LineString) geom, SDOEType.LINESTRING );
             gtyp = SDOGTypeTT.LINE;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.Polygon ) {
-            com.vividsolutions.jts.geom.Polygon polygon = (com.vividsolutions.jts.geom.Polygon) geom;
+        } else if ( geom instanceof org.locationtech.jts.geom.Polygon ) {
+            org.locationtech.jts.geom.Polygon polygon = (org.locationtech.jts.geom.Polygon) geom;
             buildJTSLineString( info, pnts, crs, polygon.getExteriorRing(), SDOEType.POLYGON_RING_EXTERIOR );
             for ( int i = 0, j = polygon.getNumInteriorRing(); i < j; i++ ) {
                 buildJTSLineString( info, pnts, crs, polygon.getInteriorRingN( i ), SDOEType.POLYGON_RING_INTERIOR );
             }
             gtyp = SDOGTypeTT.POLYGON;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.MultiPoint ) {
+        } else if ( geom instanceof org.locationtech.jts.geom.MultiPoint ) {
             for ( int m = 0, n = geom.getNumGeometries(); m < n; m++ ) {
-                buildJTSPoint( info, pnts, crs, (com.vividsolutions.jts.geom.Point) geom.getGeometryN( m ) );
+                buildJTSPoint( info, pnts, crs, (org.locationtech.jts.geom.Point) geom.getGeometryN( m ) );
             }
             gtyp = SDOGTypeTT.MULTIPOINT;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.MultiLineString ) {
+        } else if ( geom instanceof org.locationtech.jts.geom.MultiLineString ) {
             for ( int m = 0, n = geom.getNumGeometries(); m < n; m++ ) {
-                buildJTSLineString( info, pnts, crs, (com.vividsolutions.jts.geom.LineString) geom.getGeometryN( m ),
+                buildJTSLineString( info, pnts, crs, (org.locationtech.jts.geom.LineString) geom.getGeometryN( m ),
                                     SDOEType.LINESTRING );
             }
             gtyp = SDOGTypeTT.MULTILINE;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.MultiPolygon ) {
-            com.vividsolutions.jts.geom.Polygon polygon = null;
+        } else if ( geom instanceof org.locationtech.jts.geom.MultiPolygon ) {
+            org.locationtech.jts.geom.Polygon polygon = null;
             for ( int m = 0, n = geom.getNumGeometries(); m < n; m++ ) {
-                polygon = (com.vividsolutions.jts.geom.Polygon) geom.getGeometryN( m );
+                polygon = (org.locationtech.jts.geom.Polygon) geom.getGeometryN( m );
                 buildJTSLineString( info, pnts, crs, polygon.getExteriorRing(), SDOEType.POLYGON_RING_EXTERIOR );
                 for ( int i = 0, j = polygon.getNumInteriorRing(); i < j; i++ ) {
                     buildJTSLineString( info, pnts, crs, polygon.getInteriorRingN( i ), SDOEType.POLYGON_RING_INTERIOR );
                 }
             }
             gtyp = SDOGTypeTT.MULTIPOLYGON;
-        } else if ( geom instanceof com.vividsolutions.jts.geom.GeometryCollection ) {
-            com.vividsolutions.jts.geom.Geometry subgeom = null;
+        } else if ( geom instanceof org.locationtech.jts.geom.GeometryCollection ) {
+            org.locationtech.jts.geom.Geometry subgeom = null;
             for ( int m = 0, n = geom.getNumGeometries(); m < n; m++ ) {
                 subgeom = geom.getGeometryN( m );
 
-                if ( subgeom instanceof com.vividsolutions.jts.geom.Point
-                     || subgeom instanceof com.vividsolutions.jts.geom.LinearRing
-                     || subgeom instanceof com.vividsolutions.jts.geom.LineString
-                     || subgeom instanceof com.vividsolutions.jts.geom.Polygon
-                     || subgeom instanceof com.vividsolutions.jts.geom.MultiPoint
-                     || subgeom instanceof com.vividsolutions.jts.geom.MultiLineString
-                     || subgeom instanceof com.vividsolutions.jts.geom.MultiPolygon ) {
+                if ( subgeom instanceof org.locationtech.jts.geom.Point
+                     || subgeom instanceof org.locationtech.jts.geom.LinearRing
+                     || subgeom instanceof org.locationtech.jts.geom.LineString
+                     || subgeom instanceof org.locationtech.jts.geom.Polygon
+                     || subgeom instanceof org.locationtech.jts.geom.MultiPoint
+                     || subgeom instanceof org.locationtech.jts.geom.MultiLineString
+                     || subgeom instanceof org.locationtech.jts.geom.MultiPolygon ) {
                     // only non cascading types
                     buildJTSGeometry( info, pnts, crs, subgeom );
                 } else {
@@ -909,15 +909,15 @@ public class SDOGeometryConverter {
         return gtyp;
     }
 
-    private void buildJTSPoint( List<Triplet> info, List<Point> pnts, ICRS crs, com.vividsolutions.jts.geom.Point geom ) {
+    private void buildJTSPoint( List<Triplet> info, List<Point> pnts, ICRS crs, org.locationtech.jts.geom.Point geom ) {
         info.add( new Triplet( pnts.size(), 1, 1 ) );
-        addCoordinate( pnts, crs, ( (com.vividsolutions.jts.geom.Point) geom ).getCoordinate() );
+        addCoordinate( pnts, crs, ( (org.locationtech.jts.geom.Point) geom ).getCoordinate() );
     }
 
     private void buildJTSLineString( List<Triplet> info, List<Point> pnts, ICRS crs,
-                                     com.vividsolutions.jts.geom.LineString geom, int etype ) {
+                                     org.locationtech.jts.geom.LineString geom, int etype ) {
         info.add( new Triplet( pnts.size(), etype, 1 ) );
-        for ( com.vividsolutions.jts.geom.Coordinate coord : geom.getCoordinates() ) {
+        for ( org.locationtech.jts.geom.Coordinate coord : geom.getCoordinates() ) {
             addCoordinate( pnts, crs, coord );
         }
     }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>deegree-featurestore-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/SHPReader.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/SHPReader.java
@@ -76,8 +76,8 @@ import org.deegree.geometry.standard.points.PackedPoints;
 import org.deegree.geometry.standard.points.PointsList;
 import org.slf4j.Logger;
 
-import com.vividsolutions.jts.algorithm.CGAlgorithms;
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.algorithm.CGAlgorithms;
+import org.locationtech.jts.geom.Coordinate;
 
 /**
  * <code>SHPReader</code>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>deegree-core-db</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/src/main/java/org/deegree/feature/persistence/simplesql/SimpleSQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/src/main/java/org/deegree/feature/persistence/simplesql/SimpleSQLFeatureStore.java
@@ -94,7 +94,7 @@ import org.deegree.workspace.Resource;
 import org.deegree.workspace.ResourceMetadata;
 import org.slf4j.Logger;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * {@link FeatureStore} implementation that is backed by an SQL database and configured by providing an SQL statement /

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
@@ -49,6 +49,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/EbrimEOMDStoreTransaction.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/EbrimEOMDStoreTransaction.java
@@ -93,7 +93,7 @@ import org.deegree.sqldialect.postgis.PostGISWhereBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.io.ParseException;
 
 /**
  * {@link MetadataStoreTransaction} implementation for the {@link EbrimEOMDStore}.

--- a/deegree-tools/deegree-tools-3d/pom.xml
+++ b/deegree-tools/deegree-tools-3d/pom.xml
@@ -47,6 +47,10 @@
       <artifactId>java3d-vrml97</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.deegree</groupId>
       <artifactId>deegree-services-wpvs</artifactId>
       <version>${project.version}</version>

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/generalisation/WorldObjectSimplifier.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/generalisation/WorldObjectSimplifier.java
@@ -50,12 +50,12 @@ import org.deegree.rendering.r3d.opengl.rendering.model.geometry.WorldRenderable
 import org.deegree.rendering.r3d.opengl.rendering.model.prototype.PrototypeReference;
 import org.deegree.rendering.r3d.opengl.tesselation.Tesselator;
 
-import com.vividsolutions.jts.algorithm.ConvexHull;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.simplify.DouglasPeuckerSimplifier;
+import org.locationtech.jts.algorithm.ConvexHull;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
 /**
  * This class simplifies a 3D-Object. Two different simplifications will be performed. The first one create a simplified
@@ -213,7 +213,7 @@ public class WorldObjectSimplifier {
         Coordinate[] coordinates = projectToPlane( rqm );
 
         // calculate convex hull using JTS
-        ConvexHull ch = new ConvexHull( coordinates, new com.vividsolutions.jts.geom.GeometryFactory() );
+        ConvexHull ch = new ConvexHull( coordinates, new org.locationtech.jts.geom.GeometryFactory() );
         Geometry dp = DouglasPeuckerSimplifier.simplify( ch.getConvexHull(), 0.1 );
         if ( dp instanceof Polygon ) {
             return ( (Polygon) dp ).getExteriorRing().getCoordinates();

--- a/pom.xml
+++ b/pom.xml
@@ -933,9 +933,9 @@
       </dependency>
       <!-- other -->
       <dependency>
-        <groupId>com.vividsolutions</groupId>
-        <artifactId>jts</artifactId>
-        <version>1.13</version>
+        <groupId>org.locationtech.jts</groupId>
+        <artifactId>jts-core</artifactId>
+        <version>1.16.0</version>
       </dependency>
       <dependency>
         <groupId>jgridshift</groupId>


### PR DESCRIPTION
This PR migrates JTS from version 1.13 to 1.16.0 following the migration guidelines from JTS as described in https://github.com/locationtech/jts/blob/master/MIGRATION.md.
Furthermore the PR fixes the missing definition for compile dependencies in some sub-modules.