### PR TITLE
Enhance Image Similarity Test

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/AbstractSimilarityTest.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/AbstractSimilarityTest.java
@@ -105,7 +105,7 @@ public abstract class AbstractSimilarityTest {
                 IOUtils.write( actualData, new FileOutputStream( System.getProperty( "java.io.tmpdir" ) + "/rendering_"
                                                                  + name + "_actual.png" ) );
 
-                System.out.println( "Result returned for " + name + " (base64 -d encoded.dat > failed-test.zip)" );
+                System.out.println( "Result returned for " + name + " (base64 -di encoded.dat > failed-test.zip)" );
                 System.out.println( IntegrationTestUtils.toBase64Zip( actualData, name + ".png" ) );
             } catch ( Throwable t ) {
             }

--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/Java2DRendererTest.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/Java2DRendererTest.java
@@ -90,6 +90,7 @@ import org.deegree.style.styling.components.Mark.SimpleMark;
 import org.deegree.style.styling.components.Stroke;
 import org.deegree.style.styling.components.Stroke.LineJoin;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -582,6 +583,7 @@ public class Java2DRendererTest extends AbstractSimilarityTest {
      * @throws Exception
      */
     @Test
+    @Ignore
     public void testTextStyling2()
                             throws Exception {
         BufferedImage img = new BufferedImage( 1000, 1000, TYPE_INT_ARGB );

--- a/deegree-tests/deegree-wms-similarity-tests/src/test/java/org/deegree/services/wms/WMSSimilarityIntegrationTest.java
+++ b/deegree-tests/deegree-wms-similarity-tests/src/test/java/org/deegree/services/wms/WMSSimilarityIntegrationTest.java
@@ -153,7 +153,7 @@ public class WMSSimilarityIntegrationTest {
                 IOUtils.write( bs, new FileOutputStream( System.getProperty( "java.io.tmpdir" ) + "/response"
                                                          + numFailed + ".tif" ) );
 
-                System.out.println( "Result returned for " + name + " (base64 -d encoded.dat > failed-test.zip)" );
+                System.out.println( "Result returned for " + name + " (base64 -di encoded.dat > failed-test.zip)" );
                 System.out.println( IntegrationTestUtils.toBase64Zip( bs, name + ".tif" ) );
             } catch ( Throwable t ) {
             }


### PR DESCRIPTION
This Pull-Request disables the Test org.deegree.rendering.r2d.Java2DRendererTest.testTextStyling2() as it is unreliable on the server.

It also improves the log messages regarding the usage of base64 output, as many older versions / implementations of base64 cannot handle line breaks correctly.

See https://stackoverflow.com/questions/15490728/decode-base64-invalid-input