### PR TITLE
#1079 fixes build status image and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-| Master (3.4) | Maintenance (3.3) | OpenHUB |
-| ------------ | ----------------- | ------------- |
-| [![Master Build Status](https://travis-ci.org/deegree/deegree3.png?branch=master)](https://travis-ci.org/deegree/deegree3) | [![Develop Build Status](https://travis-ci.org/deegree/deegree3.png?branch=3.3-master)](https://travis-ci.org/deegree/deegree3/branches) | [![OpenHUB](https://www.openhub.net/p/deegree3/widgets/project_thin_badge.gif)](https://www.openhub.net/p/deegree3) |
-
-# deegree web services
+| Master (3.4) | Release   | OpenHUB       |
+| ------------ | --------- | ------------- |
+| [![Master Build Status](https://buildserver.deegree.org/buildStatus/icon?job=deegree-3.4-master)](https://buildserver.deegree.org/job/deegree-3.4-master/) | [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/deegree/deegree3?sort=semver)](https://github.com/deegree/deegree3/releases/latest) | [![OpenHUB](https://www.openhub.net/p/deegree3/widgets/project_thin_badge.gif)](https://www.openhub.net/p/deegree3) |
+# deegree webservices
 deegree is open source software for spatial data infrastructures and the geospatial web. deegree includes components for geospatial data management, including data access, visualization, discovery and security. Open standards are at the heart of deegree. The software is built on the standards of the Open Geospatial Consortium (OGC) and the ISO Technical Committee 211.
 
 ## User documentation
-General project information and user documentation (e.g. "How to set up WMS and WFS?" or "How to get support?")  can be found on the deegree homepage:
+General project information and user documentation (e.g. "How to set up WMS and WFS?" or "How to get support?") can be found on the deegree homepage:
 
-http://www.deegree.org
+https://www.deegree.org/documentation
 
 ## Developer documentation
-Developer-related information (e.g. "How to build deegree webservices?") can be found on the deegree3 project wiki on GiHub:
+Information for developer (e.g. "How to build deegree webservices?") can be found on the deegree project wiki on GitHub:
 
 https://github.com/deegree/deegree3/wiki
 
@@ -21,7 +20,7 @@ https://github.com/deegree/deegree3/wiki
 
 deegree is distributed under the GNU Lesser General Public License, Version 2.1 (LGPL 2.1). Generally speaking this means that you have essential freedoms such as: Run the software for any purpose, find out how it works, make changes, redistribute copies (of modified versions). Practically, with these freedoms, you do not have to pay a license fee, you can create as many installations as you need, and you're not bound to one single vendor. Instead you can contact a service provider of your choice to make necessary configurations or code adjustments. Or you may even step up and do this yourself.
 
-More information about free software can be found at the free software foundation. A good starting point is [www.gnu.org](http://www.gnu.org).
+More information about free software can be found at the free software foundation. A good starting point is [www.gnu.org](https://www.gnu.org).
 
 ## Contribution guidelines
 


### PR DESCRIPTION
This PR fixes the build status image and link to Jenkins at https://buildserver.deegree.org, changes all links to https plus fixing minor typos in README.md