### PR TITLE
Fix GetFeatureInfo on group layers

### DIFF
--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
@@ -157,12 +157,9 @@ public class FeatureLayer extends AbstractLayer {
                             throws OWSException {
         OperatorFilter filter = this.filter;
         filter = Filters.and( filter, dimFilterBuilder.getDimensionFilter( query.getDimensions(), headers ) );
-        StyleRef ref = query.getStyle();
-        if ( !ref.isResolved() ) {
-            ref.resolve( getMetadata().getStyles().get( ref.getName() ) );
-        }
-        Style style = ref.getStyle();
+        Style style = resolveStyleRef( query.getStyle() );
         style = style.filter( query.getScale() );
+
         filter = Filters.and( filter, getStyleFilters( style, query.getScale() ) );
         filter = Filters.and( filter, query.getFilter() );
 


### PR DESCRIPTION
As result of this fix, a GetFeatureInfo request against a group layer returns the result of all sub-layers instead of the result of just the first sub-layer.
Currently, this is just possible if the feature type is configured in the layer configuration.

Fixes #985.