### PR TITLE
Updated legal section in Contribution Guidelines

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -184,6 +184,65 @@ code. For the committer themselves understanding about the license is hopefully 
 committer should verify the understanding unless the committer is very comfortable that the contributor understands the 
 license (for instance frequent contributors).
 
-All committers are responsible for having read, and understood this document. And please confirm acceptance to these 
+If the contribution was developed on behalf of an employer (on work time, as part of a work project, etc) then it is 
+important that an appropriate representative of the employer understand that the code will be contributed under the 
+LGPL license. The arrangement should be cleared with an authorized supervisor, manager, or director.
+
+The code should be developed by the contributor, or the code should be from a source which can be rightfully contributed
+such as from the public domain, or from an open source project under a compatible license. All unusual situations need 
+to be discussed with the committee members and documented.
+
+Committers should adhere to the following guidelines, and may be personally legally liable for improperly contributing 
+code to the source repository:
+
+- Make sure the contributor (and possibly employer) is aware of the contribution terms.
+- Code coming from a source other than the contributor (such as adapted from another project) should be clearly marked 
+as to the original source, copyright holders, license terms and so forth. This information can be in the file headers, 
+but should also be added to the project licensing file if not exactly matching normal project licensing (LICENSE.txt).
+- Existing copyright headers and license text should never be stripped from a file. If a copyright holder wishes to give
+ up copyright they must do so in writing to the committees before copyright messages are removed. If license terms are 
+ changed it has to be by agreement (written in email is ok) of the copyright holders.
+- Code with licenses requiring credit, or disclosure to users should be added to LICENSE.TXT.
+- When substantial contributions are added to a file (such as substantial patches) the author/contributor should be added
+ to the list of copyright holders for the file.
+- If there is uncertainty about whether a change it proper to contribute to the code base, please seek more information 
+from the project steering committee, or the OSGeo foundation legal counsel.
+
+All committers are responsible for having read, and understood this document. And confirm acceptance to these 
 guidelines by sending an email to the mailing list with subject `Committer guidelines acceptance` and body 
 `I hereby accept the deegree committer guidelines. <Date> <Your Full Name>`.
+
+## Copyright holders
+
+The following list of committers (alphabetical order) will be considered as authorized deegree committers and copyright holders:
+- Andrei Aiordachioaie
+- Rutger Bezema
+- Florian Bingel
+- Reijer Copier
+- Alexander Erben
+- Lyn Goltz
+- Sebastian Goerke
+- Torsten Friebe
+- Jerry Huxtable
+- Andrei Ionita
+- Christian Kiehle
+- Ulrich Neumeister
+- Mike Nidel
+- Sebastian Niklasch
+- Jens Pabel
+- Alexander Padberg
+- Andreas Poth
+- Rammi aka Andreas M. Rammelt
+- Stephan Reichhelm
+- Andreas Schmitz
+- Markus Schneider
+- Dirk Stenger
+- Jason R. Surratt
+- Ugo Taddei
+- Steffen Thomas
+- Oliver Tonnhofer
+- Sven Tschirner
+- Georg Walenciak
+- Jeronimo Wanhoff
+- Juergen Weichand
+- Johannes Wilden

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -212,37 +212,3 @@ All committers are responsible for having read, and understood this document. An
 guidelines by sending an email to the mailing list with subject `Committer guidelines acceptance` and body 
 `I hereby accept the deegree committer guidelines. <Date> <Your Full Name>`.
 
-## Copyright holders
-
-The following list of committers (alphabetical order) will be considered as authorized deegree committers and copyright holders:
-- Andrei Aiordachioaie
-- Rutger Bezema
-- Florian Bingel
-- Reijer Copier
-- Alexander Erben
-- Lyn Goltz
-- Sebastian Goerke
-- Torsten Friebe
-- Jerry Huxtable
-- Andrei Ionita
-- Christian Kiehle
-- Ulrich Neumeister
-- Mike Nidel
-- Sebastian Niklasch
-- Jens Pabel
-- Alexander Padberg
-- Andreas Poth
-- Rammi aka Andreas M. Rammelt
-- Stephan Reichhelm
-- Andreas Schmitz
-- Markus Schneider
-- Dirk Stenger
-- Jason R. Surratt
-- Ugo Taddei
-- Steffen Thomas
-- Oliver Tonnhofer
-- Sven Tschirner
-- Georg Walenciak
-- Jeronimo Wanhoff
-- Juergen Weichand
-- Johannes Wilden

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,51 @@
+# List of contributors
+
+The following list shows in alphabetical order individuals who have contributed to deegree:
+- Andrei Aiordachioaie
+- D. Baum
+- Rutger Bezema
+- Florian Bingel
+- Danilo Bretschneider
+- Reijer Copier
+- Alexander Erben
+- Lyn Goltz
+- Sebastian Goerke
+- Volker Grabsch
+- Torsten Friebe
+- Jerry Huxtable
+- Andrei Ionita
+- Mats Isakson
+- Christian Kiehle
+- Martin W. Kirst
+- Johannes Küpper
+- Anne Loos
+- Matteo Matassoni
+- Diego Migliavacca
+- Ulrich Neumeister
+- Mike Nidel
+- Sebastian Niklasch
+- Jens Pabel
+- Alexander Padberg
+- Jarle Pedersen
+- Andreas Poth
+- Rammi aka Andreas M. Rammelt
+- Stephan Reichhelm
+- Lena Rippolz
+- Hanko Rubach
+- Andreas Schmitz
+- Markus Schneider
+- Paul Sohier
+- Dirk Stenger
+- Jason R. Surratt
+- Ugo Taddei
+- Carmen Tawalika
+- Steffen Thomas
+- Oliver Tonnhofer
+- Sven Tschirner
+- Jeroen van der Vegt
+- Martin Vieweg
+- Jeroen ter Voorde
+- Georg Walenciak
+- Jeronimo Wanhoff
+- Juergen Weichand
+- Johannes Wilden

--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ More information about free software can be found at the free software foundatio
 
 First off all, thank you for taking the time to contribute to deegree! :+1: :tada:
 
-By participating you are expected to uphold the [Contribution guidelines](CONTRIB.md). 
+By participating you are expected to uphold the [Contribution guidelines](CONTRIB.md).
+
+You can add yourself when contributing to the project to the [list of contributors](CONTRIBUTORS.md).


### PR DESCRIPTION
This PR updates the legal section to align with [OSGeo Project Graduation Checklist
Version 2.0](https://www.osgeo.org/resources/project-graduation-checklist/) and general OSS recommendations and furthermore adding a section with the list of current copyright holders.