### PR TITLE
Enable configuration of multiple schema locations

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormatOptions.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormatOptions.java
@@ -41,6 +41,7 @@ import org.deegree.geometry.Geometry;
 import org.deegree.geometry.SFSProfiler;
 import org.deegree.geometry.io.CoordinateFormatter;
 import org.deegree.gml.GMLVersion;
+import org.deegree.gml.schema.GMLSchemaInfoSet;
 
 /**
  * Configuration options for {@link GmlFormat}.
@@ -82,6 +83,9 @@ public class GmlFormatOptions {
 
     private final boolean enableResponsePaging;
 
+    private final GMLSchemaInfoSet originalSchemaLocation;
+
+
     /**
      * Creates a new {@link GmlFormatOptions} instance.
      * 
@@ -114,7 +118,8 @@ public class GmlFormatOptions {
                              final int queryMaxFeatures, final boolean checkAreaOfUse,
                              final CoordinateFormatter formatter, final String appSchemaBaseURL, final String mimeType,
                              final boolean exportOriginalSchema, final SFSProfiler geometrySimplifier,
-                             final NamespaceBindings prebindNamespaces, final boolean enableResponsePaging ) {
+                             final NamespaceBindings prebindNamespaces, final boolean enableResponsePaging,
+                             final GMLSchemaInfoSet originalSchemaLocation ) {
         this.gmlVersion = gmlVersion;
         this.responseContainerEl = responseContainerEl;
         this.responseFeatureMemberEl = responseFeatureMemberEl;
@@ -130,6 +135,7 @@ public class GmlFormatOptions {
         this.geometrySimplifier = geometrySimplifier;
         this.prebindNamespaces = prebindNamespaces;
         this.enableResponsePaging = enableResponsePaging;
+        this.originalSchemaLocation = originalSchemaLocation;
     }
 
     /**
@@ -237,6 +243,11 @@ public class GmlFormatOptions {
      */
     public boolean isEnableResponsePaging() {
         return enableResponsePaging;
+    }
+
+
+    public GMLSchemaInfoSet getOriginalSchemaLocation() {
+        return originalSchemaLocation;
     }
 
 }

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
@@ -250,12 +250,16 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
             Collection<String> namespaces = determineRequiredNamespaces( request );
             String targetNs = namespaces.iterator().next();
             if ( options.isExportOriginalSchema() ) {
-                GMLSchemaInfoSet gmlSchema = findGmlSchema( namespaces, version );
-                if ( gmlSchema != null ) {
-                    exportOriginalInfoSet( writer, gmlSchema, targetNs );
+                if (options.getOriginalSchemaLocation() != null) {
+                    exportOriginalInfoSet(writer, options.getOriginalSchemaLocation(), targetNs);
                 } else {
-                    LOG.warn( "Could not find original schema corresponding to the requested schema, try to reencode the schema!" );
-                    reencodeSchema( request, writer, targetNs, namespaces, version );
+                    GMLSchemaInfoSet gmlSchema = findGmlSchema(namespaces, version);
+                    if (gmlSchema != null) {
+                        exportOriginalInfoSet(writer, gmlSchema, targetNs);
+                    } else {
+                        LOG.warn("Could not find original schema corresponding to the requested schema, try to reencode the schema!");
+                        reencodeSchema(request, writer, targetNs, namespaces, version);
+                    }
                 }
             } else {
                 reencodeSchema( request, writer, targetNs, namespaces, version );

--- a/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
+++ b/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/3.4.0/wfs_configuration.xsd
@@ -135,6 +135,7 @@
                       </simpleContent>
                     </complexType>
                   </element>
+                  <element name="SchemaLocation" type="string" minOccurs="0" />
                   <element name="DisableStreaming" type="boolean" minOccurs="0" default="false" />
                   <element name="PrebindNamespace" minOccurs="0" maxOccurs="unbounded">
                     <complexType>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -398,6 +398,7 @@ _GMLFormat_.
       http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/deprecatedTypes.xsd
     </AdditionalSchemaLocation>
     <DisableDynamicSchema>true</DisableDynamicSchema>
+    <SchemaLocation>../appschema/originalGmlSchema.xsd</SchemaLocation>
     <DisableStreaming>false</DisableStreaming>
     <GeometryLinearization>
       <Accuracy>0.1</Accuracy>
@@ -466,6 +467,9 @@ attribute of wfs:FeatureCollection
 |DisableDynamicSchema |0..1 |Complex |Controls DescribeFeatureType
 strategy, default: regenerate schema
 
+|SchemaLocation |0..1 |Complex |Location of the GML application schema
+for this GML version
+
 |DisableStreaming |0..1 |Boolean |Disables output streaming, include
 numberOfFeature information/gml:boundedBy
 
@@ -503,6 +507,15 @@ for configuring the feature store. If you want the references to point
 to an external copy of your GML application schema files (instead of
 pointing back to the deegree WFS), use the optional attribute
 _baseURL_ that this element provides.
+* _SchemaLocation_: By default, the GML application schema
+returned in DescribeFeatureType reponses (and referenced in the
+_xsi:schemaLocation_ of query responses) will be generated dynamically
+from the internal feature type representation or, if DisableDynamicSchema
+is set to _true_, the original schema files used for configuring the feature
+store is used. If your service supports multiple GML version it may be useful
+to configure the GML application schema for each version differently.
+Use _SchemaLocation_ to configure the original GML application schema
+for this GML version. To enable this option _DisableDynamicSchema_ must be _true_.
 * _DisableStreaming_: By default, returned features are not collected
 in memory, but directly streamed from the backend (e.g. an SQL database)
 and individually encoded as GML. This enables the querying of huge

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -509,7 +509,7 @@ pointing back to the deegree WFS), use the optional attribute
 _baseURL_ that this element provides.
 * _SchemaLocation_: By default, the GML application schema
 returned in DescribeFeatureType reponses (and referenced in the
-_xsi:schemaLocation_ of query responses) will be generated dynamically
+_xsi:schemaLocation_ of GetFeature responses) will be generated dynamically
 from the internal feature type representation or, if DisableDynamicSchema
 is set to _true_, the original schema files used for configuring the feature
 store is used. If your service supports multiple GML version it may be useful
