### PR TITLE
Fixes #962 by disabling the deegree-maven-plugin goal assemble-log4j 

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -32,7 +32,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>assemble-log4j</goal>
               <goal>generate-buildinfo</goal>
             </goals>
           </execution>

--- a/deegree-services/deegree-webservices/src/main/resources/log4j.properties
+++ b/deegree-services/deegree-webservices/src/main/resources/log4j.properties
@@ -1,0 +1,655 @@
+# by default, only log to stdout
+log4j.rootLogger=ERROR, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{HH:mm:ss}] %5p: [%c{1}] %m%n
+
+## example log file appender
+## ${context.name} as variable in log file names is NOT supported any more (it breaks more often than not)
+
+#log.dir=${catalina.base}/logs
+#log4j.appender.logfile=org.apache.log4j.RollingFileAppender
+#log4j.appender.logfile.File=${log.dir}/example.log
+#log4j.appender.logfile.MaxFileSize=1000KB
+## Keep one backup file
+#log4j.appender.logfile.MaxBackupIndex=1
+#log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
+#log4j.appender.logfile.layout.ConversionPattern=%d %-5p [%c] %m%n
+
+# The log level for the org.reflections package (to avoid superfluous messages).
+log4j.logger.org.reflections = FATAL
+
+# The log level for all classes that are not configured below.
+log4j.logger.org.deegree = INFO
+
+# automatically generated output follows
+
+# ======================================================================================================================
+# =============================================== Severe error messages ================================================
+# ======================================================================================================================
+
+## logs grave errors that were not forseen to happen
+#log4j.logger.org.deegree.feature.persistence.shape.ShapeFeatureStore = ERROR
+
+# ============================================ WMS service specific logging ============================================
+
+
+## logs errors when querying feature stores/evaluating filter encoding expressions
+#log4j.logger.org.deegree.services.wms.MapService = ERROR
+
+## logs unknown errors, problems with GetFeatureInfo templates
+#log4j.logger.org.deegree.services.wms.controller.WMSController = ERROR
+
+# ======================================================================================================================
+# ============================================= Important warning messages =============================================
+# ======================================================================================================================
+
+## logs information about dimension handling
+#log4j.logger.org.deegree.layer.AbstractLayer = WARN
+
+# ======================================================================================================================
+# ================================================ rendering subsystem =================================================
+# ======================================================================================================================
+
+# ==================================================== 2D rendering ====================================================
+
+
+## logs when null rasters are rendered
+#log4j.logger.org.deegree.rendering.r2d.Java2DRasterRenderer = WARN
+
+## log info about problems with the renderer setup, or broken geometries coming in, or problematic usage of the renderer
+#log4j.logger.org.deegree.rendering.r2d.Java2DRenderer = WARN
+
+## logs usage of text rendering with unsupported geometry types
+#log4j.logger.org.deegree.rendering.r2d.Java2DTextRenderer = WARN
+
+# ======================================================================================================================
+# ================================================ rendering subsystem =================================================
+# ======================================================================================================================
+
+# ==================================================== 2D rendering ====================================================
+
+
+## logs when null rasters are rendered
+#log4j.logger.org.deegree.rendering.r2d.Java2DRasterRenderer = WARN
+
+## log info about problems with the renderer setup, or broken geometries coming in, or problematic usage of the renderer
+#log4j.logger.org.deegree.rendering.r2d.Java2DRenderer = WARN
+
+## logs usage of text rendering with unsupported geometry types
+#log4j.logger.org.deegree.rendering.r2d.Java2DTextRenderer = WARN
+
+## logs reasons for not setting up the store
+#log4j.logger.org.deegree.feature.persistence.shape.ShapeFeatureStore = WARN
+
+# ============================================ WMS service specific logging ============================================
+
+
+## logs information on all kinds of possible problems in your requests and your setup
+#log4j.logger.org.deegree.services.wms = WARN
+
+## logs problems when loading layers, also invalid values for vendor specific parameters such as ANTIALIAS, QUALITY etc.
+#log4j.logger.org.deegree.services.wms.MapService = WARN
+
+## logs problems with custom serializer classes
+#log4j.logger.org.deegree.services.wms.controller.WMSController = WARN
+
+## logs problems with CRS when outputting 1.1.1 capabilities
+#log4j.logger.org.deegree.services.wms.controller.capabilities.Capabilities111XMLAdapter = WARN
+
+## logs problems with CRS when outputting 1.3.0 capabilities
+#log4j.logger.org.deegree.services.wms.controller.capabilities.Capabilities130XMLAdapter = WARN
+
+## logs information about dimension handling
+#log4j.logger.org.deegree.layer.AbstractLayer = WARN
+
+# ======================================================================================================================
+# =============================================== Informational messages ===============================================
+# ======================================================================================================================
+
+## logs particle converter initialization
+#log4j.logger.org.deegree.feature.persistence.sql.SQLFeatureStore = INFO
+
+# ======================================================================================================================
+# ================================================= feature subsystem ==================================================
+# ======================================================================================================================
+
+
+## logs SQL connection errors
+#log4j.logger.org.deegree.feature.utils.DBUtils = INFO
+
+## logs problems when connecting to the DB/getting data from the DB
+#log4j.logger.org.deegree.feature.persistence.simplesql.SimpleSQLFeatureStore = INFO
+
+## logs problems when accessing the DB
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLReader = INFO
+
+## logs connection problems with the DB
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLWriter = INFO
+
+## logs when style files cannot be loaded
+#log4j.logger.org.deegree.services.wms.StyleRegistry = INFO
+
+## logs problems when accessing the DB
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLReader = INFO
+
+## logs connection problems with the DB
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLWriter = INFO
+
+# ======================================================================================================================
+# ====================== Debugging messages, useful for in-depth debugging of e.g. service setups ======================
+# ======================================================================================================================
+
+## logs which named layers were extracted from SLD
+#log4j.logger.org.deegree.protocol.wms.ops.SLDParser = DEBUG
+
+## logs the SQL statements sent to the SQL server and startup/shutdown information
+#log4j.logger.org.deegree.feature.persistence.sql.SQLFeatureStore = DEBUG
+
+# ======================================================================================================================
+# ================================================= coverage subsystem =================================================
+# ======================================================================================================================
+
+
+## logs when raster files could not be loaded
+#log4j.logger.org.deegree.coverage.raster.container.DiskBasedTileContainer = DEBUG
+
+## logs which named layers were extracted from SLD
+#log4j.logger.org.deegree.protocol.wms.ops.SLDParser = DEBUG
+
+# ======================================================================================================================
+# ================================================= feature subsystem ==================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.feature = DEBUG
+
+# ======================================================================================================================
+# ================================================== filter subsystem ==================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.filter = DEBUG
+
+# ======================================================================================================================
+# =================================================== GML subsystem ====================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.gml = DEBUG
+
+# ======================================================================================================================
+# ================================================= geometry subsystem =================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.geometry = DEBUG
+
+# ======================================================================================================================
+# ================================================= geometry subsystem =================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.geometry = DEBUG
+
+# ======================================================================================================================
+# ================================================= feature subsystem ==================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.feature = DEBUG
+
+# ======================================================================================================================
+# ================================================== filter subsystem ==================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.filter = DEBUG
+
+# ======================================================================================================================
+# =================================================== GML subsystem ====================================================
+# ======================================================================================================================
+
+
+## placeholder to enable quick debugging, please describe further
+#log4j.logger.org.deegree.gml = DEBUG
+
+# ======================================================================================================================
+# ================================================ rendering subsystem =================================================
+# ======================================================================================================================
+
+# ==================================================== 2D rendering ====================================================
+
+
+## logs which raster style is used for rendering
+#log4j.logger.org.deegree.rendering.r2d.Java2DRasterRenderer = DEBUG
+
+## log what's funny about rendering, eg. when null geometries are rendered, general info about the renderer, also log 
+## stack traces, use for debugging/improving your styles
+#log4j.logger.org.deegree.rendering.r2d.Java2DRenderer = DEBUG
+
+## logs rendering of null/zero length texts/null geometries
+#log4j.logger.org.deegree.rendering.r2d.Java2DTextRenderer = DEBUG
+
+## logs which text is rendered how
+#log4j.logger.org.deegree.rendering.r2d.strokes.TextStroke = DEBUG
+
+# ======================================================================================================================
+# ================================================ rendering subsystem =================================================
+# ======================================================================================================================
+
+# ==================================================== 2D rendering ====================================================
+
+
+## logs which raster style is used for rendering
+#log4j.logger.org.deegree.rendering.r2d.Java2DRasterRenderer = DEBUG
+
+## log what's funny about rendering, eg. when null geometries are rendered, general info about the renderer, also log 
+## stack traces, use for debugging/improving your styles
+#log4j.logger.org.deegree.rendering.r2d.Java2DRenderer = DEBUG
+
+## logs rendering of null/zero length texts/null geometries
+#log4j.logger.org.deegree.rendering.r2d.Java2DTextRenderer = DEBUG
+
+## logs which text is rendered how
+#log4j.logger.org.deegree.rendering.r2d.strokes.TextStroke = DEBUG
+
+## logs the SQL statements sent to the SQL server
+#log4j.logger.org.deegree.feature.persistence.simplesql.SimpleSQLFeatureStore = DEBUG
+
+## logs the server startup, incoming requests and timing info, also enables enhanced request logging in $HOME/.deegree
+#log4j.logger.org.deegree.services.controller.OGCFrontController = DEBUG
+
+## logs resource requests
+#log4j.logger.org.deegree.services.resources.ResourcesServlet = DEBUG
+
+## logs when the fallback value is used or values cannot be parsed properly for the given type
+#log4j.logger.org.deegree.filter.expression.custom.se.Interpolate = DEBUG
+
+# ======================================================================================================================
+# ======================================================= Styles =======================================================
+# ======================================================================================================================
+
+
+## logs which named layers were extracted from SLD
+#log4j.logger.org.deegree.style.persistence.sld.SLDParser = DEBUG
+
+## logs when problematic styles were found in the database
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLReader = DEBUG
+
+## logs information about reading the files, which srs etc.
+#log4j.logger.org.deegree.feature.persistence.shape.ShapeFeatureStore = DEBUG
+
+# ============================================ WMS service specific logging ============================================
+
+
+## logs all kinds of information on the layer/styles structure and how it's created
+#log4j.logger.org.deegree.services.wms = DEBUG
+
+## logs if layers are skipped because of scale constraints, and info about feature store queries
+#log4j.logger.org.deegree.services.wms.MapService = DEBUG
+
+## logs information about loading/reloading of style files
+#log4j.logger.org.deegree.services.wms.StyleRegistry = DEBUG
+
+## logs sent exception messages, security information
+#log4j.logger.org.deegree.services.wms.controller.WMSController = DEBUG
+
+# ======================================================================================================================
+# =================================================== crs subsystem ====================================================
+# ======================================================================================================================
+
+
+## Get information about metadata of Coordinate System components.
+#log4j.logger.org.deegree.cs.CRSIdentifiable = DEBUG
+
+## Get information about the transformation of a list of ordinates.
+#log4j.logger.org.deegree.cs.CoordinateTransformer = DEBUG
+
+## Get information about created transformation chain.
+#log4j.logger.org.deegree.cs.Transformer = DEBUG
+
+# ============================================= crs configuration logging ==============================================
+
+
+## Output logging information on loading of Coordinate Systems from a configuration.
+#log4j.logger.org.deegree.cs.configuration = DEBUG
+
+## Get information about initializing the xml file.
+#log4j.logger.org.deegree.cs.configuration.resources.XMLFileResource = DEBUG
+
+## Get information about the initialization of the provider, as well as on requested objects.
+#log4j.logger.org.deegree.cs.persistence.AbstractCRSStore = DEBUG
+
+## the deegree XML format provider
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.DeegreeCRSStore = DEBUG
+
+## Get information about the currently parsed crs, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.CoordinateSystemParser = DEBUG
+
+## Get information about the currently parsed datums, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.DatumParser = DEBUG
+
+## Get stacktraces if something goes wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.DefinitionParser = DEBUG
+
+## Get information about the currently parsed ellipsoid, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.EllipsoidParser = DEBUG
+
+## Get information about the currently parsed primemeridian, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.PrimemeridianParser = DEBUG
+
+## Get information about the currently parsed projections, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.ProjectionParser = DEBUG
+
+## Get information about the currently parsed transformation, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.TransformationParser = DEBUG
+
+## Get information about the currently parsed coordinate system components.
+#log4j.logger.org.deegree.cs.persistence.gml.GMLCRSStore = DEBUG
+
+## Get information about the currently parsed transformations.
+#log4j.logger.org.deegree.cs.persistence.gml.GMLFileResource = DEBUG
+
+## the proj4 format provider
+#log4j.logger.org.deegree.cs.persistence.proj4.PROJ4CRSStore = DEBUG
+
+## Get information about errors while parsing the proj4 file.
+#log4j.logger.org.deegree.cs.persistence.proj4.ProjFileResource = DEBUG
+
+# ================================================ projections logging =================================================
+
+
+## Get logging information about projections and the execution of projections.
+#log4j.logger.org.deegree.cs.projections = DEBUG
+
+## Get information about incoming ordinates.
+#log4j.logger.org.deegree.cs.projections.cylindric.Mercator = DEBUG
+
+## Get information about incoming ordinates of the (inverse) projection.
+#log4j.logger.org.deegree.cs.projections.cylindric.TransverseMercator = DEBUG
+
+# =============================================== Transformation logging ===============================================
+
+
+## Get information about transformations and the creation of transformation chains.
+#log4j.logger.org.deegree.cs.transformations = DEBUG
+
+## Get information about the transformation steps which were 'automatically' created.
+#log4j.logger.org.deegree.cs.transformations.TransformationFactory = DEBUG
+
+## Get information about the concatenation of two or more transformations.
+#log4j.logger.org.deegree.cs.transformations.coordinate.ConcatenatedTransform = DEBUG
+
+## Get information about the incoming ordinates of a direct transformation.
+#log4j.logger.org.deegree.cs.transformations.coordinate.DirectTransform = DEBUG
+
+## Get information about the incoming ordinates of a geocentric transformation.
+#log4j.logger.org.deegree.cs.transformations.coordinate.GeocentricTransform = DEBUG
+
+## Get information about axis of the projection as well as the used projection and the incoming ordinates.
+#log4j.logger.org.deegree.cs.transformations.coordinate.ProjectionTransform = DEBUG
+
+## Get stack traces if an error occurred while loading / transforming (on) a gridshift file.
+#log4j.logger.org.deegree.cs.transformations.ntv2.NTv2Transformation = DEBUG
+
+## Get information transformation substitution process.
+#log4j.logger.org.deegree.cs.utilities.MappingUtils = DEBUG
+
+## Get information about the swapping of axis and the creation of standardized values.
+#log4j.logger.org.deegree.cs.utilities.Matrix = DEBUG
+
+# ======================================================================================================================
+# ================================================= coverage subsystem =================================================
+# ======================================================================================================================
+
+
+## logs when raster files could not be loaded
+#log4j.logger.org.deegree.coverage.raster.container.DiskBasedTileContainer = DEBUG
+
+# ======================================================================================================================
+# ===================================== common logging settings for all of deegree =====================================
+# ======================================================================================================================
+
+
+## logs information about pool usage
+#log4j.logger.org.deegree.commons.jdbc.ConnectionPool = DEBUG
+
+## logs information about dynamically guessing the encoding of strings/files when such information is not present
+#log4j.logger.org.deegree.commons.utils.EncodingGuesser = DEBUG
+
+## logs when the fallback value is used or values cannot be parsed properly for the given type
+#log4j.logger.org.deegree.filter.expression.custom.se.Interpolate = DEBUG
+
+# ======================================================================================================================
+# ======================================================= Styles =======================================================
+# ======================================================================================================================
+
+
+## logs which named layers were extracted from SLD
+#log4j.logger.org.deegree.style.persistence.sld.SLDParser = DEBUG
+
+## logs when problematic styles were found in the database
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLReader = DEBUG
+
+# ======================================================================================================================
+# =================================================== crs subsystem ====================================================
+# ======================================================================================================================
+
+
+## Get information about metadata of Coordinate System components.
+#log4j.logger.org.deegree.cs.CRSIdentifiable = DEBUG
+
+## Get information about the transformation of a list of ordinates.
+#log4j.logger.org.deegree.cs.CoordinateTransformer = DEBUG
+
+## Get information about created transformation chain.
+#log4j.logger.org.deegree.cs.Transformer = DEBUG
+
+# ============================================= crs configuration logging ==============================================
+
+
+## Output logging information on loading of Coordinate Systems from a configuration.
+#log4j.logger.org.deegree.cs.configuration = DEBUG
+
+## Get information about initializing the xml file.
+#log4j.logger.org.deegree.cs.configuration.resources.XMLFileResource = DEBUG
+
+## Get information about the currently exported coordinate system.
+#log4j.logger.org.deegree.cs.io.deegree.CRSExporter = DEBUG
+
+## Get information about the currently exported coordinate system.
+#log4j.logger.org.deegree.cs.io.deegree.CRSExporterBase = DEBUG
+
+## Get information about the initialization of the provider, as well as on requested objects.
+#log4j.logger.org.deegree.cs.persistence.AbstractCRSStore = DEBUG
+
+## the deegree XML format provider
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.DeegreeCRSStore = DEBUG
+
+## Get information about the currently parsed crs, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.CoordinateSystemParser = DEBUG
+
+## Get information about the currently parsed datums, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.DatumParser = DEBUG
+
+## Get stacktraces if something goes wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.DefinitionParser = DEBUG
+
+## Get information about the currently parsed ellipsoid, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.EllipsoidParser = DEBUG
+
+## Get information about the currently parsed primemeridian, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.PrimemeridianParser = DEBUG
+
+## Get information about the currently parsed projections, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.ProjectionParser = DEBUG
+
+## Get information about the currently parsed transformation, as well as a stack trace if something went wrong.
+#log4j.logger.org.deegree.cs.persistence.deegree.d3.parsers.TransformationParser = DEBUG
+
+## Get information about the currently parsed coordinate system components.
+#log4j.logger.org.deegree.cs.persistence.gml.GMLCRSStore = DEBUG
+
+## Get information about the currently parsed transformations.
+#log4j.logger.org.deegree.cs.persistence.gml.GMLFileResource = DEBUG
+
+## the proj4 format provider
+#log4j.logger.org.deegree.cs.persistence.proj4.PROJ4CRSStore = DEBUG
+
+## Get information about errors while parsing the proj4 file.
+#log4j.logger.org.deegree.cs.persistence.proj4.ProjFileResource = DEBUG
+
+# ================================================ projections logging =================================================
+
+
+## Get logging information about projections and the execution of projections.
+#log4j.logger.org.deegree.cs.projections = DEBUG
+
+## Get information about incoming ordinates.
+#log4j.logger.org.deegree.cs.projections.cylindric.Mercator = DEBUG
+
+## Get information about incoming ordinates of the (inverse) projection.
+#log4j.logger.org.deegree.cs.projections.cylindric.TransverseMercator = DEBUG
+
+# =============================================== Transformation logging ===============================================
+
+
+## Get information about transformations and the creation of transformation chains.
+#log4j.logger.org.deegree.cs.transformations = DEBUG
+
+## Get information about the transformation steps which were 'automatically' created.
+#log4j.logger.org.deegree.cs.transformations.TransformationFactory = DEBUG
+
+## Get information about the concatenation of two or more transformations.
+#log4j.logger.org.deegree.cs.transformations.coordinate.ConcatenatedTransform = DEBUG
+
+## Get information about the incoming ordinates of a direct transformation.
+#log4j.logger.org.deegree.cs.transformations.coordinate.DirectTransform = DEBUG
+
+## Get information about the incoming ordinates of a geocentric transformation.
+#log4j.logger.org.deegree.cs.transformations.coordinate.GeocentricTransform = DEBUG
+
+## Get information about axis of the projection as well as the used projection and the incoming ordinates.
+#log4j.logger.org.deegree.cs.transformations.coordinate.ProjectionTransform = DEBUG
+
+## Get stack traces if an error occurred while loading / transforming (on) a gridshift file.
+#log4j.logger.org.deegree.cs.transformations.ntv2.NTv2Transformation = DEBUG
+
+## Get information transformation substitution process.
+#log4j.logger.org.deegree.cs.utilities.MappingUtils = DEBUG
+
+## Get information about the swapping of axis and the creation of standardized values.
+#log4j.logger.org.deegree.cs.utilities.Matrix = DEBUG
+
+# ======================================================================================================================
+# ===================================== common logging settings for all of deegree =====================================
+# ======================================================================================================================
+
+
+## logs information about pool usage
+#log4j.logger.org.deegree.commons.jdbc.ConnectionPool = DEBUG
+
+## logs information about dynamically guessing the encoding of strings/files when such information is not present
+#log4j.logger.org.deegree.commons.utils.EncodingGuesser = DEBUG
+
+## log the executed statements
+#log4j.logger.org.deegree.client.core.utils.SQLExecution = DEBUG
+
+# ======================================================================================================================
+# ======================================= Tracing messages, for developers only ========================================
+# ======================================================================================================================
+
+# ======================================================================================================================
+# ================================================= coverage subsystem =================================================
+# ======================================================================================================================
+
+
+## logs stack traces
+#log4j.logger.org.deegree.coverage.raster.container.DiskBasedTileContainer = TRACE
+
+# ======================================================================================================================
+# ================================================= feature subsystem ==================================================
+# ======================================================================================================================
+
+
+## logs stack traces
+#log4j.logger.org.deegree.feature.utils.DBUtils = TRACE
+
+# ======================================================================================================================
+# ================================================ rendering subsystem =================================================
+# ======================================================================================================================
+
+# ==================================================== 2D rendering ====================================================
+
+
+## logs details about the raster rendering process
+#log4j.logger.org.deegree.rendering.r2d.Java2DRasterRenderer = TRACE
+
+## logs implementation/code debugging details about text strokes
+#log4j.logger.org.deegree.rendering.r2d.strokes.TextStroke = TRACE
+
+# ======================================================================================================================
+# ================================================ rendering subsystem =================================================
+# ======================================================================================================================
+
+# ==================================================== 2D rendering ====================================================
+
+
+## logs details about the raster rendering process
+#log4j.logger.org.deegree.rendering.r2d.Java2DRasterRenderer = TRACE
+
+## logs implementation/code debugging details about text strokes
+#log4j.logger.org.deegree.rendering.r2d.strokes.TextStroke = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.feature.persistence.simplesql.SimpleSQLFeatureStore = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLReader = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLWriter = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.feature.persistence.shape.ShapeFeatureStore = TRACE
+
+# ============================================ WMS service specific logging ============================================
+
+
+## logs stack traces
+#log4j.logger.org.deegree.services.wms.MapService = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.services.wms.StyleRegistry = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.services.wms.controller.WMSController = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.services.wms.controller.capabilities.Capabilities111XMLAdapter = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.services.wms.controller.capabilities.Capabilities130XMLAdapter = TRACE
+
+# ======================================================================================================================
+# ================================================= coverage subsystem =================================================
+# ======================================================================================================================
+
+
+## logs stack traces
+#log4j.logger.org.deegree.coverage.raster.container.DiskBasedTileContainer = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLReader = TRACE
+
+## logs stack traces
+#log4j.logger.org.deegree.style.se.parser.PostgreSQLWriter = TRACE
+


### PR DESCRIPTION
Fixes #962 by disabling the `deegree-maven-plugin` goal `assemble-log4j` and provides a default `log4j.properties` configuration file matching current log4j 1.2 provider.
This is considered as a temporary fix.