### PR TITLE
Upgrade to most recent MS SQL Server JDBC Driver version for JDK 8

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -40,9 +40,9 @@
       </repositories>
       <dependencies>
         <dependency>
-          <groupId>com.microsoft</groupId>
-          <artifactId>sqljdbc4</artifactId>
-          <version>3.0</version>
+          <groupId>com.microsoft.sqlserver</groupId>
+          <artifactId>mssql-jdbc</artifactId>
+          <version>7.4.1.jre8</version>
         </dependency>
       </dependencies>
     </profile>
@@ -62,4 +62,3 @@
   </dependencies>
 
 </project>
-


### PR DESCRIPTION
This PR upgrades the JDBC driver for MS SQL Server to the most recent version for JDK 8 which is available from maven central.