### PR TITLE
Upgrade gdal to official release version 2.4.x

### DIFF
--- a/deegree-core/deegree-core-gdal/pom.xml
+++ b/deegree-core/deegree-core-gdal/pom.xml
@@ -44,8 +44,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>it.geosolutions.imageio-ext</groupId>
-      <artifactId>imageio-ext-gdal-bindings</artifactId>
+      <groupId>org.gdal</groupId>
+      <artifactId>gdal</artifactId>
     </dependency>
 	<dependency>
       <groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -988,9 +988,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>it.geosolutions.imageio-ext</groupId>
-        <artifactId>imageio-ext-gdal-bindings</artifactId>
-        <version>1.10.1</version>
+        <groupId>org.gdal</groupId>
+        <artifactId>gdal</artifactId>
+        <version>1.11.2</version>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -990,7 +990,7 @@
       <dependency>
         <groupId>org.gdal</groupId>
         <artifactId>gdal</artifactId>
-        <version>1.11.2</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>


### PR DESCRIPTION
Fixes #994 - upgrade to official version 1.11.2 as preparation to move to offical 2.x version