### PR TITLE
Fixes issue #886

### DIFF
--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/AbstractGeometryValidationEvent.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/AbstractGeometryValidationEvent.java
@@ -37,6 +37,9 @@ package org.deegree.geometry.validation.event;
 
 import java.util.List;
 
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.components.Axis;
+
 /**
  * Abstract base class for {@link GeometryValidationEvent} implementations.
  * 
@@ -63,6 +66,40 @@ abstract class AbstractGeometryValidationEvent implements GeometryValidationEven
     @Override
     public List<Object> getGeometryParticleHierarchy() {
         return geometryParticleHierachy;
+    }
+
+    /**
+     * Returns true if the geometry has a left handed CRS.
+     * 
+     * @return <code>true</code> if geometry has a left handed CRS, <code>false</code> if CRS is right handed
+     */
+    protected boolean isLeftHanded( ICRS crs ) {
+        // get number of dimensions (it should be 2)
+        if ( crs.getDimension() == 2 ) {
+            int axis1 = crs.getAxis()[0].getOrientation();
+            int axis2 = crs.getAxis()[1].getOrientation();
+
+            // check if CRS is left handed
+            if ( axis1 == Axis.AO_EAST || axis1 == Axis.AO_WEST ) {
+                if ( axis1 == Axis.AO_EAST && ( axis2 == Axis.AO_SOUTH || axis2 == Axis.AO_DOWN ) ) {
+                    return true;
+                }
+                else if ( axis1 == Axis.AO_WEST && ( axis2 == Axis.AO_NORTH || axis2 == Axis.AO_UP ) ) {
+                    return true;
+                }
+            }
+            else {
+                if ( ( axis1 == Axis.AO_SOUTH || axis1 == Axis.AO_DOWN ) && axis2 == Axis.AO_WEST ) {
+                    return true;
+                }
+                else if ( ( axis1 == Axis.AO_NORTH || axis1 == Axis.AO_UP ) && axis2 == Axis.AO_EAST ) {
+                    return true;
+                }
+            }
+        }
+
+        // return false in any other case
+        return false;
     }
 
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/ExteriorRingOrientation.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/ExteriorRingOrientation.java
@@ -40,9 +40,6 @@ import java.util.List;
 import org.deegree.geometry.primitive.Ring;
 import org.deegree.geometry.primitive.patches.PolygonPatch;
 
