### PR TITLE
Make gml:id attribute optional as defined in updated GML 3.2.1 schemas

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -51,9 +51,6 @@ import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.nextElement;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.require;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.skipElement;
-import static org.deegree.gml.GMLVersion.GML_2;
-import static org.deegree.gml.GMLVersion.GML_30;
-import static org.deegree.gml.GMLVersion.GML_31;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -181,30 +178,15 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
      * Parses the gml:id attribute of a GML object element.
      *
      * @param xmlStream
-     *            must not be <code>null</code> and point to the start element of a GML object
+     *                      must not be <code>null</code> and point to the start element of a GML object
      * @return value of the GML id, can be <code>null</code>
-     * @throws XMLStreamException
-     *             if the GML version requires a gml:id attribute and none is present (or invalid)
      */
-    public String parseGmlId( final XMLStreamReader xmlStream )
-                            throws XMLStreamException {
+    public String parseGmlId( final XMLStreamReader xmlStream ) {
         final String gmlId = xmlStream.getAttributeValue( gmlNs, "id" );
-        if ( gmlId == null && isGmlIdRequired() ) {
-            final String msg = "Required attribute gml:id is missing.";
-            throw new XMLStreamException( msg, xmlStream.getLocation() );
-        }
         if ( gmlId != null ) {
             checkValidNcName( gmlId );
         }
         return gmlId;
-    }
-
-    // required since GML 3.2
-    private boolean isGmlIdRequired() {
-        if ( gmlStreamReader.getLaxMode() ) {
-            return false;
-        }
-        return version != GML_2 && version != GML_30 || version != GML_31;
     }
 
     private void checkValidNcName( final String gmlId ) {

--- a/pom.xml
+++ b/pom.xml
@@ -1019,7 +1019,7 @@
       <dependency>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-ogcschemas</artifactId>
-        <version>20120804</version>
+        <version>20190425</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>


### PR DESCRIPTION
NOTE: In order to make this patch work, the attached file (deegree-ogcschemas-20190425.zip) must be uploaded to the deegree repo (or installed locally) first, it contains updated GML 3.2.1 core schemas. Please change the extension to jar (no way to add jars directly to GitHub tickets, sorry).

Before this PR, deegree was using an older version of the GML 3.2.1 schemas which declare the gml:id attribute to be mandatory. However, since 2016-12-02 this is no longer the case [1]. The official GML 3.2.1 schemas have been replaced with a corrigendum (actually 3.2.1 is 3.2.2 now) that makes the gml:id optional. As a consequence, the deegree GML reader will reject valid GML 3.2.1 instance files that are missing gml:ids, e.g. for an INSPIRE ManagementRestrictionOrRegulationZone, deegree does not accept an omitted gml:id at path am:plan/base2:DocumentCitation.

After this PR (and uploading the attached deegree-ogcschemas artifact), gml:ids will not be required any more, even for GML 3.2 input.

[1] http://schemas.opengis.net/gml/ReadMe.txt

[deegree-ogcschemas-20190425.zip](https://github.com/deegree/deegree3/files/3117193/deegree-ogcschemas-20190425.zip)