@@ -531,19 +531,24 @@ numberOfFeature information and gml:boundedBy for the collection.
 However, for huge response and heavy server load, this is not
 recommended as it introduces significant overhead and may result in
 out-of-memory errors.
-
 * _PrebindNamespace_: By default, XML namespaces are bound when they
 are needed. This will result in valid output, but may lead to the same
 namespace being bound again and again in different parts of the response
 document. Using this option, namespaces can be bound in the root
 element, so they are defined for the full scope of the response document
 and do not need re-definition at several positions in the document. This
-option has the required attributes _prefix_ and _uri_. .. note::
-PrebindNamespaces must be configured as in used GML application schemas
+option has the required attributes _prefix_ and _uri_.
+
+NOTE: PrebindNamespaces must be configured as in used GML application schemas
 respectively the imported features (at least for the BLOB mode). It is
 essential to ensure that prefixes are bound to the same namespace URIs.
 Otherwise, a GetFeature request may result in a failure ("Duplicate
 declaration for namespace prefix").
+
+TIP: _SchemaLocation_ can be used in addition to the referenced GML application
+schema in the feature store. It is not required to configure a schema twice.
+E.g. if in the feature store the GML application schema for GML 3.2 is referenced,
+_SchemaLocation_ must be configured only for GML 3.1 not for GML 3.2.
 
 ===== Coordinate formatters
 


### PR DESCRIPTION
This enhancement makes it possible to configure multiple schema locations to support static schemas for multiple GML versions in DescribeFeatureType responses of a single WFS.

For example, if DescribeFeatureType responses of a single WFS shall support non generated schemas for multiple GML versions, the newly introduced configuration option solves that use case.

Please also see #892 for further details.

Caution, this pull request also includes #1001. Thus, #1001 should be merged first.

Fixes #892.