### PR TITLE
Fix NPE in exception serializer if exception is NPE

### DIFF
--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/PreOWSExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/ows/PreOWSExceptionReportSerializer.java
@@ -87,7 +87,7 @@ public class PreOWSExceptionReportSerializer extends XMLExceptionSerializer {
         if ( ex.getLocator() != null && !"".equals( ex.getLocator().trim() ) ) {
             writer.writeAttribute( "locator", ex.getLocator() );
         }
-        writer.writeCharacters( ex.getMessage() );
+        writer.writeCharacters( ex.getMessage() != null ? ex.getMessage() : "not available" );
         writer.writeEndElement(); // ServiceException
         writer.writeEndElement(); // ServiceExceptionReport
     }


### PR DESCRIPTION
Fixes an NPE when an exception is serialized and the message is null (concerns WMS 1.3, WFS 1.0).