### PR TITLE
Enhance GetFeatureInfo on raster

### DIFF
--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
@@ -43,6 +43,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.File;
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedSet;
@@ -50,6 +51,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
+import org.deegree.commons.utils.FileUtils;
 import org.deegree.commons.utils.StringUtils;
 import org.deegree.coverage.raster.SimpleRaster;
 import org.deegree.coverage.raster.data.RasterDataFactory;
@@ -110,6 +112,9 @@ public class RasterCache {
 
     private final static ConcurrentSkipListSet<CacheRasterReader> cache = new ConcurrentSkipListSet<CacheRasterReader>(
                                                                                                                         new CacheComparator() );
+
+    private final static Map<String, String> uniqueRasterCacheIds = new HashMap<String, String>();
+
     static {
         evaluateProperties();
     }
@@ -481,6 +486,7 @@ public class RasterCache {
                 boolean createCache = reader.shouldCreateCacheFile();
                 File cacheFile = null;
                 if ( createCache ) {
+                    LOG.trace( "create cachefule for location {}", reader.getDataLocationId() );
                     cacheFile = createCacheFile( reader.getDataLocationId() );
                 }
                 result = new CacheRasterReader( reader, cacheFile, this );
@@ -594,4 +600,47 @@ public class RasterCache {
         maxCacheDisk = 0;
     }
 
+    /**
+     * Generate unique (in the scope of RasterCache) short filename for raster reader identification
+     * 
+     * @param file
+     *            file reference to start with
+     * @return unique filename (may contains prefix to make it unique)
+     */
+    public static synchronized String getUniqueCacheIdentifier( File file ) {
+        String fname = FileUtils.getFilename( file );
+        String apath = file.getAbsolutePath();
+
+        int idx = 0;
+        String key = fname;
+
+        while ( !apath.equals( uniqueRasterCacheIds.getOrDefault( key, apath ) ) ) {
+            idx++;
+            key = idx + "_" + fname;
+        }
+        uniqueRasterCacheIds.put( key, apath );
+        return key;
+    }
+    
+    /**
+     * Helper function to check if a .no-cache or .no-cache-[level] file exists
+     */
+    public static boolean hasNoCacheFile( File file, int level ) {
+        try {
+            if ( file == null || !file.exists() )
+                return false;
+
+            File all = new File( file.getParentFile(), file.getName() + ".no-cache" );
+            if ( all.exists() ) {
+                return true;
+            }
+
+            File lvl = new File( file.getParentFile(), file.getName() + ".no-cache-" + level );
+            return lvl.exists();
+        } catch ( Exception ex ) {
+            LOG.debug( "Failed to check for .no-cache files for {} level {}", file, level );
+            LOG.debug( "Got exception", ex );
+            return false;
+        }
+    }
 }

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterReader.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import org.deegree.commons.utils.FileUtils;
 import org.deegree.coverage.raster.AbstractRaster;
+import org.deegree.coverage.raster.cache.RasterCache;
 import org.deegree.coverage.raster.data.container.BufferResult;
 import org.deegree.coverage.raster.data.info.RasterDataInfo;
 import org.deegree.coverage.raster.geom.RasterGeoReference;
@@ -132,7 +133,7 @@ public class JAIRasterReader implements RasterReader {
         this.dataLocationId = options != null ? options.get( RasterIOOptions.ORIGIN_OF_RASTER ) : null;
         if ( dataLocationId == null ) {
             if ( this.file != null ) {
-                this.dataLocationId = FileUtils.getFilename( this.file );
+                this.dataLocationId = RasterCache.getUniqueCacheIdentifier( this.file );
             }
         }
     }

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
@@ -124,6 +124,11 @@ class LegendBuilder {
             res.first = max( res.first, item.getMaxWidth( opts ) );
         }
 
+        if ( res.second == 0 ) {
+            // prevent >0 * 0 sized images
+            res.second = 2 * opts.spacing + opts.baseWidth;
+        }
+
         return res;
     }
 

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoHandler.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoHandler.java
@@ -63,6 +63,8 @@ import org.deegree.coverage.raster.SimpleRaster;
 import org.deegree.coverage.raster.data.RasterData;
 import org.deegree.coverage.raster.data.info.DataType;
 import org.deegree.coverage.raster.geom.Grid;
