### PR TITLE
Upgrade Jersey to 1.19.4 and commons-fileupload to 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.3</version>
+        <version>1.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -511,7 +511,7 @@
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>
-        <version>1.17.1</version>
+        <version>1.19.4</version>
       </dependency>
       <!-- logging -->
       <dependency>


### PR DESCRIPTION
This PR upgrades the dependencies Jersey to 1.19.4 (from 1.17.1) and commons-fileupload to 1.4 (from 1.3.3).