-import org.deegree.cs.coordinatesystems.ICRS;
-import org.deegree.cs.components.Axis;
-
 /**
  * {@link GeometryValidationEvent} that indicates the orientation of an exterior {@link Ring} of a {@link PolygonPatch}.
  * 
@@ -90,42 +87,6 @@ public class ExteriorRingOrientation extends AbstractGeometryValidationEvent {
     public boolean isClockwise() {
         return isClockwise;
     }
-    
-    /**
-     * Returns true if the geometry has a left handed CRS.
-     * 
-     * @return <code>true</code> if geometry has a left handed CRS, <code>false</code> if CRS is right handed
-     */
-    public boolean hasLeftHandedSrs() {
-        ICRS crs = patch.getExteriorRing().getCoordinateSystem();
-    
-        // get number of dimensions (it should be 2)
-        if ( crs.getDimension() == 2 ) {
-            int axis1 = crs.getAxis()[0].getOrientation();
-            int axis2 = crs.getAxis()[1].getOrientation();
-
-            // check if CRS is left handed
-            if ( axis1 == Axis.AO_EAST || axis1 == Axis.AO_WEST ) {
-                if ( axis1 == Axis.AO_EAST && ( axis2 == Axis.AO_SOUTH || axis2 == Axis.AO_DOWN ) ) {
-                    return true;
-                }
-                else if ( axis1 == Axis.AO_WEST && ( axis2 == Axis.AO_NORTH || axis2 == Axis.AO_UP ) ) {
-                    return true;
-                }
-            }
-            else {
-                if ( ( axis1 == Axis.AO_SOUTH || axis1 == Axis.AO_DOWN ) && axis2 == Axis.AO_WEST ) {
-                    return true;
-                }
-                else if ( ( axis1 == Axis.AO_NORTH || axis1 == Axis.AO_UP ) && axis2 == Axis.AO_EAST ) {
-                    return true;
-                }
-            }
-        }
-
-        // return false in any other case
-        return false;
-    }
 
     /**
      * Returns true if the geometry is an exterior boundary.
@@ -135,7 +96,7 @@ public class ExteriorRingOrientation extends AbstractGeometryValidationEvent {
     public boolean isExterior() {
         boolean isExterior = !isClockwise;
 
-        if ( hasLeftHandedSrs() ) {
+        if ( isLeftHanded( patch.getExteriorRing().getCoordinateSystem() ) ) {
             isExterior = !isExterior;
         }
 

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/ExteriorRingOrientation.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/ExteriorRingOrientation.java
@@ -40,6 +40,9 @@ import java.util.List;
 import org.deegree.geometry.primitive.Ring;
 import org.deegree.geometry.primitive.patches.PolygonPatch;
 
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.components.Axis;
+
 /**
  * {@link GeometryValidationEvent} that indicates the orientation of an exterior {@link Ring} of a {@link PolygonPatch}.
  * 
@@ -86,6 +89,57 @@ public class ExteriorRingOrientation extends AbstractGeometryValidationEvent {
      */
     public boolean isClockwise() {
         return isClockwise;
+    }
+    
+    /**
+     * Returns true if the geometry has a left handed CRS.
+     * 
+     * @return <code>true</code> if geometry has a left handed CRS, <code>false</code> if CRS is right handed
+     */
+    public boolean hasLeftHandedSrs() {
+        ICRS crs = patch.getExteriorRing().getCoordinateSystem();
+    
+        // get number of dimensions (it should be 2)
+        if ( crs.getDimension() == 2 ) {
+            int axis1 = crs.getAxis()[0].getOrientation();
+            int axis2 = crs.getAxis()[1].getOrientation();
+
+            // check if CRS is left handed
+            if ( axis1 == Axis.AO_EAST || axis1 == Axis.AO_WEST ) {
+                if ( axis1 == Axis.AO_EAST && ( axis2 == Axis.AO_SOUTH || axis2 == Axis.AO_DOWN ) ) {
+                    return true;
+                }
+                else if ( axis1 == Axis.AO_WEST && ( axis2 == Axis.AO_NORTH || axis2 == Axis.AO_UP ) ) {
+                    return true;
+                }
+            }
+            else {
+                if ( ( axis1 == Axis.AO_SOUTH || axis1 == Axis.AO_DOWN ) && axis2 == Axis.AO_WEST ) {
+                    return true;
+                }
+                else if ( ( axis1 == Axis.AO_NORTH || axis1 == Axis.AO_UP ) && axis2 == Axis.AO_EAST ) {
+                    return true;
+                }
+            }
+        }
+
+        // return false in any other case
+        return false;
+    }
+
+    /**
+     * Returns true if the geometry is an exterior boundary.
+     * 
+     * @return <code>true</code> if geometry is an exterior boundary, <code>false</code> if it's interior
+     */
+    public boolean isExterior() {
+        boolean isExterior = !isClockwise;
+
+        if ( hasLeftHandedSrs() ) {
+            isExterior = !isExterior;
+        }
+
+        return isExterior;
     }
 
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/InteriorRingOrientation.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/InteriorRingOrientation.java
@@ -40,6 +40,9 @@ import java.util.List;
 import org.deegree.geometry.primitive.Ring;
 import org.deegree.geometry.primitive.patches.PolygonPatch;
 
