### PR TITLE
Revert "Change surefire settings"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,8 @@
           <configuration>
             <!-- Travis build workaround -->
             <argLine>-Xms1024m -Xmx2048m</argLine>
-            <forkCount>5</forkCount>
+            <forkCount>1</forkCount>
+            <reuseForks>true</reuseForks>
             <skip>${skip.unit.tests}</skip>
           </configuration>
         </plugin>


### PR DESCRIPTION
Reverts deegree/deegree3#1050

Fixes following test errors when building with `mvn clean install -Pintegration-tests,oracle,mssql,handbook`:
```
[ERROR] Errors: 
[ERROR]   WCSCite100IntegrationTest.getResultSnippets:58 NullPointer
[ERROR]   WFSCite110IntegrationTest.getResultSnippets:60 NullPointer
[ERROR]   WMSCite130IntegrationTest.getResultSnippets:58 NullPointer
[ERROR]   WMSCite130NewIntegrationTest.getResultSnippets:58 NullPointer
[INFO] 
[ERROR] Tests run: 600, Failures: 0, Errors: 4, Skipped: 0
```