### PR TITLE
Downgrade to JTS 1.15.0 to resolve the failing integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -936,7 +936,7 @@
       <dependency>
         <groupId>org.locationtech.jts</groupId>
         <artifactId>jts-core</artifactId>
-        <version>1.16.0</version>
+        <version>1.15.0</version>
       </dependency>
       <dependency>
         <groupId>jgridshift</groupId>


### PR DESCRIPTION
Fixes #1033 Downgrade to JTS 1.15.0 to resolve the failing integration testsWMSSimilarityIntegrationTest.testSimilarity