### PR TITLE
Fix incomplete implementation of proxy authentication

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/proxy/ProxySettings.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/proxy/ProxySettings.java
@@ -41,6 +41,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Properties;
@@ -123,6 +125,7 @@ public final class ProxySettings implements Initializable {
             LOG.info( "Using global 'proxy.xml'." );
             proxyConfigFile = globalProxy;
         } else {
+            setDefaultAuthenticator();
             LOG.info( "No 'proxy.xml' file -- skipping set up of proxy configuration." );
             return;
         }
@@ -141,6 +144,7 @@ public final class ProxySettings implements Initializable {
             String msg = "Could not unmarshall proxy configuration: " + e.getMessage();
             throw new ResourceInitException( msg, e );
         }
+        setDefaultAuthenticator();
         logProxyConfiguration( LOG );
         LOG.info( "" );
     }
@@ -450,6 +454,16 @@ public final class ProxySettings implements Initializable {
                   + ", ftp.proxyPassword=" + getFtpProxyPassword( false ) );
         log.info( "- nonProxyHosts=" + getNonProxyHosts() + ", http.nonProxyHosts=" + getHttpNonProxyHosts( false )
                   + ", ftp.nonProxyHosts=" + getFtpNonProxyHosts( false ) );
+    }
+
+    private void setDefaultAuthenticator() {
+        Authenticator.setDefault(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication( getHttpProxyUser( true ),
+                        getHttpProxyPassword( true ).toCharArray() );
+            }
+        } );
     }
 
 }

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/proxy/ProxySettings.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/proxy/ProxySettings.java
@@ -109,10 +109,9 @@ public final class ProxySettings implements Initializable {
 
     /**
      * Sets/augments the VM's proxy configuration.
-     * 
-     * @param dir
-     *            fallback directory, in case the workspace root has no proxy.xml
-     * 
+     *
+     * @param workspace proxy.xml located in the workspaces is used
+     *                  in case the workspace root has no proxy.xml, never <code>null</code>
      */
     public void init( Workspace workspace ) {
 
@@ -125,7 +124,7 @@ public final class ProxySettings implements Initializable {
             LOG.info( "Using global 'proxy.xml'." );
             proxyConfigFile = globalProxy;
         } else {
-            setDefaultAuthenticator();
+            setupAuthenticator();
             LOG.info( "No 'proxy.xml' file -- skipping set up of proxy configuration." );
             return;
         }
@@ -144,7 +143,7 @@ public final class ProxySettings implements Initializable {
             String msg = "Could not unmarshall proxy configuration: " + e.getMessage();
             throw new ResourceInitException( msg, e );
         }
-        setDefaultAuthenticator();
+        setupAuthenticator();
         logProxyConfiguration( LOG );
         LOG.info( "" );
     }
@@ -456,7 +455,7 @@ public final class ProxySettings implements Initializable {
                   + ", ftp.nonProxyHosts=" + getFtpNonProxyHosts( false ) );
     }
 
-    private void setDefaultAuthenticator() {
+    private void setupAuthenticator() {
         Authenticator.setDefault(new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/proxy/ProxySettings.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/proxy/ProxySettings.java
@@ -456,13 +456,19 @@ public final class ProxySettings implements Initializable {
     }
 
     private void setupAuthenticator() {
-        Authenticator.setDefault(new Authenticator() {
+        String httpProxyUser = getHttpProxyUser( true );
+        String httpProxyPassword = getHttpProxyPassword( true );
+        if ( httpProxyUser != null && httpProxyPassword != null )
+            Authenticator.setDefault( createAuthenticator( httpProxyUser, httpProxyPassword ) );
+    }
+
+    private Authenticator createAuthenticator( String httpProxyUser, String httpProxyPassword ) {
+        return new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {
-                return new PasswordAuthentication( getHttpProxyUser( true ),
-                        getHttpProxyPassword( true ).toCharArray() );
+                return new PasswordAuthentication( httpProxyUser, httpProxyPassword.toCharArray() );
             }
-        } );
+        };
     }
 
 }


### PR DESCRIPTION
**Scenario:**
User wants to use deegree with a forwarding proxy for outgoing requests.
The user configures HTTP proxy host, HTTP proxy port, HTTP proxy user and HTTP proxy password in `proxy.xml`.
Used workspace contains GML schema referencing external resources. Also, a remote WMS is configured.

**Status without this pull request:**
HTTP proxy host and HTTP proxy port are used correctly during initialisation of workspace.
However, HTTP proxy user and HTTP proxy password are not considered during initialisation of FeatureStore using GML schema referencing external resources and of remote WMS. Instead, HTTP status code 407 is returned by proxy.

**Fix provided by this pull request:**
Authenticator is implemented enabling proxy authentication for above described scenario.

Fixes #947.