### PR TITLE
Fix cache handling of raster files

### DIFF
--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
@@ -486,7 +486,7 @@ public class RasterCache {
                 boolean createCache = reader.shouldCreateCacheFile();
                 File cacheFile = null;
                 if ( createCache ) {
-                    LOG.trace( "create cachefule for location {}", reader.getDataLocationId() );
+                    LOG.trace( "create cachefile for location {}", reader.getDataLocationId() );
                     cacheFile = createCacheFile( reader.getDataLocationId() );
                 }
                 result = new CacheRasterReader( reader, cacheFile, this );

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
@@ -43,6 +43,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.File;
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedSet;
@@ -50,6 +51,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
+import org.deegree.commons.utils.FileUtils;
 import org.deegree.commons.utils.StringUtils;
 import org.deegree.coverage.raster.SimpleRaster;
 import org.deegree.coverage.raster.data.RasterDataFactory;
@@ -110,6 +112,9 @@ public class RasterCache {
 
     private final static ConcurrentSkipListSet<CacheRasterReader> cache = new ConcurrentSkipListSet<CacheRasterReader>(
                                                                                                                         new CacheComparator() );
+
+    private final static Map<String, String> uniqueRasterCacheIds = new HashMap<String, String>();
+
     static {
         evaluateProperties();
     }
@@ -481,6 +486,7 @@ public class RasterCache {
                 boolean createCache = reader.shouldCreateCacheFile();
                 File cacheFile = null;
                 if ( createCache ) {
+                    LOG.trace( "create cachefule for location {}", reader.getDataLocationId() );
                     cacheFile = createCacheFile( reader.getDataLocationId() );
                 }
                 result = new CacheRasterReader( reader, cacheFile, this );
@@ -594,4 +600,47 @@ public class RasterCache {
         maxCacheDisk = 0;
     }
 
+    /**
+     * Generate unique (in the scope of RasterCache) short filename for raster reader identification
+     * 
+     * @param file
+     *            file reference to start with
+     * @return unique filename (may contains prefix to make it unique)
+     */
+    public static synchronized String getUniqueCacheIdentifier( File file ) {
+        String fname = FileUtils.getFilename( file );
+        String apath = file.getAbsolutePath();
+
+        int idx = 0;
+        String key = fname;
+
+        while ( !apath.equals( uniqueRasterCacheIds.getOrDefault( key, apath ) ) ) {
+            idx++;
+            key = idx + "_" + fname;
+        }
+        uniqueRasterCacheIds.put( key, apath );
+        return key;
+    }
+    
+    /**
+     * Helper function to check if a .no-cache or .no-cache-[level] file exists
+     */
+    public static boolean hasNoCacheFile( File file, int level ) {
+        try {
+            if ( file == null || !file.exists() )
+                return false;
+
+            File all = new File( file.getParentFile(), file.getName() + ".no-cache" );
+            if ( all.exists() ) {
+                return true;
+            }
+
+            File lvl = new File( file.getParentFile(), file.getName() + ".no-cache-" + level );
+            return lvl.exists();
+        } catch ( Exception ex ) {
+            LOG.debug( "Failed to check for .no-cache files for {} level {}", file, level );
+            LOG.debug( "Got exception", ex );
+            return false;
+        }
+    }
 }

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterReader.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import org.deegree.commons.utils.FileUtils;
 import org.deegree.coverage.raster.AbstractRaster;
+import org.deegree.coverage.raster.cache.RasterCache;
 import org.deegree.coverage.raster.data.container.BufferResult;
 import org.deegree.coverage.raster.data.info.RasterDataInfo;
 import org.deegree.coverage.raster.geom.RasterGeoReference;
@@ -132,7 +133,7 @@ public class JAIRasterReader implements RasterReader {
         this.dataLocationId = options != null ? options.get( RasterIOOptions.ORIGIN_OF_RASTER ) : null;
         if ( dataLocationId == null ) {
             if ( this.file != null ) {
-                this.dataLocationId = FileUtils.getFilename( this.file );
+                this.dataLocationId = RasterCache.getUniqueCacheIdentifier( this.file );
             }
         }
     }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
@@ -124,6 +124,11 @@ class LegendBuilder {
             res.first = max( res.first, item.getMaxWidth( opts ) );
         }
 
+        if ( res.second == 0 ) {
+            // prevent >0 * 0 sized images
+            res.second = 2 * opts.spacing + opts.baseWidth;
+        }
+
         return res;
     }
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/GetLegendHandler.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/GetLegendHandler.java
@@ -45,18 +45,21 @@ import static java.awt.RenderingHints.KEY_ANTIALIASING;
 import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
 import static java.awt.RenderingHints.VALUE_ANTIALIAS_ON;
 import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+import static org.deegree.cs.i18n.Messages.get;
 import static org.deegree.style.utils.ImageUtils.postprocessPng8bit;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 
+import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.utils.Pair;
 import org.deegree.layer.LayerRef;
 import org.deegree.protocol.wms.ops.GetLegendGraphic;
 import org.deegree.rendering.r2d.legends.Legends;
 import org.deegree.style.StyleRef;
 import org.deegree.style.se.unevaluated.Style;
+import org.deegree.theme.Theme;
 
 /**
  * Produces legends for the map service.
@@ -78,7 +81,7 @@ class GetLegendHandler {
         this.service = service;
     }
 
-    BufferedImage getLegend( GetLegendGraphic req ) {
+    BufferedImage getLegend( GetLegendGraphic req ) throws OWSException {
         Legends renderer = new Legends( req.getLegendOptions() );
 
         Style style = findLegendStyle( req.getLayer(), req.getStyle() );
@@ -122,12 +125,24 @@ class GetLegendHandler {
         return res;
     }
 
-    private Style findLegendStyle( LayerRef layer, StyleRef styleRef ) {
+    private Style findLegendStyle( LayerRef layer, StyleRef styleRef )
+                            throws OWSException {
         Style style;
-        style = service.themeMap.get( layer.getName() ).getLayerMetadata().getLegendStyles().get( styleRef.getName() );
-        if ( style == null ) {
-            style = service.themeMap.get( layer.getName() ).getLayerMetadata().getStyles().get( styleRef.getName() );
+        Theme theme = service.themeMap.get( layer.getName() );
+        if ( theme == null ) {
+            throw new OWSException( get( "WMS.LAYER_NOT_KNOWN", layer.getName() ), OWSException.LAYER_NOT_DEFINED );
         }
+
+        style = theme.getLayerMetadata().getLegendStyles().get( styleRef.getName() );
+        if ( style == null ) {
+            style = theme.getLayerMetadata().getStyles().get( styleRef.getName() );
+        }
+
+        if ( style == null ) {
+            throw new OWSException( get( "WMS.UNDEFINED_STYLE", styleRef.getName(), layer.getName() ),
+                                    OWSException.STYLE_NOT_DEFINED );
+        }
+
         return style;
     }
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/coveragestores.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/coveragestores.adoc
@@ -55,6 +55,13 @@ coverage sources. The RasterDirectory paramter can additionally have the
 recursive attribute with true and false as value to declare
 subdirectories to be included.
 
+WARNING: When using raster files, deegree creates on demand cache files. 
+Depending on the raster data used, the size of the cache files may vary.
+In individual cases, the use of cache files can be prevented by creating a 
+file _<filename>.no-cache_ or _<filename>.no-cache-<level>_ for whole files 
+or individual levels. Disabling the cache files can have a negative effect 
+on memory consumption. It is recommend to leave the cache enabled if possible.
+
 === MultiResolutionRaster
 
 A <MultiResolutionRaster> wraps single raster elements and adds a


### PR DESCRIPTION
This PR contains both a correction of the cache handling and a method to better control the raster cache for file base raster.

Previously there was the problem that the naming of cache files was derived from the raster data.
This could lead to unwanted errors in two situations.  
First it can happen that raster files in different directories have identical names (For example ../data/dop/overview.tif and ../data/infrared/overview.tif).  
Secodn the cache files were not distinguished between the different levels, which e.g. a geotiff can contain, and the same cache file was rewritten on every access.  
