### PR TITLE
Enhanced implementation for WFS 2.0 response paging

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
@@ -35,6 +35,8 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.sqldialect;
 
+import org.deegree.sqldialect.filter.expression.SQLOperationBuilder;
+
 /**
  * Implementations provide the vendor-specific behavior for a spatial DBMS so it can be accessed by deegree.
  *
@@ -54,6 +56,19 @@ public abstract class AbstractSQLDialect implements SQLDialect{
     @Override
     public char getTailingEscapeChar() {
         return defaultEscapeChar;
+    }
+
+    @Override public String getOffsetAndFetch( int maxFeatures, int startIndex ) {
+        StringBuilder sql = new StringBuilder();
+        if ( startIndex > 0 )
+            sql.append( "OFFSET " ).append( startIndex );
+        if ( maxFeatures > -1 )
+            sql.append( " ROWS FETCH NEXT " ).append( maxFeatures ).append( " ROWS ONLY" );
+        String offsetAndFetch = sql.toString();
+        if ( !offsetAndFetch.isEmpty() ) {
+            return offsetAndFetch;
+        }
+        return null;
     }
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
@@ -35,8 +35,6 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.sqldialect;
 
-import org.deegree.sqldialect.filter.expression.SQLOperationBuilder;
-
 /**
  * Implementations provide the vendor-specific behavior for a spatial DBMS so it can be accessed by deegree.
  *
@@ -56,19 +54,6 @@ public abstract class AbstractSQLDialect implements SQLDialect{
     @Override
     public char getTailingEscapeChar() {
         return defaultEscapeChar;
-    }
-
-    @Override public String getOffsetAndFetch( int maxFeatures, int startIndex ) {
-        StringBuilder sql = new StringBuilder();
-        if ( startIndex > 0 )
-            sql.append( "OFFSET " ).append( startIndex ).append( " ROWS" );
-        if ( maxFeatures > -1 )
-            sql.append( " FETCH NEXT " ).append( maxFeatures ).append( " ROWS ONLY" );
-        String offsetAndFetch = sql.toString();
-        if ( !offsetAndFetch.isEmpty() ) {
-            return offsetAndFetch;
-        }
-        return null;
     }
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
@@ -61,9 +61,9 @@ public abstract class AbstractSQLDialect implements SQLDialect{
     @Override public String getOffsetAndFetch( int maxFeatures, int startIndex ) {
         StringBuilder sql = new StringBuilder();
         if ( startIndex > 0 )
-            sql.append( "OFFSET " ).append( startIndex );
+            sql.append( "OFFSET " ).append( startIndex ).append( " ROWS" );
         if ( maxFeatures > -1 )
-            sql.append( " ROWS FETCH NEXT " ).append( maxFeatures ).append( " ROWS ONLY" );
+            sql.append( " FETCH NEXT " ).append( maxFeatures ).append( " ROWS ONLY" );
         String offsetAndFetch = sql.toString();
         if ( !offsetAndFetch.isEmpty() ) {
             return offsetAndFetch;

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
@@ -226,18 +226,4 @@ public interface SQLDialect {
      */
     char getTailingEscapeChar();
 
