### PR TITLE
Fix ConcurrentModificationException

### DIFF
--- a/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/standard/DefaultWorkspace.java
+++ b/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/standard/DefaultWorkspace.java
@@ -522,7 +522,6 @@ public class DefaultWorkspace implements Workspace {
         states.remove( id );
         removeMetadataFromResourceManager( id );
         resources.remove( id );
-        graph.removeNode( id );
         errors.clear( id );
     }
 


### PR DESCRIPTION
Fixes #1096 

Regression of #1058 

Collecting all resource to destroy results in an unexpected status of the resource graph and problem when resources are initialized again. Therefor the old behavior was restored.