### PR TITLE
fix(#933): retain requested SRS name in CRS object for XML requests

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/query/xml/QueryXMLAdapter.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/query/xml/QueryXMLAdapter.java
@@ -52,6 +52,7 @@ import javax.xml.stream.XMLStreamReader;
 
 import org.apache.axiom.om.OMElement;
 import org.deegree.commons.ows.exception.OWSException;
+import org.deegree.commons.tom.ReferenceResolvingException;
 import org.deegree.commons.tom.ResolveMode;
 import org.deegree.commons.tom.ResolveParams;
 import org.deegree.commons.utils.StringUtils;
@@ -63,6 +64,7 @@ import org.deegree.commons.xml.stax.XMLStreamReaderWrapper;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
+import org.deegree.cs.refs.coordinatesystem.CRSRef;
 import org.deegree.filter.Filter;
 import org.deegree.filter.expression.ValueReference;
 import org.deegree.filter.projection.ProjectionClause;
@@ -251,8 +253,10 @@ public class QueryXMLAdapter extends AbstractWFSRequestXMLAdapter {
         String srsName = getNodeAsString( queryEl, new XPath( "@srsName", nsContext ), null );
         if ( srsName != null ) {
             try {
-                crs = CRSManager.lookup( srsName );
-            } catch ( UnknownCRSException e ) {
+                CRSRef ref = CRSManager.getCRSRef( srsName );
+                ref.getReferencedObject(); // test if referenced object exists
+                crs = ref; // use reference as that prefers the requested name/code/alias
+            } catch ( ReferenceResolvingException e ) {
                 throw new InvalidParameterValueException( e.getMessage(), "srsName" );
             }
         }


### PR DESCRIPTION
When doing a GetFeature request to the WFS endpoint via a posted XML
query, the name of the SRS that was passed into the request by the user
was not retained, but an alias from the looked-up CRS was stated in the
returned features.
This only happened in XML POST requests, not in KVP GET requests.

refs #933