### PR TITLE
Fixes deegree web admin console showing stack trace in case of session timeout

### DIFF
--- a/deegree-services/deegree-webservices/src/main/webapp/WEB-INF/faces-config.xml
+++ b/deegree-services/deegree-webservices/src/main/webapp/WEB-INF/faces-config.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd"
   version="2.0">
 
-  <name>goawayeclipsebug</name>
+  <name>deegree services console UI</name>
 
   <application>
     <locale-config>
@@ -54,6 +54,10 @@
     <navigation-case>
       <from-outcome>failed</from-outcome>
       <to-view-id>/console/jsf/logInFailed.xhtml</to-view-id>
+    </navigation-case>
+    <navigation-case>
+      <from-outcome>home</from-outcome>
+      <to-view-id>/index.xhtml</to-view-id>
     </navigation-case>
   </navigation-rule>
   <!-- PhaseListener -->

--- a/deegree-services/deegree-webservices/src/main/webapp/WEB-INF/web.xml
+++ b/deegree-services/deegree-webservices/src/main/webapp/WEB-INF/web.xml
@@ -95,7 +95,6 @@
     <role-name>deegree</role-name>
   </security-role>
 
-
   <!-- http basic auth enable -->
   <!-- Define a security constraint on this application -->
   <!-- User and role must be added to tomcat-users.xml -->
@@ -105,9 +104,9 @@
     role that is required to log in to the Manager Application</description> <role-name>demoadmin</role-name> </security-role> -->
   <!-- end -->
 
-  <!-- error-page>
-      <exception-type>java.lang.Exception</exception-type>
-      <location>/error.xhtml</location>
-  </error-page-->
+  <error-page>
+    <exception-type>javax.faces.application.ViewExpiredException</exception-type>
+    <location>/index.jsf</location>
+  </error-page>
 
 </web-app>

--- a/deegree-services/deegree-webservices/src/main/webapp/index.xhtml
+++ b/deegree-services/deegree-webservices/src/main/webapp/index.xhtml
@@ -12,23 +12,24 @@
         <ul>
           <li>workspaces: Download and activate example configurations</li>
           <li>proxy: Configure proxy settings</li>
+          <li>password: Set a password to restrict access to the deegree service console <b style="color:Red;">(IMPORTANT!)</b></li>
           <li>module info: Display loaded deegree modules</li>
           <li>send requests: Send raw XML requests</li>
           <li>see layers: Display WMS layers</li>
         </ul>
         <h:outputText value="The lower menu on the left configures the active workspace:" />
         <ul>
-          <li>web services: Configure offered OGC web services</li>
+          <li>web services: Configure OGC web services</li>
           <li>data stores: Configure access to data sources</li>
           <li>map layers: Configure map layers and styles</li>
-          <li>server connections: Configure connections to external servers</li>
+          <li>connections: Configure connections to databases and external servers</li>
           <li>processes: Configure geospatial WPS processes</li>
         </ul>
       </h:panelGroup>
       <br />
       <h:panelGroup styleClass="welcomeText">
         <h:outputText value="For more information, please refer to the " />
-        <h:outputLink styleClass="welcomeLink" value="http://www.deegree.org/Documentation">
+        <h:outputLink styleClass="welcomeLink" value="https://www.deegree.org/documentation">
           <h:outputText value="official documentation" />
         </h:outputLink>
         <h:outputText value="." />

--- a/deegree-services/deegree-webservices/src/main/webapp/layout.xhtml
+++ b/deegree-services/deegree-webservices/src/main/webapp/layout.xhtml
@@ -41,7 +41,7 @@
         </h:panelGroup>
       </h:panelGroup>
       <h:panelGroup id="logo" layout="block">
-        <h:graphicImage name="images/logo.png" />
+        <h:graphicImage name="images/logo.png" alt="deegree logo"/>
       </h:panelGroup>
       <h:panelGroup id="login">
         <ui:include src="/console/security/login.xhtml" />

--- a/deegree-services/deegree-webservices/src/main/webapp/menu.xhtml
+++ b/deegree-services/deegree-webservices/src/main/webapp/menu.xhtml
@@ -3,6 +3,7 @@
   xmlns:c="http://java.sun.com/jsp/jstl/core" xmlns:fn="http://java.sun.com/jsp/jstl/functions"
   xmlns:dg="http://deegree.org/jsf" xmlns:dgc="http://java.sun.com/jsf/composite/deegree">
   <h:panelGroup layout="block">
+    <h:link styleClass="menutopic" value="Home" outcome="home"/><br/><br/>
     <h:outputText styleClass="menutopic" value="general" />
   </h:panelGroup>
   <h:panelGroup rendered="#{logBean.loggedIn}" layout="block">
@@ -17,7 +18,7 @@
   </h:panelGroup>
   <h:panelGroup rendered="#{logBean.loggedIn}">
     <h:panelGroup layout="block">
-      <h:outputText styleClass="menutopic" value="webservices" />
+      <h:outputText styleClass="menutopic" value="web services" />
     </h:panelGroup>
     <h:panelGroup layout="block">
       <dgc:menuitem displayname="services" target="/console/webservices/index" hasErrors="#{servicesBean.hasErrors}" />


### PR DESCRIPTION
This PR fixes a bug in deegree's web console that a session timeout produces a stack trace. Now the browser navigates back to the main page after session timeout instead of showing a stack trace.
It also fixes also a broken link to documentation and minor typos and wording in console main page, furthermore adds a new menu entry "home" to navigate back to entry page.