-    /**
-     * Returns the FETCH clause to apply maxFeatures and startIndex if
-     *  <ul>
-     *      <li>maxFeatures > -1 and </li>
-     *      <li>startIndex  > 0 </li>
-     *  </ul>
-     *
-     * @param maxFeatures
-     *        number of features to return
-     * @param startIndex
-     *        index of the first item
-     * @return the FETCH clause to apply maxFeatures and startIndex
-     */
-    String getOffsetAndFetch( int maxFeatures, int startIndex );
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
@@ -175,7 +175,7 @@ public interface SQLDialect {
      *            name of the database to be created, must not be <code>null</code>
      * @throws SQLException
      */
-    public void createDB( Connection adminConn, String dbName )
+    void createDB( Connection adminConn, String dbName )
                             throws SQLException;
 
     /**
@@ -187,13 +187,13 @@ public interface SQLDialect {
      *            name of the database to be created, must not be <code>null</code>
      * @throws SQLException
      */
-    public void dropDB( Connection adminConn, String dbName )
+    void dropDB( Connection adminConn, String dbName )
                             throws SQLException;
 
-    public void createAutoColumn( StringBuffer currentStmt, List<StringBuffer> additionalSmts, SQLIdentifier column,
+    void createAutoColumn( StringBuffer currentStmt, List<StringBuffer> additionalSmts, SQLIdentifier column,
                                   SQLIdentifier table );
 
-    public ResultSet getTableColumnMetadata( DatabaseMetaData md, TableName table )
+    ResultSet getTableColumnMetadata( DatabaseMetaData md, TableName table )
                             throws SQLException;
 
     /**
@@ -201,7 +201,7 @@ public interface SQLDialect {
      * 
      * @return <code>true</code>, if a transaction context is required, <code>false</code> otherwise
      */
-    public boolean requiresTransactionForCursorMode();
+    boolean requiresTransactionForCursorMode();
 
     /**
      * Returns a <code>SELECT</code> statement for retrieving the next value in the specified DB sequence.
@@ -217,12 +217,27 @@ public interface SQLDialect {
      *
      * @return leading escape char
      */
-    public char getLeadingEscapeChar();
+    char getLeadingEscapeChar();
 
     /**
      * Returns the tailing escape char for the SQLDialect
      *
      * @return tailing escape char
      */
-    public char getTailingEscapeChar();
+    char getTailingEscapeChar();
+
+    /**
+     * Returns the FETCH clause to apply maxFeatures and startIndex if
+     *  <ul>
+     *      <li>maxFeatures > -1 and </li>
+     *      <li>startIndex  > 0 </li>
+     *  </ul>
+     *
+     * @param maxFeatures
+     *        number of features to return
+     * @param startIndex
+     *        index of the first item
+     * @return the FETCH clause to apply maxFeatures and startIndex
+     */
+    String getOffsetAndFetch( int maxFeatures, int startIndex );
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
@@ -57,6 +57,7 @@ import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.utils.GeometryParticleConverter;
 import org.deegree.sqldialect.SQLDialect;
+import org.deegree.sqldialect.SortCriterion;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
 import org.deegree.sqldialect.filter.PropertyNameMapper;
 import org.deegree.sqldialect.filter.UnmappableException;
@@ -115,9 +116,9 @@ public class MSSQLDialect extends AbstractSQLDialect implements SQLDialect {
 
     @Override
     public AbstractWhereBuilder getWhereBuilder( PropertyNameMapper mapper, OperatorFilter filter,
-                                                 SortProperty[] sortCrit, boolean allowPartialMappings )
+                                                 SortProperty[] sortCrit, List<SortCriterion> defaultSortCriteria, boolean allowPartialMappings )
                             throws UnmappableException, FilterEvaluationException {
-        return new MSSQLWhereBuilder( this, mapper, filter, sortCrit, allowPartialMappings );
+        return new MSSQLWhereBuilder( this, mapper, filter, sortCrit, defaultSortCriteria, allowPartialMappings );
     }
 
     @Override

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/FeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/FeatureStore.java
@@ -90,6 +90,15 @@ public interface FeatureStore extends Resource {
     boolean isMapped( QName ftName );
 
     /**
+     * Returns whether the store supports evaluation of maxFeatures and startIndex.
+     *
+     * @param queries
+     *            the queries to check if evaluation of maxFeatures and startIndex is applicable, must not be <code>null</code>
+     * @return <code>true</code>, if evaluation of maxFeatures and startIndex is applicable, <code>false</code> otherwise
+     */
+    boolean isMaxFeaturesAndStartIndexApplicable( Query[] queries );
+
+    /**
      * Returns the envelope for all stored features of the given type.
      * <p>
      * NOTE: This method may return incorrect (cached) results. Use {@link #calcEnvelope(QName)} to force the

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/query/Query.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/query/Query.java
@@ -307,4 +307,12 @@ public class Query {
     public int getMaxFeatures() {
         return maxFeatures;
     }
+
+    /**
+     * @return the index of the first feature to return
+     */
+    public int getStartIndex() {
+        return startIndex;
+    }
+
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/query/Query.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/query/Query.java
@@ -97,6 +97,8 @@ public class Query {
 
     private int maxFeatures = -1;
 
+    private int startIndex = 0;
+
     private final List<ProjectionClause> projections;
 
     /**
@@ -146,6 +148,34 @@ public class Query {
     public Query( TypeName[] typeNames, Filter filter, String featureVersion, ICRS srsName, SortProperty[] sortBy ) {
         this.typeNames = typeNames;
         this.filter = filter;
+        if ( sortBy != null ) {
+            this.sortBy = sortBy;
+        } else {
+            this.sortBy = new SortProperty[0];
+        }
+        this.projections = emptyList();
+    }
+
+    /**
+     * Creates a new {@link Query} instance.
+     *
+     * @param typeNames
+     *            feature type names to be queried, must not be <code>null</code> and contain at least one entry
+     * @param filter
+     *            filter to be applied, can be <code>null</code>, if not <code>null</code>, all contained geometry
+     *            operands must have a non-null {@link CRS}
+     * @param sortBy
+     *            sort criteria to be applied, can be <code>null</code>
+     * @param maxFeatures
+     *            number of features to return, if not specified: -1
+     * @param startIndex
+     *            index of the first feature to return, default: 0
+     */
+    public Query( TypeName[] typeNames, Filter filter, SortProperty[] sortBy, int maxFeatures, int startIndex ) {
+        this.typeNames = typeNames;
+        this.filter = filter;
+        this.maxFeatures = maxFeatures;
+        this.startIndex = startIndex;
         if ( sortBy != null ) {
             this.sortBy = sortBy;
         } else {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStore.java
@@ -123,6 +123,11 @@ public class MemoryFeatureStore implements FeatureStore {
     }
 
     @Override
+    public boolean isMaxFeaturesAndStartIndexApplicable( Query[] queries ) {
+        return false;
+    }
+
+    @Override
     public FeatureInputStream query( Query query )
                             throws FilterEvaluationException, FeatureStoreException {
         return storedFeatures.query( query );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/src/main/java/org/deegree/feature/persistence/remotewfs/RemoteWFSFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/src/main/java/org/deegree/feature/persistence/remotewfs/RemoteWFSFeatureStore.java
@@ -143,6 +143,11 @@ public class RemoteWFSFeatureStore implements FeatureStore {
     }
 
     @Override
+    public boolean isMaxFeaturesAndStartIndexApplicable( Query[] queries ) {
+        return false;
+    }
+
+    @Override
     public Envelope getEnvelope( QName ftName )
                             throws FeatureStoreException {
         WFSFeatureType ftMetadata = client.getFeatureType( ftName );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/ShapeFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/ShapeFeatureStore.java
@@ -588,6 +588,11 @@ public class ShapeFeatureStore implements FeatureStore {
         return schema.getFeatureType( ftName ) != null;
     }
 
+    @Override
+    public boolean isMaxFeaturesAndStartIndexApplicable( Query[] queries ) {
+        return false;
+    }
+
     /**
      * Returns the CRS used by the shape file.
      * 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/src/main/java/org/deegree/feature/persistence/simplesql/SimpleSQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/src/main/java/org/deegree/feature/persistence/simplesql/SimpleSQLFeatureStore.java
@@ -270,6 +270,11 @@ public class SimpleSQLFeatureStore implements FeatureStore {
         return available;
     }
 
+    @Override
+    public boolean isMaxFeaturesAndStartIndexApplicable( Query[] queries ) {
+        return false;
+    }
+
     public FeatureInputStream query( Query query )
                             throws FeatureStoreException, FilterEvaluationException {
         return query( new Query[] { query } );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -137,7 +137,6 @@ import org.deegree.sqldialect.filter.PropertyNameMapping;
 import org.deegree.sqldialect.filter.TableAliasManager;
 import org.deegree.sqldialect.filter.UnmappableException;
 import org.deegree.sqldialect.filter.expression.SQLArgument;
-import org.deegree.sqldialect.filter.expression.SQLExpression;
 import org.deegree.workspace.Resource;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceMetadata;
@@ -1356,6 +1355,11 @@ public class SQLFeatureStore implements FeatureStore {
             if ( wb.getOrderBy() != null ) {
                 sql.append( " ORDER BY " );
                 sql.append( wb.getOrderBy().getSQL() );
+            }
+
+            String fetchClause = dialect.getOffsetAndFetch( query.getMaxFeatures(), query.getStartIndex() );
+            if ( fetchClause != null ) {
+                sql.append( " " ).append( fetchClause ).append( " " );
             }
 
             LOG.debug( "SQL: {}", sql );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -1357,10 +1357,7 @@ public class SQLFeatureStore implements FeatureStore {
                 sql.append( wb.getOrderBy().getSQL() );
             }
 
-            String fetchClause = dialect.getOffsetAndFetch( query.getMaxFeatures(), query.getStartIndex() );
-            if ( fetchClause != null ) {
-                sql.append( " " ).append( fetchClause ).append( " " );
-            }
+            appendOffsetAndFetch(sql,  query.getMaxFeatures(), query.getStartIndex() );
 
             LOG.debug( "SQL: {}", sql );
             long begin = System.currentTimeMillis();
@@ -1649,6 +1646,13 @@ public class SQLFeatureStore implements FeatureStore {
                 throw new InvalidParameterValueException( "Requested feature does not match the requested feature type.",
                                                           "RESOURCEID" );
         }
+    }
+
+    private void appendOffsetAndFetch( StringBuilder sql, int maxFeatures, int startIndex ) {
+        if ( startIndex > 0 )
+            sql.append( " OFFSET " ).append( startIndex ).append( " ROWS" );
+        if ( maxFeatures > -1 )
+            sql.append( " FETCH NEXT " ).append( maxFeatures ).append( " ROWS ONLY " );
     }
 
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -885,7 +885,7 @@ public class SQLFeatureStore implements FeatureStore {
     @Override
     public FeatureInputStream query( Query query )
                             throws FeatureStoreException, FilterEvaluationException {
-        return query( query, false );
+        return query( query, true );
     }
 
     @Override
@@ -1153,7 +1153,8 @@ public class SQLFeatureStore implements FeatureStore {
         return transaction.get() != null;
     }
 
-    private FeatureInputStream queryByOperatorFilterBlob( Query query, QName ftName, OperatorFilter filter )
+    private FeatureInputStream queryByOperatorFilterBlob( Query query, QName ftName, OperatorFilter filter,
+                                                          boolean isMaxFeaturesAndStartIndexApplicable )
                             throws FeatureStoreException {
 
         LOG.debug( "Performing blob query by operator filter" );
@@ -1244,6 +1245,9 @@ public class SQLFeatureStore implements FeatureStore {
             // sql.append( wb.getOrderBy().getSQL() );
             // }
 
+            if ( isMaxFeaturesAndStartIndexApplicable )
+                appendOffsetAndFetch( sql, query.getMaxFeatures(), query.getStartIndex() );
+
             LOG.debug( "SQL: {}", sql );
             long begin = System.currentTimeMillis();
             stmt = conn.prepareStatement( sql.toString() );
@@ -1301,7 +1305,7 @@ public class SQLFeatureStore implements FeatureStore {
         LOG.debug( "Performing query by operator filter" );
 
         if ( getSchema().getBlobMapping() != null ) {
-            return queryByOperatorFilterBlob( query, ftName, filter );
+            return queryByOperatorFilterBlob( query, ftName, filter, isMaxFeaturesAndStartIndexApplicable );
         }
 
         AbstractWhereBuilder wb = null;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -151,8 +151,19 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
 
         GMLVersion gmlVersion = options.getGmlVersion();
 
+        int returnMaxFeatures = options.getQueryMaxFeatures();
+        BigInteger count = request.getPresentationParams().getCount();
+        if ( count != null && ( options.getQueryMaxFeatures() < 1 || count.intValue() < options.getQueryMaxFeatures() ) ) {
+            returnMaxFeatures = count.intValue();
+        }
+
+        int startIndex = 0;
+        if ( request.getPresentationParams().getStartIndex() != null ) {
+            startIndex = request.getPresentationParams().getStartIndex().intValue();
+        }
+
         QueryAnalyzer analyzer = new QueryAnalyzer( request.getQueries(), format.getMaster(),
-                                                    format.getMaster().getStoreManager(), options.isCheckAreaOfUse() );
+                                                    format.getMaster().getStoreManager(), options.isCheckAreaOfUse(), returnMaxFeatures, startIndex );
         Lock lock = acquireLock( request, analyzer );
 
         String schemaLocation = getSchemaLocation( request.getVersion(), analyzer.getFeatureTypes() );
@@ -249,17 +260,6 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
             if ( GML_32 == gmlVersion && !request.getVersion().equals( VERSION_200 ) ) {
                 xmlStream.writeAttribute( "gml", GML3_2_NS, "id", "WFS_RESPONSE" );
             }
-        }
-
-        int returnMaxFeatures = options.getQueryMaxFeatures();
-        BigInteger count = request.getPresentationParams().getCount();
-        if ( count != null && ( options.getQueryMaxFeatures() < 1 || count.intValue() < options.getQueryMaxFeatures() ) ) {
-            returnMaxFeatures = count.intValue();
-        }
-
-        int startIndex = 0;
-        if ( request.getPresentationParams().getStartIndex() != null ) {
-            startIndex = request.getPresentationParams().getStartIndex().intValue();
         }
 
         GMLStreamWriter gmlStream = createGMLStreamWriter( gmlVersion, xmlStream );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -129,7 +129,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
     /**
      * Creates a new {@link GmlGetFeatureHandler} instance.
      * 
-     * @param gmlFormat
+     * @param format
      *            never <code>null</code>
      */
     public GmlGetFeatureHandler( GmlFormat format ) {
@@ -481,8 +481,6 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
         }
 
         // retrieve and write result features
-        int featuresAdded = 0;
-        int featuresSkipped = 0;
         GmlXlinkOptions resolveState = gmlStream.getReferenceResolveStrategy().getResolveOptions();
         for ( Map.Entry<FeatureStore, List<Query>> fsToQueries : analyzer.getQueries().entrySet() ) {
             FeatureStore fs = fsToQueries.getKey();
@@ -493,16 +491,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                     if ( lock != null && !lock.isLocked( member.getId() ) ) {
                         continue;
                     }
-                    if ( featuresAdded == maxFeatures ) {
-                        // limit the number of features written to maxfeatures
-                        break;
-                    }
-                    if ( featuresSkipped < startIndex ) {
-                        featuresSkipped++;
-                    } else {
-                        writeMemberFeature( member, gmlStream, xmlStream, resolveState, featureMemberEl );
-                        featuresAdded++;
-                    }
+                    writeMemberFeature( member, gmlStream, xmlStream, resolveState, featureMemberEl );
                 }
             } finally {
                 LOG.debug( "Closing FeatureResultSet (stream)" );
@@ -521,8 +510,6 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
         Set<String> fids = new HashSet<String>();
 
         // retrieve maxfeatures features
-        int featuresAdded = 0;
-        int featuresSkipped = 0;
         for ( Map.Entry<FeatureStore, List<Query>> fsToQueries : analyzer.getQueries().entrySet() ) {
             FeatureStore fs = fsToQueries.getKey();
             Query[] queries = fsToQueries.getValue().toArray( new Query[fsToQueries.getValue().size()] );
@@ -532,15 +519,9 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                     if ( lock != null && !lock.isLocked( feature.getId() ) ) {
                         continue;
                     }
-                    if ( featuresAdded == maxFeatures ) {
-                        break;
-                    }
-                    if ( featuresSkipped < startIndex ) {
-                        featuresSkipped++;
-                    } else if ( !fids.contains( feature.getId() ) ) {
+                    if ( !fids.contains( feature.getId() ) ) {
                         allFeatures.add( feature );
                         fids.add( feature.getId() );
-                        featuresAdded++;
                     }
                 }
             } finally {

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -503,6 +503,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                         if ( featuresSkipped < startIndex ) {
                             featuresSkipped++;
                         } else {
+                            writeMemberFeature( member, gmlStream, xmlStream, resolveState, featureMemberEl );
                             featuresAdded++;
                         }
                     } else {

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -532,7 +532,6 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
         int featuresSkipped = 0;
         Map<FeatureStore, List<Query>> analysedQueries = analyzer.getQueries();
         boolean applyMaxFeaturesAndStartIndex = checkIfMaxFeaturesAndStartIndexMustBeApplied( analysedQueries );
-        System.out.println( "#########APPLY??? " + applyMaxFeaturesAndStartIndex );
         for ( Map.Entry<FeatureStore, List<Query>> fsToQueries : analysedQueries.entrySet() ) {
             FeatureStore fs = fsToQueries.getKey();
             Query[] queries = fsToQueries.getValue().toArray( new Query[fsToQueries.getValue().size()] );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/QueryAnalyzer.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/QueryAnalyzer.java
@@ -43,6 +43,7 @@ import static org.deegree.services.wfs.query.StoredQueryHandler.GET_FEATURE_BY_T
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.math.BigInteger;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,11 +139,17 @@ public class QueryAnalyzer {
 
     private final boolean checkAreaOfUse;
 
+    private final int count;
+
+    private final int startIndex;
+
     /**
      * Creates a new {@link QueryAnalyzer}.
-     * 
+     *
      * @param wfsQueries
      *            queries be performed, must not be <code>null</code>
+     * @param controller
+     *            {@link WebFeatureService} to be used, must not be <code>null</code>
      * @param service
      *            {@link WfsFeatureStoreManager} to be used, must not be <code>null</code>
      * @param checkInputDomain
@@ -153,10 +160,36 @@ public class QueryAnalyzer {
      */
     public QueryAnalyzer( List<org.deegree.protocol.wfs.query.Query> wfsQueries, WebFeatureService controller,
                           WfsFeatureStoreManager service, boolean checkInputDomain ) throws OWSException {
+        this(wfsQueries, controller, service, checkInputDomain, -1, 0);
+    }
+
+    /**
+     * Creates a new {@link QueryAnalyzer}.
+     *
+     * @param wfsQueries
+     *            queries be performed, must not be <code>null</code>
+     * @param controller
+     *            {@link WebFeatureService} to be used, must not be <code>null</code>
+     * @param service
+     *            {@link WfsFeatureStoreManager} to be used, must not be <code>null</code>
+     * @param checkInputDomain
+     *            true, if geometries in query constraints should be checked against validity domain of the SRS (needed
+     *            for CITE 1.1.0 compliance)
+     * @param count
+     *            number of features to return, if not specified: -1
+     * @param startIndex
+     *            index of the first feature to return, default: 0
+     * @throws OWSException
+     *             if the request cannot be performed, e.g. because it queries feature types that are not served
+     */
+    public QueryAnalyzer( List<org.deegree.protocol.wfs.query.Query> wfsQueries, WebFeatureService controller,
+                          WfsFeatureStoreManager service, boolean checkInputDomain, int count, int startIndex ) throws OWSException {
 
         this.controller = controller;
         this.service = service;
         this.checkAreaOfUse = checkInputDomain;
+        this.count = count;
+        this.startIndex = startIndex;
 
         // generate validated feature store queries
         if ( wfsQueries.isEmpty() ) {
@@ -458,8 +491,7 @@ public class QueryAnalyzer {
             Filters.setDefaultCRS( filter, controller.getDefaultQueryCrs() );
         }
 
-        return new Query( typeNames, filter, ( (AdHocQuery) wfsQuery ).getFeatureVersion(),
-                          ( (AdHocQuery) wfsQuery ).getSrsName(), sortProps );
+        return new Query( typeNames, filter, sortProps, count, startIndex );
     }
 
     private void validatePropertyName( ValueReference propName, TypeName[] typeNames )


### PR DESCRIPTION
Fixes #648 and replaces #832. This pull request enhances the paging mechanism for WFS GetFeature response processing when parameter STARTINDEX and COUNT are provided.
It uses SQL `OFFSET/ROWS FETCH NEXT` syntax which requires at least Oracle 12c, MS SQLServer 2008 or PostgreSQL 9.4. The behavior of PR  #619 is preserved.