### PR TITLE
[GML_322_support] add GML 3.2.2 support

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/AppSchemaGeometryHierarchy.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/AppSchemaGeometryHierarchy.java
@@ -36,6 +36,7 @@
 package org.deegree.feature.types;
 
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -119,7 +120,7 @@ public class AppSchemaGeometryHierarchy {
     }
 
     private QName getAbstractElementName( String localPart, GMLVersion version ) {
-        if ( version == GML_32 ) {
+        if ( version == GML_32 || version == GML_322 ) {
             return new QName( version.getNamespace(), "Abstract" + localPart );
         }
         return new QName( version.getNamespace(), "_" + localPart );

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/function/ParameterType.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/function/ParameterType.java
@@ -42,6 +42,7 @@ import static org.deegree.gml.GMLVersion.GML_2;
 import static org.deegree.gml.GMLVersion.GML_30;
 import static org.deegree.gml.GMLVersion.GML_31;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,11 +65,13 @@ public class ParameterType {
     public static final ParameterType GEOMETRY = new ParameterType( new QName( GMLNS, "_Geometry", "gml" ),
                                                                     new QName( GMLNS, "_Geometry", "gml" ),
                                                                     new QName( GMLNS, "_Geometry", "gml" ),
+                                                                    new QName( GML3_2_NS, "AbstractGeometry", "gml32" ),
                                                                     new QName( GML3_2_NS, "AbstractGeometry", "gml32" ) );
 
     public static final ParameterType POINT = new ParameterType( new QName( GMLNS, "Point", "gml" ),
                                                                  new QName( GMLNS, "Point", "gml" ),
                                                                  new QName( GMLNS, "Point", "gml" ),
+                                                                 new QName( GML3_2_NS, "Point", "gml32" ),
                                                                  new QName( GML3_2_NS, "Point", "gml32" ) );
 
     public static final ParameterType STRING = new ParameterType( new QName( XSNS, "string", "xsd" ) );
@@ -88,13 +91,15 @@ public class ParameterType {
         versionToName.put( GML_30, name );
         versionToName.put( GML_31, name );
         versionToName.put( GML_32, name );
+        versionToName.put( GML_322, name );
     }
 
-    public ParameterType( QName gml2Name, QName gml30Name, QName gml31Name, QName gml32Name ) {
+    public ParameterType( QName gml2Name, QName gml30Name, QName gml31Name, QName gml32Name, QName gml322Name ) {
         versionToName.put( GML_2, gml2Name );
         versionToName.put( GML_30, gml30Name );
         versionToName.put( GML_31, gml31Name );
         versionToName.put( GML_32, gml32Name );
+        versionToName.put( GML_322, gml322Name );
     }
 
     /**

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamReader.java
@@ -470,7 +470,8 @@ public class GMLStreamReader {
             }
             case GML_30:
             case GML_31:
-            case GML_32: {
+            case GML_32:
+            case GML_322: {
                 geometryReader = new GML3GeometryReader( this );
                 break;
             }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLStreamWriter.java
@@ -44,6 +44,7 @@ import static org.deegree.feature.property.ExtraProps.EXTRA_PROP_NS;
 import static org.deegree.feature.property.ExtraProps.EXTRA_PROP_NS_GEOMETRY;
 import static org.deegree.feature.property.ExtraProps.EXTRA_PROP_NS_STRING;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 
 import java.util.HashMap;
 import java.util.List;
@@ -134,12 +135,27 @@ public class GMLStreamWriter {
         this.xmlStream = xmlStream;
         referenceExportStrategy = new DefaultGmlXlinkStrategy( "#{}", new GmlXlinkOptions() );
         prefixToNs.put( "ogc", OGCNS );
-        prefixToNs.put( "gml", version != GML_32 ? GMLNS : GML3_2_NS );
+        prefixToNs.put( "gml", !isVersionOfGML32( version ) ? GMLNS : GML3_2_NS );
         prefixToNs.put( "xlink", XLNNS );
         prefixToNs.put( "xsi", XSINS );
         prefixToNs.put( "dxtra", EXTRA_PROP_NS );
         prefixToNs.put( "dxtra-string", EXTRA_PROP_NS_STRING );
         prefixToNs.put( "dxtra-geometry", EXTRA_PROP_NS_GEOMETRY );
+    }
+
+    /**
+     * Returns if a version is of GML 3.2.
+     *
+     * @param version
+     *             GML version of the output, must not be <code>null</code>
+     *
+     * @return <code>true</code>, if version is 3.2.1 or 3.2.2, <code>false</code> otherwise
+     */
+    private boolean isVersionOfGML32( GMLVersion version ) {
+        if ( version == GML_32 || version == GML_322 ){
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -413,7 +429,8 @@ public class GMLStreamWriter {
             }
             case GML_30:
             case GML_31:
-            case GML_32: {
+            case GML_32:
+            case GML_322: {
                 geometryWriter = new GML3GeometryWriter( this );
                 break;
             }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLVersion.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/GMLVersion.java
@@ -58,8 +58,10 @@ public enum GMLVersion {
     GML_30( GMLNS, "3.0", "3.0.1" ),
     /** GML 3.1 versions (either 3.1.0 or 3.1.1) */
     GML_31( GMLNS, "3.1", "3.1.1" ),
-    /** GML 3.2 versions (3.2.1) */
-    GML_32( GML3_2_NS, "3.2", "3.2.1" );
+    /** GML 3.2.1 versions (3.2.1) */
+    GML_32( GML3_2_NS, "3.2", "3.2.1" ),
+    /** GML 3.2.2 versions (3.2.2) */
+    GML_322( GML3_2_NS, "3.2", "3.2.2" );
 
     private final String ns;
 
@@ -141,6 +143,8 @@ public enum GMLVersion {
                                     result = GML_31;
                                 } else if ( v.compareTo( new Version( 3, 2, 1 ) ) <= 0 ) {
                                     result = GML_32;
+                                } else if ( v.compareTo( new Version( 3, 2, 2 ) ) <= 0 ) {
+                                    result = GML_322;
                                 }
                             }
                         }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -51,9 +51,7 @@ import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.nextElement;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.require;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.skipElement;
-import static org.deegree.gml.GMLVersion.GML_2;
-import static org.deegree.gml.GMLVersion.GML_30;
-import static org.deegree.gml.GMLVersion.GML_31;
+import static org.deegree.gml.GMLVersion.GML_32;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -204,7 +202,7 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
         if ( gmlStreamReader.getLaxMode() ) {
             return false;
         }
-        return version != GML_2 && version != GML_30 || version != GML_31;
+        return version == GML_32;
     }
 
     private void checkValidNcName( final String gmlId ) {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryWriter.java
@@ -41,6 +41,7 @@ import static org.deegree.geometry.Geometry.GeometryType.COMPOSITE_GEOMETRY;
 import static org.deegree.geometry.Geometry.GeometryType.ENVELOPE;
 import static org.deegree.gml.GMLVersion.GML_30;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 
 import java.util.List;
 import java.util.UUID;
@@ -119,6 +120,7 @@ import org.deegree.geometry.primitive.segments.OffsetCurve;
 import org.deegree.geometry.refs.GeometryReference;
 import org.deegree.geometry.standard.curvesegments.AffinePlacement;
 import org.deegree.gml.GMLStreamWriter;
+import org.deegree.gml.GMLVersion;
 import org.deegree.gml.commons.AbstractGMLObjectWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -261,7 +263,7 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
             break;
         }
         case MULTI_LINE_STRING: {
-            if ( version == GML_32 ) {
+            if ( isGML32version( version ) ) {
                 // GML 3.2 does not define MultiLineString anymore -> export as MultiCurve
                 MultiCurve<Curve> multiCurve = (MultiCurve<Curve>) geometry;
                 startGeometry( "MultiCurve", geometry );
@@ -308,7 +310,7 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
             writer.writeEndElement(); // MultiPoint
             break;
         case MULTI_POLYGON:
-            if ( version == GML_32 ) {
+            if ( isGML32version( version ) ) {
                 // GML 3.2 does not define MultiPolygon anymore -> export as MultiSurface
                 MultiSurface<Surface> multiSurface = (MultiSurface<Surface>) geometry;
                 startGeometry( "MultiSurface", geometry );
@@ -743,7 +745,7 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
 
         switch ( ring.getRingType() ) {
         case Ring:
-            if ( GML_32 != version ) {
+            if ( !isGML32version( version ) ) {
                 startGeometry( "Ring", ring );
             } else {
                 // in GML 3.2, a Ring is not a Geometry object
@@ -760,7 +762,7 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
         case LinearRing:
             LinearRing linearRing = (LinearRing) ring;
 
-            if ( GML_32 != version ) {
+            if ( !isGML32version( version ) ) {
                 startGeometry( "LinearRing", linearRing );
             } else {
                 // in GML 3.2, a LinearRing is not a Geometry object
@@ -772,6 +774,13 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
             writer.writeEndElement();
             break;
         }
+    }
+
+    private boolean isGML32version( GMLVersion version ) {
+        if ( version == GML_32 || version == GML_322 ) {
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -1561,7 +1570,7 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
             referenceExportStrategy.addExportedId( geometry.getId() );
             writeAttributeWithNS( gmlNs, "id", geometry.getId() );
         } else if ( version == GML_32 && geometry.getId() == null ) {
-            // in GML 3.2, a gml:id is required for every geometry
+            // Only in GML 3.2.1, a gml:id is required for every geometry
             writeAttributeWithNS( gmlNs, "id", "GEOMETRY_" + generateNewId() );
         }
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/props/GMLStdPropsReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/props/GMLStdPropsReader.java
@@ -104,6 +104,7 @@ public class GMLStdPropsReader {
             props = readGML31( xmlStream );
             break;
         case GML_32:
+        case GML_322:
             props = readGML32( xmlStream );
             break;
         }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/props/GMLStdPropsWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/props/GMLStdPropsWriter.java
@@ -95,6 +95,7 @@ public class GMLStdPropsWriter {
             writeGML3( props );
             break;
         case GML_32:
+        case GML_322:
             writeGML32( props );
             break;
         }

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLAppSchemaWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLAppSchemaWriter.java
@@ -231,6 +231,7 @@ public class GMLAppSchemaWriter {
             }
             break;
         case GML_32:
+        case GML_322:
             gmlNsURI = GML3_2_NS;
             abstractGMLFeatureElement = "gml:AbstractFeature";
             featurePropertyType = "gml:FeaturePropertyType";

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
@@ -256,7 +256,8 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
             abstractFeatureElementTypeDecl = getTypeDef( "AbstractFeatureType", GML_PRE_32_NS );
             break;
         }
-        case GML_32: {
+        case GML_32:
+        case GML_322: {
             abstractObjectElementDecl = getElementDecl( "AbstractObject", GML_32_NS );
             abstractGmlElementDecl = getElementDecl( "AbstractGML", GML_32_NS );
             abstractFeatureElementDecl = getElementDecl( "AbstractFeature", GML_32_NS );
@@ -295,6 +296,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
             break;
         }
         case GML_32:
+        case GML_322: {
             List<XSElementDeclaration> featureDecls = getFeatureElementDeclarations( null, false );
             fcDecls = new ArrayList<XSElementDeclaration>();
             for ( XSElementDeclaration featureDecl : featureDecls ) {
@@ -303,6 +305,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
                 }
             }
             break;
+        }
         }
 
         for ( XSElementDeclaration elemDecl : ftDecls ) {

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/VersionFromMimeTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/VersionFromMimeTest.java
@@ -40,6 +40,9 @@ package org.deegree.gml;
 
 import static junit.framework.Assert.assertEquals;
 import static org.deegree.gml.GMLVersion.fromMimeType;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
@@ -105,8 +108,23 @@ public class VersionFromMimeTest {
     }
 
     @Test
-    public void gml3_2_1() {
+    public void gml3_2() {
         assertEquals( GMLVersion.GML_32, fromMimeType( "text/xml; subtype=gml/3.2.1", null ) );
+    }
+
+    @Test
+    public void gml3_2_2() {
+        assertEquals( GMLVersion.GML_322, fromMimeType( "text/xml; subtype=gml/3.2.2", null ) );
+    }
+
+    @Test
+    public void subtypeGML3_2_1shouldNotMatchGMLVersion322() {
+        assertThat( GMLVersion.GML_322, is( not( fromMimeType( "text/xml; subtype=gml/3.2.1", null ) ) ) );
+    }
+
+    @Test
+    public void subtypeGML3_2_2shouldNotMatchGMLVersion32() {
+        assertThat( GMLVersion.GML_32, is( not( fromMimeType( "text/xml; subtype=gml/3.2.2", null ) ) ) );
     }
 
     @Test
@@ -115,7 +133,7 @@ public class VersionFromMimeTest {
     }
 
     @Test
-    public void multipleSubtypes() {
+    public void multipleSubtypesGML32() {
         assertEquals( GMLVersion.GML_32, fromMimeType( "text/xml; subtype=gml/3.2; subtype=gml/3.2.1", null ) );
     }
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
@@ -52,7 +52,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/time/gml/reader/GmlTimePositionTypeReaderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/time/gml/reader/GmlTimePositionTypeReaderTest.java
@@ -49,7 +49,6 @@ import javax.xml.stream.XMLStreamReader;
 
 import org.deegree.gml.GMLInputFactory;
 import org.deegree.gml.GMLStreamReader;
-import org.deegree.time.gml.reader.GmlTimePositionTypeReader;
 import org.deegree.time.position.TimePosition;
 import org.junit.Test;
 

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/serializing/FeatureInfoGmlWriter.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/serializing/FeatureInfoGmlWriter.java
@@ -211,6 +211,9 @@ public class FeatureInfoGmlWriter implements FeatureInfoSerializer {
             if ( format.endsWith( "3.2" ) || format.endsWith( "3.2.1" ) ) {
                 gmlVersion = GMLVersion.GML_32;
             }
+            if ( format.endsWith( "3.2.2" ) ) {
+                gmlVersion = GMLVersion.GML_322;
+            }
 
             GMLStreamWriter gmlWriter = GMLOutputFactory.createGMLStreamWriter( gmlVersion, xmlWriter );
             gmlWriter.setOutputCrs( params.getCrs() );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -48,7 +48,6 @@ import static org.deegree.commons.xml.CommonNamespaces.OGCNS;
 import static org.deegree.commons.xml.CommonNamespaces.XLNNS;
 import static org.deegree.commons.xml.XMLAdapter.writeElement;
 import static org.deegree.commons.xml.stax.XMLStreamUtils.skipElement;
-import static org.deegree.feature.Features.findFeaturesAndGeometries;
 import static org.deegree.gml.GMLInputFactory.createGMLStreamReader;
 import static org.deegree.gml.GMLVersion.GML_32;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_100;
@@ -68,11 +67,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
@@ -114,8 +111,6 @@ import org.deegree.filter.Filters;
 import org.deegree.filter.IdFilter;
 import org.deegree.filter.OperatorFilter;
 import org.deegree.filter.expression.ValueReference;
-import org.deegree.geometry.Envelope;
-import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.SimpleGeometryFactory;
 import org.deegree.geometry.validation.CoordinateValidityInspector;
@@ -124,7 +119,6 @@ import org.deegree.gml.GMLStreamReader;
 import org.deegree.gml.GMLVersion;
 import org.deegree.gml.feature.GMLFeatureReader;
 import org.deegree.gml.reference.FeatureReference;
-import org.deegree.gml.reference.matcher.ReferencePatternMatcher;
 import org.deegree.protocol.wfs.transaction.ReleaseAction;
 import org.deegree.protocol.wfs.transaction.Transaction;
 import org.deegree.protocol.wfs.transaction.TransactionAction;
@@ -911,6 +905,8 @@ class TransactionHandler {
                 gmlVersion = GMLVersion.GML_31;
             } else if ( "text/xml; subtype=gml/3.2.1".equals( format ) ) {
                 gmlVersion = GMLVersion.GML_32;
+            } else if ( "text/xml; subtype=gml/3.2.2".equals( format ) ) {
+                gmlVersion = GMLVersion.GML_322;
             }
         }
         return gmlVersion;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -187,6 +187,7 @@ import static org.deegree.gml.GMLVersion.GML_2;
 import static org.deegree.gml.GMLVersion.GML_30;
 import static org.deegree.gml.GMLVersion.GML_31;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_100;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_110;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_200;
@@ -216,13 +217,13 @@ import static org.deegree.services.jaxb.wfs.IdentifierGenerationOptionType.USE_E
  * <li>2.0.0</li>
  * </ul>
  * </p>
- * 
+ *
  * @see AbstractOWS
  * @see OGCFrontController
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author: mschneider $
- * 
+ *
  * @version $Revision: 15339 $, $Date: 2008-12-11 18:40:09 +0100 (Do, 11 Dez 2008) $
  */
 public class WebFeatureService extends AbstractOWS {
@@ -549,8 +550,10 @@ public class WebFeatureService extends AbstractOWS {
                                                                                                                      GML_31 );
             org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat(
                                                                                                                      this,
-
                                                                                                                      GML_32 );
+            org.deegree.services.wfs.format.gml.GmlFormat gml322 = new org.deegree.services.wfs.format.gml.GmlFormat(
+                                                                                                                     this,
+                                                                                                                     GML_322 );
             mimeTypeToFormat.put( "application/gml+xml; version=2.1", gml21 );
             mimeTypeToFormat.put( "application/gml+xml; version=3.0", gml30 );
             mimeTypeToFormat.put( "application/gml+xml; version=3.1", gml31 );
@@ -559,10 +562,12 @@ public class WebFeatureService extends AbstractOWS {
             mimeTypeToFormat.put( "text/xml; subtype=gml/3.0.1", gml30 );
             mimeTypeToFormat.put( "text/xml; subtype=gml/3.1.1", gml31 );
             mimeTypeToFormat.put( "text/xml; subtype=gml/3.2.1", gml32 );
+            mimeTypeToFormat.put( "text/xml; subtype=gml/3.2.2", gml322 );
             mimeTypeToFormat.put( "text/xml; subtype=\"gml/2.1.2\"", gml21 );
             mimeTypeToFormat.put( "text/xml; subtype=\"gml/3.0.1\"", gml30 );
             mimeTypeToFormat.put( "text/xml; subtype=\"gml/3.1.1\"", gml31 );
             mimeTypeToFormat.put( "text/xml; subtype=\"gml/3.2.1\"", gml32 );
+            mimeTypeToFormat.put( "text/xml; subtype=\"gml/3.2.2\"", gml322 );
         } else {
             LOG.debug( "Using customized format configuration." );
             for ( JAXBElement<? extends AbstractFormatType> formatEl : formatList ) {
@@ -701,7 +706,7 @@ public class WebFeatureService extends AbstractOWS {
 
     /**
      * Returns the underlying {@link WfsFeatureStoreManager} instance.
-     * 
+     *
      * @return the underlying {@link WfsFeatureStoreManager}
      */
     public WfsFeatureStoreManager getStoreManager() {
@@ -1298,7 +1303,7 @@ public class WebFeatureService extends AbstractOWS {
 
     /**
      * Returns an <code>XMLStreamWriter</code> for writing an XML response document.
-     * 
+     *
      * @param writer
      *            writer to write the XML to, must not be <code>null</code>
      * @param mimeType
@@ -1363,7 +1368,7 @@ public class WebFeatureService extends AbstractOWS {
 
     /**
      * Determines the requested output/input format.
-     * 
+     *
      * @param requestVersion
      *            version of the WFS request, must not be <code>null</code>
      * @param format
@@ -1459,7 +1464,7 @@ public class WebFeatureService extends AbstractOWS {
      * {@link OWSException#VERSION_NEGOTIATION_FAILED} -- the latter should only be used for failed GetCapabilities
      * requests.
      * </p>
-     * 
+     *
      * @param requestedVersion
      *            version to be checked, may be null (causes exception)
      * @return <code>requestedVersion</code> (if it is not null), or highest version supported

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/AbstractGmlRequestHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/AbstractGmlRequestHandler.java
@@ -42,6 +42,7 @@ import static org.deegree.commons.xml.CommonNamespaces.XLNNS;
 import static org.deegree.gml.GMLVersion.GML_2;
 import static org.deegree.gml.GMLVersion.GML_31;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 import static org.deegree.protocol.wfs.WFSConstants.GML32_NS;
 import static org.deegree.protocol.wfs.WFSConstants.GML32_SCHEMA_URL;
 import static org.deegree.protocol.wfs.WFSConstants.QUERY_ID_GET_FEATURE_BY_ID;
@@ -356,7 +357,7 @@ abstract class AbstractGmlRequestHandler {
             memberElementName = new QName( options.getResponseFeatureMemberEl().getNamespaceURI(),
                                            options.getResponseFeatureMemberEl().getLocalPart(),
                                            options.getResponseFeatureMemberEl().getPrefix() );
-        } else if ( gmlVersion == GML_32 ) {
+        } else if ( gmlVersion == GML_32 || gmlVersion == GML_322 ) {
             // WFS 1.0.0 / 1.1.0 without custom configured member element, GML 3.2 -> wfs:featureMember
             memberElementName = new QName( WFS_NS, "member", "wfs" );
         } else {
@@ -454,7 +455,7 @@ abstract class AbstractGmlRequestHandler {
         try {
             if ( VERSION_100.equals( version ) && gmlVersion == GML_2 ) {
                 baseUrl.append( "XMLSCHEMA" );
-            } else if ( VERSION_200.equals( version ) && gmlVersion == GML_32 ) {
+            } else if ( VERSION_200.equals( version ) && ( gmlVersion == GML_32 || gmlVersion == GML_322 ) ) {
                 baseUrl.append( URLEncoder.encode( gmlVersion.getMimeType(), "UTF-8" ) );
             } else {
                 baseUrl.append( URLEncoder.encode( gmlVersion.getMimeTypeOldStyle(), "UTF-8" ) );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
@@ -42,6 +42,7 @@ import static org.deegree.commons.xml.CommonNamespaces.GML_PREFIX;
 import static org.deegree.commons.xml.CommonNamespaces.XSNS;
 import static org.deegree.commons.xml.CommonNamespaces.XS_PREFIX;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 import static org.deegree.gml.schema.GMLAppSchemaWriter.GML_2_DEFAULT_INCLUDE;
 import static org.deegree.gml.schema.GMLAppSchemaWriter.GML_30_DEFAULT_INCLUDE;
 import static org.deegree.gml.schema.GMLAppSchemaWriter.GML_31_DEFAULT_INCLUDE;
@@ -396,6 +397,7 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
             writer.writeAttribute( "schemaLocation", GML_31_DEFAULT_INCLUDE );
             break;
         case GML_32:
+        case GML_322:
             // there is no abstract FeatureCollection element in GML 3.2 anymore
             parentElement = GML_PREFIX + ":AbstractFeature";
             parentType = GML_PREFIX + ":AbstractFeatureType";
@@ -417,7 +419,7 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
         writer.writeStartElement( XSNS, "extension" );
         writer.writeAttribute( "base", parentType );
 
-        if ( GML_32 == gmlVersion ) {
+        if ( GML_32 == gmlVersion || GML_322 == gmlVersion ) {
             // in GML 3.2, FeatureCollections are Features with properties that derive
             // gml:AbstractFeatureMemberType
             writer.writeStartElement( XSNS, "sequence" );
@@ -450,7 +452,7 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
         writer.writeEndElement();
         writer.writeEndElement();
 
-        if ( GML_32 == gmlVersion ) {
+        if ( GML_32 == gmlVersion || GML_322 == gmlVersion ) {
             // write wfs:FeaturePropertyType declaration
             writer.writeStartElement( XSNS, "complexType" );
             writer.writeAttribute( "name", "FeaturePropertyType" );

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -46,6 +46,7 @@ import static org.deegree.commons.xml.stax.XMLStreamUtils.writeNamespaceIfNotBou
 import static org.deegree.gml.GMLOutputFactory.createGMLStreamWriter;
 import static org.deegree.gml.GMLVersion.GML_2;
 import static org.deegree.gml.GMLVersion.GML_32;
+import static org.deegree.gml.GMLVersion.GML_322;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_100;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_110;
 import static org.deegree.protocol.wfs.WFSConstants.VERSION_200;
@@ -248,7 +249,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
             // ensure that namespace for gml (e.g. geometry elements) is bound
             writeNamespaceIfNotBound( xmlStream, "gml", gmlVersion.getNamespace() );
 
-            if ( GML_32 == gmlVersion && !request.getVersion().equals( VERSION_200 ) ) {
+            if ( ( GML_32 == gmlVersion || GML_322 == gmlVersion )  && !request.getVersion().equals( VERSION_200 ) ) {
                 xmlStream.writeAttribute( "gml", GML3_2_NS, "id", "WFS_RESPONSE" );
             }
         }
@@ -640,7 +641,8 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
             xmlStream.writeEndElement();
             break;
         }
-        case GML_32: {
+        case GML_32:
+        case GML_322: {
             if ( wfsVersion.equals( VERSION_200 ) ) {
                 xmlStream.writeStartElement( "wfs", "boundedBy", GML3_2_NS );
                 if ( env == null ) {

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetGmlObjectHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetGmlObjectHandler.java
@@ -142,6 +142,7 @@ public class GmlGetGmlObjectHandler extends AbstractGmlRequestHandler {
                 schemaLocation = GMLNS + " http://schemas.opengis.net/gml/3.1.1/base/geometryComplexes.xsd";
                 break;
             case GML_32:
+            case GML_322:
                 schemaLocation = GML3_2_NS + " http://schemas.opengis.net/gml/3.2.1/geometryComplexes.xsd";
                 break;
             }


### PR DESCRIPTION
* Renamed existing version GML_32 to GML_321
* Added new verison GML_322
* Added a few tests to make sure the right version is picked.
* Modified a few methods to check for GML_321 and GML_322 instead of only to check for GML_321 (old GML_32)
* Left gml:id check intact for GML_321. In GML_322 gml:id is not required.
