### PR TITLE
Add support for ObjectPropertyType in GMLAppSchema

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLAppSchemaWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLAppSchemaWriter.java
@@ -65,6 +65,7 @@ import org.deegree.feature.types.property.FeaturePropertyType;
 import org.deegree.feature.types.property.GeometryPropertyType;
 import org.deegree.feature.types.property.GeometryPropertyType.GeometryType;
 import org.deegree.feature.types.property.MeasurePropertyType;
+import org.deegree.feature.types.property.ObjectPropertyType;
 import org.deegree.feature.types.property.SimplePropertyType;
 import org.deegree.gml.GMLVersion;
 import org.slf4j.Logger;
@@ -638,6 +639,8 @@ public class GMLAppSchemaWriter {
                 export( writer, (MeasurePropertyType) pt );
             } else if ( pt instanceof CustomPropertyType ) {
                 export( writer, (CustomPropertyType) pt );
+            } else if ( pt instanceof ObjectPropertyType ) {
+                export( writer, (ObjectPropertyType) pt );
             } else {
                 throw new RuntimeException( "Unhandled property type '" + pt.getClass() + "'" );
             }
@@ -842,15 +845,34 @@ public class GMLAppSchemaWriter {
         if ( xsTypeDef == null ) {
             LOG.warn( "Type definition null inside " + pt.getName() + " property type." );
         } else {
-            if ( !xsTypeDef.getAnonymous() ) {
-                QName qName = new QName( xsTypeDef.getNamespace(), xsTypeDef.getName() );
-                writer.writeAttribute( "type", getPrefixedName( qName ) );
-            } else {
-                LOG.debug( "Exporting anonymous type " + xsTypeDef );
-                exportType( writer, xsTypeDef );
-            }
+            export( writer, xsTypeDef );
         }
     }
+
+    private void export( XMLStreamWriter writer, ObjectPropertyType pt )
+                            throws XMLStreamException {
+
+        XSElementDeclaration xsElDecl = pt.getElementDecl();
+        XSTypeDefinition xsTypeDef = xsElDecl != null ? xsElDecl.getTypeDefinition() : null;
+
+        if ( xsTypeDef == null ) {
+            LOG.warn( "Type definition null inside " + pt.getName() + " property type." );
+        } else {
+            export( writer, xsTypeDef );
+        }
+    }
+
+    private void export( XMLStreamWriter writer, XSTypeDefinition xsTypeDef )
+                            throws XMLStreamException {
+        if ( !xsTypeDef.getAnonymous() ) {
+            QName qName = new QName( xsTypeDef.getNamespace(), xsTypeDef.getName() );
+            writer.writeAttribute( "type", getPrefixedName( qName ) );
+        } else {
+            LOG.debug( "Exporting anonymous type " + xsTypeDef );
+            exportType( writer, xsTypeDef );
+        }
+    }
+
 
     private void export( XMLStreamWriter writer, CodePropertyType pt )
                             throws XMLStreamException {


### PR DESCRIPTION
 * e.g. gml:TemporalPeriodPropertyType is parsed by the Schema analysis
   to an ObjectPropertyType - which was previously unsupported in the
   GMLAppSchemaWriter, resulting in an "Unhandled property type" runtime
   exception.

 * This PR adds support for the ObjectPropertyType through the same
   generic mechanism as used for the CustomPropertyType, i.e. exporting
   the underlying XSComplexTypeDefinition, and therefore also includes
   minimal code refactoring to avoid duplication of code previously only
   used by the CustomPropertyType export.