### PR TITLE
Make gml:id attribute optional as defined in updated GML 3.2.1 schemas

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -51,9 +51,6 @@ import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.nextElement;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.require;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.skipElement;
-import static org.deegree.gml.GMLVersion.GML_2;
-import static org.deegree.gml.GMLVersion.GML_30;
-import static org.deegree.gml.GMLVersion.GML_31;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -181,30 +178,15 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
      * Parses the gml:id attribute of a GML object element.
      *
      * @param xmlStream
-     *            must not be <code>null</code> and point to the start element of a GML object
+     *                      must not be <code>null</code> and point to the start element of a GML object
      * @return value of the GML id, can be <code>null</code>
-     * @throws XMLStreamException
-     *             if the GML version requires a gml:id attribute and none is present (or invalid)
      */
-    public String parseGmlId( final XMLStreamReader xmlStream )
-                            throws XMLStreamException {
+    public String parseGmlId( final XMLStreamReader xmlStream ) {
         final String gmlId = xmlStream.getAttributeValue( gmlNs, "id" );
-        if ( gmlId == null && isGmlIdRequired() ) {
-            final String msg = "Required attribute gml:id is missing.";
-            throw new XMLStreamException( msg, xmlStream.getLocation() );
-        }
         if ( gmlId != null ) {
             checkValidNcName( gmlId );
         }
         return gmlId;
-    }
-
-    // required since GML 3.2
-    private boolean isGmlIdRequired() {
-        if ( gmlStreamReader.getLaxMode() ) {
-            return false;
-        }
-        return version != GML_2 && version != GML_30 || version != GML_31;
     }
 
     private void checkValidNcName( final String gmlId ) {

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/describefeaturetype/xml/DescribeFeatureTypeXMLAdapterTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/describefeaturetype/xml/DescribeFeatureTypeXMLAdapterTest.java
@@ -68,7 +68,8 @@ public class DescribeFeatureTypeXMLAdapterTest {
                             throws Exception {
 
         DescribeFeatureTypeXMLAdapter parser = new DescribeFeatureTypeXMLAdapter();
-        parser.load( get200ExampleUrl( "DescribeFeatureType_Example01_Request.xml" ) );
+        parser.load( DescribeFeatureTypeXMLAdapterTest.class.getResource(
+                                "wfs200/DescribeFeatureType_Example01_Request.xml" ) );
         DescribeFeatureType request = parser.parse();
         assertEquals( VERSION_200, request.getVersion() );
         assertEquals( null, request.getHandle() );
@@ -83,7 +84,8 @@ public class DescribeFeatureTypeXMLAdapterTest {
                             throws Exception {
 
         DescribeFeatureTypeXMLAdapter parser = new DescribeFeatureTypeXMLAdapter();
-        parser.load( get200ExampleUrl( "DescribeFeatureType_Example02_Request.xml" ) );
+        parser.load( DescribeFeatureTypeXMLAdapterTest.class.getResource(
+                                "wfs200/DescribeFeatureType_Example02_Request.xml" ) );
         DescribeFeatureType request = parser.parse();
         assertEquals( VERSION_200, request.getVersion() );
         assertEquals( null, request.getHandle() );
@@ -91,6 +93,11 @@ public class DescribeFeatureTypeXMLAdapterTest {
         assertEquals( 1, request.getTypeNames().length );
     }
 
+    /**
+     * TODO: Unused until https://github.com/deegree/deegree3/issues/1091 is implemented.
+     * @param name
+     * @return
+     */
     private URL get200ExampleUrl( String name ) {
         try {
             String url = new RedirectingEntityResolver().redirect( WFS200_EXAMPLES_BASE_URL + name );

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/resources/org/deegree/protocol/wfs/describefeaturetype/xml/wfs200/DescribeFeatureType_Example01_Request.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/resources/org/deegree/protocol/wfs/describefeaturetype/xml/wfs200/DescribeFeatureType_Example01_Request.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<DescribeFeatureType
+    service="WFS"
+    version="2.0.0"
+    xmlns="http://www.opengis.net/wfs/2.0"
+    xmlns:myns="http://www.myserver.com/myns"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/wfs/2.0
+                       http://schemas.opengis.net/wfs/2.0/wfs.xsd">
+  <TypeName>myns:TreesA_1M</TypeName>
+  <TypeName>myns:RoadL_1M</TypeName>
+</DescribeFeatureType>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/resources/org/deegree/protocol/wfs/describefeaturetype/xml/wfs200/DescribeFeatureType_Example02_Request.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/resources/org/deegree/protocol/wfs/describefeaturetype/xml/wfs200/DescribeFeatureType_Example02_Request.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<DescribeFeatureType
+    service="WFS"
+    version="2.0.0"
+    outputFormat="text/xml; subtype=gml/3.2"
+    xmlns="http://www.opengis.net/wfs/2.0"
+    xmlns:myns="http://www.someserver.com/myns"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/wfs/2.0
+                       http://schemas.opengis.net/wfs/2.0/wfs.xsd">
+  <TypeName>myns:Person</TypeName>
+</DescribeFeatureType>

--- a/pom.xml
+++ b/pom.xml
@@ -1040,7 +1040,7 @@
       <dependency>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-ogcschemas</artifactId>
-        <version>20190425</version>
+        <version>20191108</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1040,7 +1040,7 @@
       <dependency>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-ogcschemas</artifactId>
-        <version>20120804</version>
+        <version>20190425</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>


### PR DESCRIPTION
Replaces #974. Updated deegree-ogcschemas to http://repo.deegree.org/content/repositories/releases/org/deegree/deegree-ogcschemas/20191108/ and fixed test failure. 
