### PR TITLE
SchemaLocation points to GML 3.2.2 when GML 3.2.1 is requested

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/AbstractGmlRequestHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/AbstractGmlRequestHandler.java
@@ -454,8 +454,8 @@ abstract class AbstractGmlRequestHandler {
         try {
             if ( VERSION_100.equals( version ) && gmlVersion == GML_2 ) {
                 baseUrl.append( "XMLSCHEMA" );
-            } else if ( VERSION_200.equals( version ) && gmlVersion == GML_32 ) {
-                baseUrl.append( URLEncoder.encode( gmlVersion.getMimeType(), "UTF-8" ) );
+            } else if ( gmlVersion == GML_32 ) {
+                baseUrl.append( URLEncoder.encode( options.getMimeType(), "UTF-8" ) );
             } else {
                 baseUrl.append( URLEncoder.encode( gmlVersion.getMimeTypeOldStyle(), "UTF-8" ) );
             }


### PR DESCRIPTION
This pull request implements that the correct GML version is used as described in  #1126.

Fixes #1126.