+import org.deegree.coverage.raster.geom.RasterGeoReference.OriginLocation;
+import org.deegree.coverage.raster.geom.RasterRect;
 import org.deegree.coverage.raster.interpolation.InterpolationType;
 import org.deegree.feature.Feature;
 import org.deegree.feature.FeatureCollection;
@@ -71,6 +73,7 @@ import org.deegree.feature.GenericFeatureCollection;
 import org.deegree.feature.property.GenericProperty;
 import org.deegree.feature.types.FeatureType;
 import org.deegree.geometry.Envelope;
+import org.deegree.geometry.primitive.Point;
 import org.deegree.layer.dims.Dimension;
 import org.slf4j.Logger;
 
@@ -107,10 +110,82 @@ class CoverageFeatureInfoHandler {
         this.dimensionHandler = dimensionHandler;
     }
 
+    FeatureCollection handleFeatureInfoPoint( int x, int y, int width, int height ) {
+        try {
+            Point bboxCenter = bbox.getCentroid();
+
+            double[] dpos = raster.getRasterReference().getRasterCoordinateUnrounded( bboxCenter.get0(),
+                                                                                      bboxCenter.get1() );
+            int[] pos = new int[] { (int) dpos[0], (int) dpos[1] };
+
+            Envelope pixelEnv = raster.getRasterReference().getEnvelope( OriginLocation.OUTER,
+                                                                         new RasterRect( pos[0], pos[1], 1, 1 ),
+                                                                         raster.getCoordinateSystem() );
+
+            GenericFeatureCollection col = new GenericFeatureCollection();
+            if ( !bbox.intersects( pixelEnv ) ) {
+                LOG.debug( "FeatureInfo point does not intersects with info box" );
+                return col;
+            } else if ( x < 0 || y < 0 || x >= width || y >= height ) {
+                LOG.debug( "FeatureInfo is not aligned with the pixel box" );
+                return col;
+            }
+
+            // TRICKY It is necessary to perform a raster transformation first to avoid addressing issues with
+            // getXxxSample. 
+            // Background is that getXxxSample accesses the memory/file-buffer address directly, bypassing the 
+            // tiling, which leads to address problems with large files.
+            SimpleRaster infoRaster = transform( raster, bbox, Grid.fromSize( width, height, MAX_VALUE, bbox ),
+                                                 interpol.toString() ).getAsSimpleRaster();
+
+            RasterData data = infoRaster.getAsSimpleRaster().getRasterData();
+            List<Property> props = new LinkedList<Property>();
+            DataType dataType = data.getDataType();
+            switch ( dataType ) {
+            case SHORT:
+            case USHORT: {
+                PrimitiveValue val = new PrimitiveValue( new BigDecimal( 0xffff & data.getShortSample( x, y, 0 ) ),
+                                                         new PrimitiveType( BaseType.DECIMAL ) );
+                props.add( new GenericProperty( featureType.getPropertyDeclarations().get( 0 ), val ) );
+                break;
+            }
+            case BYTE: {
+                // TODO unknown why this always yields 0 values for eg. satellite images/RGB/ARGB
+                for ( int i = 0; i < data.getBands(); ++i ) {
+                    PrimitiveValue val = new PrimitiveValue( new BigDecimal( 0xff & data.getByteSample( x, y, i ) ),
+                                                             new PrimitiveType( BaseType.DECIMAL ) );
+                    props.add( new GenericProperty( featureType.getPropertyDeclarations().get( 0 ), val ) );
+                }
+                break;
+            }
+            case DOUBLE:
+            case INT:
+            case UNDEFINED:
+                LOG.warn( "The raster is of type '{}', this is handled as float currently.", dataType );
+            case FLOAT:
+                props.add( new GenericProperty( featureType.getPropertyDeclarations().get( 0 ),
+                                                new PrimitiveValue( new BigDecimal( data.getFloatSample( x, y, 0 ) ),
+                                                                    new PrimitiveType( BaseType.DECIMAL ) ) ) );
+                break;
+            }
+            Feature f = new GenericFeature( featureType, null, props, null );
+            if ( pixelEnv != null ) {
+                f.setEnvelope( pixelEnv );
+            }
+            col.add( f );
+            return col;
+        } catch ( Throwable e ) {
+            LOG.trace( "Stack trace:", e );
+            LOG.error( "Unable to create raster feature info: {}", e.getLocalizedMessage() );
+        }
+        return null;
+    }
+
     FeatureCollection handleFeatureInfo() {
         try {
             SimpleRaster res = transform( raster, bbox, Grid.fromSize( 1, 1, MAX_VALUE, bbox ),
                                           interpol.toString() ).getAsSimpleRaster();
+
             RasterData data = res.getRasterData();
             GenericFeatureCollection col = new GenericFeatureCollection();
             List<Property> props = new LinkedList<Property>();

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoMode.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageFeatureInfoMode.java
@@ -1,0 +1,46 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.layer.persistence.coverage;
+
+public enum CoverageFeatureInfoMode {
+                                     INTERPOLATION, POINT
+}

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
@@ -72,11 +72,18 @@ public class CoverageLayer extends AbstractLayer {
 
     private final CoverageDimensionHandler dimensionHandler;
 
-    public CoverageLayer( LayerMetadata md, AbstractRaster raster, MultiResolutionRaster multiraster ) {
+    private final CoverageFeatureInfoMode featureInfoMode;
+
+    public CoverageLayer( LayerMetadata md, AbstractRaster raster, MultiResolutionRaster multiraster, CoverageFeatureInfoMode featureInfoMode ) {
         super( md );
         this.raster = raster;
         this.multiraster = multiraster;
+        this.featureInfoMode = featureInfoMode != null ? featureInfoMode : CoverageFeatureInfoMode.INTERPOLATION;
         dimensionHandler = new CoverageDimensionHandler( md.getDimensions() );
+    }
+
+    public CoverageLayer( LayerMetadata md, AbstractRaster raster, MultiResolutionRaster multiraster ) {
+        this(md, raster, multiraster, null);
     }
 
     @Override
@@ -98,7 +105,7 @@ public class CoverageLayer extends AbstractLayer {
             }
 
             return new CoverageLayerData( raster, bbox, query.getWidth(), query.getHeight(), interpol, filter, style,
-                                          getMetadata().getFeatureTypes().get( 0 ) );
+                                          getMetadata().getFeatureTypes().get( 0 ), featureInfoMode );
         } catch ( OWSException e ) {
             throw e;
         } catch ( Throwable e ) {
@@ -153,7 +160,9 @@ public class CoverageLayer extends AbstractLayer {
 
             return new CoverageLayerData( raster, bbox, query.getWidth(), query.getHeight(),
                                           InterpolationType.NEAREST_NEIGHBOR, filter, style,
-                                          getMetadata().getFeatureTypes().get( 0 ) , dimensionHandler );
+                                          getMetadata().getFeatureTypes().get( 0 ), dimensionHandler, featureInfoMode,
+                                          query.getX(), query.getY() );
+
         } catch ( OWSException e ) {
             throw e;
         } catch ( Throwable e ) {

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayerData.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayerData.java
@@ -91,15 +91,22 @@ public class CoverageLayerData implements LayerData {
 
     private CoverageDimensionHandler dimensionHandler;
 
-    public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
-                              RangeSet filter, Style style, FeatureType featureType ) {
-        this( raster, bbox, width, height, interpol, filter, style, featureType, null );
+    private final CoverageFeatureInfoMode featureInfoMode;
 
+    private final int infoPosX;
+
+    private final int infoPosY;
+
+    public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
+                              RangeSet filter, Style style, FeatureType featureType,
+                              CoverageFeatureInfoMode featureInfoMode ) {
+        this( raster, bbox, width, height, interpol, filter, style, featureType, null, featureInfoMode, -1, -1 );
     }
 
     public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
                               RangeSet filter, Style style, FeatureType featureType,
-                              CoverageDimensionHandler dimensionHandler ) {
+                              CoverageDimensionHandler dimensionHandler, CoverageFeatureInfoMode featureInfoMode,
+                              int infoPosX, int infoPosY ) {
         this.raster = raster;
         this.bbox = bbox;
         this.width = width;
@@ -109,6 +116,9 @@ public class CoverageLayerData implements LayerData {
         this.style = style;
         this.featureType = featureType;
         this.dimensionHandler = dimensionHandler;
+        this.featureInfoMode = featureInfoMode;
+        this.infoPosX = infoPosX;
+        this.infoPosY = infoPosY;
     }
 
     @Override
@@ -167,7 +177,10 @@ public class CoverageLayerData implements LayerData {
     public FeatureCollection info() {
         CoverageFeatureInfoHandler handler = new CoverageFeatureInfoHandler( raster, bbox, featureType, interpol,
                                                                              dimensionHandler );
-        return handler.handleFeatureInfo();
+        if ( featureInfoMode == CoverageFeatureInfoMode.POINT ) {
+            return handler.handleFeatureInfoPoint( infoPosX, infoPosY, width, height );
+        } else {
+            return handler.handleFeatureInfo();
+        }
     }
-
 }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/ManualCoverageLayerBuilder.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/ManualCoverageLayerBuilder.java
@@ -58,6 +58,7 @@ import org.deegree.layer.persistence.LayerStore;
 import org.deegree.layer.persistence.MultipleLayerStore;
 import org.deegree.layer.persistence.coverage.jaxb.CoverageLayerType;
 import org.deegree.layer.persistence.coverage.jaxb.CoverageLayers;
+import org.deegree.layer.persistence.coverage.jaxb.FeatureInfoModeType;
 import org.deegree.style.se.unevaluated.Style;
 import org.deegree.workspace.ResourceMetadata;
 import org.deegree.workspace.Workspace;
@@ -88,12 +89,19 @@ class ManualCoverageLayerBuilder {
 
         for ( CoverageLayerType lay : cfg.getCoverageLayer() ) {
             LayerMetadata md = buildLayerMetadata( lay, cov );
+            CoverageFeatureInfoMode infoMode = null;
+            if ( FeatureInfoModeType.POINT == lay.getFeatureInfoMode() ) {
+                infoMode = CoverageFeatureInfoMode.POINT;
+            } else if ( FeatureInfoModeType.INTERPOLATION == lay.getFeatureInfoMode() ) {
+                infoMode = CoverageFeatureInfoMode.INTERPOLATION;
+            }
 
             Pair<Map<String, Style>, Map<String, Style>> p = parseStyles( workspace, lay.getName(), lay.getStyleRef() );
             md.setStyles( p.first );
             md.setLegendStyles( p.second );
             Layer l = new CoverageLayer( md, cov instanceof AbstractRaster ? (AbstractRaster) cov : null,
-                                         cov instanceof MultiResolutionRaster ? (MultiResolutionRaster) cov : null );
+                                         cov instanceof MultiResolutionRaster ? (MultiResolutionRaster) cov : null,
+                                         infoMode );
             map.put( lay.getName(), l );
         }
 

--- a/deegree-layers/deegree-layers-coverage/src/main/resources/META-INF/schemas/layers/coverage/3.4.0/coverage.xsd
+++ b/deegree-layers/deegree-layers-coverage/src/main/resources/META-INF/schemas/layers/coverage/3.4.0/coverage.xsd
@@ -17,6 +17,7 @@
   <complexType name="CoverageLayerType">
     <sequence>
       <group ref="l:LayerInfo" />
+      <element name="FeatureInfoMode" type="f:FeatureInfoModeType" minOccurs="0" />
     </sequence>
   </complexType>
 
@@ -41,6 +42,13 @@
       <attribute name="configVersion" type="f:ConfigVersionType" use="required" />
     </complexType>
   </element>
+
+  <simpleType name="FeatureInfoModeType">
+    <restriction base="string">
+      <enumeration value="INTERPOLATION" />
+      <enumeration value="POINT" />
+    </restriction>
+  </simpleType>
 
   <simpleType name="ConfigVersionType">
     <restriction base="string">

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/GetLegendHandler.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/GetLegendHandler.java
@@ -45,18 +45,21 @@ import static java.awt.RenderingHints.KEY_ANTIALIASING;
 import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
 import static java.awt.RenderingHints.VALUE_ANTIALIAS_ON;
 import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+import static org.deegree.cs.i18n.Messages.get;
 import static org.deegree.style.utils.ImageUtils.postprocessPng8bit;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 
+import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.utils.Pair;
 import org.deegree.layer.LayerRef;
 import org.deegree.protocol.wms.ops.GetLegendGraphic;
 import org.deegree.rendering.r2d.legends.Legends;
 import org.deegree.style.StyleRef;
 import org.deegree.style.se.unevaluated.Style;
+import org.deegree.theme.Theme;
 
 /**
  * Produces legends for the map service.
@@ -78,7 +81,7 @@ class GetLegendHandler {
         this.service = service;
     }
 
-    BufferedImage getLegend( GetLegendGraphic req ) {
+    BufferedImage getLegend( GetLegendGraphic req ) throws OWSException {
         Legends renderer = new Legends( req.getLegendOptions() );
 
         Style style = findLegendStyle( req.getLayer(), req.getStyle() );
@@ -122,12 +125,24 @@ class GetLegendHandler {
         return res;
     }
 
-    private Style findLegendStyle( LayerRef layer, StyleRef styleRef ) {
+    private Style findLegendStyle( LayerRef layer, StyleRef styleRef )
+                            throws OWSException {
         Style style;
-        style = service.themeMap.get( layer.getName() ).getLayerMetadata().getLegendStyles().get( styleRef.getName() );
-        if ( style == null ) {
-            style = service.themeMap.get( layer.getName() ).getLayerMetadata().getStyles().get( styleRef.getName() );
+        Theme theme = service.themeMap.get( layer.getName() );
+        if ( theme == null ) {
+            throw new OWSException( get( "WMS.LAYER_NOT_KNOWN", layer.getName() ), OWSException.LAYER_NOT_DEFINED );
         }
+
+        style = theme.getLayerMetadata().getLegendStyles().get( styleRef.getName() );
+        if ( style == null ) {
+            style = theme.getLayerMetadata().getStyles().get( styleRef.getName() );
+        }
+
+        if ( style == null ) {
+            throw new OWSException( get( "WMS.UNDEFINED_STYLE", styleRef.getName(), layer.getName() ),
+                                    OWSException.STYLE_NOT_DEFINED );
+        }
+
         return style;
     }
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/coveragestores.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/coveragestores.adoc
@@ -55,6 +55,13 @@ coverage sources. The RasterDirectory paramter can additionally have the
 recursive attribute with true and false as value to declare
 subdirectories to be included.
 
+WARNING: When using raster files, deegree creates on demand cache files. 
+Depending on the raster data used, the size of the cache files may vary.
+In individual cases, the use of cache files can be prevented by creating a 
+file _<filename>.no-cache_ or _<filename>.no-cache-<level>_ for whole files 
+or individual levels. Disabling the cache files can have a negative effect 
+on memory consumption. It is recommend to leave the cache enabled if possible.
+
 === MultiResolutionRaster
 
 A <MultiResolutionRaster> wraps single raster elements and adds a

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/layers.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/layers.adoc
@@ -287,7 +287,7 @@ Here's a copy of the corresponding table for reference:
 
 [width="100%",cols="18%,12%,7%,63%",options="header",]
 |===
-|Option |Cardinality |String |Description
+|Option |Cardinality |Value |Description
 |AntiAliasing |0..1 |String |Whether to antialias NONE, TEXT, IMAGE or
 BOTH, default is BOTH
 
@@ -520,10 +520,37 @@ and one or many coverage layer definitions:
 </CoverageLayers>
 ----
 
-Within the _CoverageLayer_ element you can only define the
-link:#common[common] layer options. While only one coverage is supported
+Within the _CoverageLayer_ element you can define the link:#common[common] 
+layer options and one optional element. While only one coverage is supported
 per coverage store, it might still be desirable to define multiple
 layers based on the store, for example one layer per style.
+
+The optional element _FeatureInfoMode_ can be used to control how
+the GetFeatureInfo operations are dealt with. 
+
+[source,xml]
+----
+<CoverageLayers xmlns="http://www.deegree.org/layers/coverage"
+                xmlns:d="http://www.deegree.org/metadata/description"
+                xmlns:l="http://www.deegree.org/layers/base"
+                configVersion="3.4.0">
+  <CoverageStoreId>dem</CoverageStoreId>
+  <CoverageLayer>
+    <!-- standard layer options -->
+    <FeatureInfoMode>POINT</FeatureInfoMode>
+  </CoverageLayer>
+</CoverageLayers>
+----
+
+[width="100%",cols="18%,12%,7%,63%",options="header",]
+|=======================================================================
+|Option |Cardinality |Value |Description
+
+
+|FeatureInfoMode |0..1 |String |Whether to use a INTERPOLATION
+or POINT based approach to get a GetFeatureInfo result, default is INTERPOLATION
+
+|=======================================================================
 
 === Remote WMS layers
 


### PR DESCRIPTION
This PR contains the changes from PR #1084.

Included is a configuration option to select whether a GetFeatureInfo can be configured on raster data.  
You can choose between an interpolation from a region (standard, as before) or alternatively a determination based on the grid value at the click position.