+import org.deegree.cs.coordinatesystems.ICRS;
+import org.deegree.cs.components.Axis;
+
 /**
  * {@link GeometryValidationEvent} that indicates the orientation of an interior {@link Ring} of a {@link PolygonPatch}.
  * 
@@ -101,6 +104,57 @@ public class InteriorRingOrientation extends AbstractGeometryValidationEvent {
      */
     public boolean isClockwise() {
         return isClockwise;
+    }
+    
+    /**
+     * Returns true if the geometry has a left handed CRS.
+     * 
+     * @return <code>true</code> if geometry has a left handed CRS, <code>false</code> if CRS is right handed
+     */
+    public boolean hasLeftHandedSrs() {
+        ICRS crs = patch.getInteriorRings().get( ringIdx ).getCoordinateSystem();
+    
+        // get number of dimensions (it should be 2)
+        if ( crs.getDimension() == 2 ) {
+            int axis1 = crs.getAxis()[0].getOrientation();
+            int axis2 = crs.getAxis()[1].getOrientation();
+
+            // check if CRS is left handed
+            if ( axis1 == Axis.AO_EAST || axis1 == Axis.AO_WEST ) {
+                if ( axis1 == Axis.AO_EAST && ( axis2 == Axis.AO_SOUTH || axis2 == Axis.AO_DOWN ) ) {
+                    return true;
+                }
+                else if ( axis1 == Axis.AO_WEST && ( axis2 == Axis.AO_NORTH || axis2 == Axis.AO_UP ) ) {
+                    return true;
+                }
+            }
+            else {
+                if ( ( axis1 == Axis.AO_SOUTH || axis1 == Axis.AO_DOWN ) && axis2 == Axis.AO_WEST ) {
+                    return true;
+                }
+                else if ( ( axis1 == Axis.AO_NORTH || axis1 == Axis.AO_UP ) && axis2 == Axis.AO_EAST ) {
+                    return true;
+                }
+            }
+        }
+
+        // return false in any other case
+        return false;
+    }
+
+    /**
+     * Returns true if the geometry is an interior boundary.
+     * 
+     * @return <code>true</code> if geometry is an interior boundary, <code>false</code> if it's exterior
+     */
+    public boolean isInterior() {
+        boolean isInterior = isClockwise;
+
+        if ( hasLeftHandedSrs() ) {
+            isInterior = !isInterior;
+        }
+
+        return isInterior;
     }
 
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/InteriorRingOrientation.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/event/InteriorRingOrientation.java
@@ -40,9 +40,6 @@ import java.util.List;
 import org.deegree.geometry.primitive.Ring;
 import org.deegree.geometry.primitive.patches.PolygonPatch;
 
-import org.deegree.cs.coordinatesystems.ICRS;
-import org.deegree.cs.components.Axis;
-
 /**
  * {@link GeometryValidationEvent} that indicates the orientation of an interior {@link Ring} of a {@link PolygonPatch}.
  * 
@@ -105,42 +102,6 @@ public class InteriorRingOrientation extends AbstractGeometryValidationEvent {
     public boolean isClockwise() {
         return isClockwise;
     }
-    
-    /**
-     * Returns true if the geometry has a left handed CRS.
-     * 
-     * @return <code>true</code> if geometry has a left handed CRS, <code>false</code> if CRS is right handed
-     */
-    public boolean hasLeftHandedSrs() {
-        ICRS crs = patch.getInteriorRings().get( ringIdx ).getCoordinateSystem();
-    
-        // get number of dimensions (it should be 2)
-        if ( crs.getDimension() == 2 ) {
-            int axis1 = crs.getAxis()[0].getOrientation();
-            int axis2 = crs.getAxis()[1].getOrientation();
-
-            // check if CRS is left handed
-            if ( axis1 == Axis.AO_EAST || axis1 == Axis.AO_WEST ) {
-                if ( axis1 == Axis.AO_EAST && ( axis2 == Axis.AO_SOUTH || axis2 == Axis.AO_DOWN ) ) {
-                    return true;
-                }
-                else if ( axis1 == Axis.AO_WEST && ( axis2 == Axis.AO_NORTH || axis2 == Axis.AO_UP ) ) {
-                    return true;
-                }
-            }
-            else {
-                if ( ( axis1 == Axis.AO_SOUTH || axis1 == Axis.AO_DOWN ) && axis2 == Axis.AO_WEST ) {
-                    return true;
-                }
-                else if ( ( axis1 == Axis.AO_NORTH || axis1 == Axis.AO_UP ) && axis2 == Axis.AO_EAST ) {
-                    return true;
-                }
-            }
-        }
-
-        // return false in any other case
-        return false;
-    }
 
     /**
      * Returns true if the geometry is an interior boundary.
@@ -150,7 +111,7 @@ public class InteriorRingOrientation extends AbstractGeometryValidationEvent {
     public boolean isInterior() {
         boolean isInterior = isClockwise;
 
-        if ( hasLeftHandedSrs() ) {
+        if ( isLeftHanded( patch.getInteriorRings().get( ringIdx ).getCoordinateSystem() ) ) {
             isInterior = !isInterior;
         }
 


### PR DESCRIPTION
Added fix for https://github.com/deegree/deegree3/issues/886 methods `hasLeftHandedSrs`, `isInterior` and `isExterior` in InteriorRingOriention and ExteriorRingOrientation respectively. The solution implemented checks the orientation of the axis for the declared Polygon patch to decide the left-handness, and uses this to check if the ring is exterior or interior.