### PR TITLE
Update schema handling and prepare migration

### DIFF
--- a/uncoupled/deegree-jaxb-resolver/pom.xml
+++ b/uncoupled/deegree-jaxb-resolver/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.deegree</groupId>
@@ -21,7 +22,15 @@
 		</repository>
 	</repositories>
 
-	<!-- TRICKY require to start compiler forked, to allow build against reference in rt.jar -->
+	<scm>
+		<connection>scm:git:git@github.com:deegree/deegree3.git</connection>
+		<developerConnection>scm:git:git@github.com:deegree/deegree3.git</developerConnection>
+		<url>https://github.com/deegree/deegree3</url>
+		<tag>HEAD</tag>
+	</scm>
+
+	<!-- TRICKY require to start compiler forked, to allow build against reference 
+		in rt.jar -->
 	<build>
 		<plugins>
 			<plugin>
@@ -34,8 +43,39 @@
 					<fork>true</fork>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<tagNameFormat>jaxb-resolver-@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
+
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License (LGPL), version 2.1</name>
+			<url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<issueManagement>
+		<system>github</system>
+		<url>https://github.com/deegree/deegree3/issues</url>
+	</issueManagement>
+
+	<developers>
+		<developer>
+			<id>TMC</id>
+			<name>Technical Management Committee</name>
+			<organization>OSGeo deegree project</organization>
+			<organizationUrl>https://www.deegree.org</organizationUrl>
+			<email>tmc@deegree.org</email>
+		</developer>
+	</developers>
 
 	<dependencies>
 		<dependency>
@@ -46,4 +86,9 @@
 			<systemPath>${java.home}/lib/rt.jar</systemPath>
 		</dependency>
 	</dependencies>
+
+	<ciManagement>
+		<system>Jenkins CI</system>
+		<url>http://buildserver.deegree.org/</url>
+	</ciManagement>
 </project>

--- a/uncoupled/deegree-jaxb-resolver/pom.xml
+++ b/uncoupled/deegree-jaxb-resolver/pom.xml
@@ -1,17 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.deegree</groupId>
 	<artifactId>deegree-jaxb-resolver</artifactId>
-	<version>1.0</version>
+	<version>1.1-SNAPSHOT</version>
 	<name>deegree-jaxb-resolver</name>
 	<packaging>jar</packaging>
 	<description>JAXB resolver to search for deegree schema files on classpath</description>
-
-	<parent>
-		<groupId>org.deegree</groupId>
-		<artifactId>deegree</artifactId>
-		<version>3.4-RC1</version>
-	</parent>
 
 	<repositories>
 		<repository>

--- a/uncoupled/deegree-jaxb-resolver/src/main/java/org/deegree/uncoupled/jaxb/CatalogResolver.java
+++ b/uncoupled/deegree-jaxb-resolver/src/main/java/org/deegree/uncoupled/jaxb/CatalogResolver.java
@@ -1,12 +1,11 @@
 /*----------------------------------------------------------------------------
- This file is part of deegree
- Copyright (C) 2001-2014 by:
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2022 by:
  - Department of Geography, University of Bonn -
  and
  - lat/lon GmbH -
  and
- - grit GmbH -
- and others
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
 
  This library is free software; you can redistribute it and/or modify it under
  the terms of the GNU Lesser General Public License as published by the Free
@@ -22,21 +21,30 @@
 
  Contact information:
 
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
  e-mail: info@deegree.org
- website: http://www.deegree.org/
-----------------------------------------------------------------------------*/
+ ----------------------------------------------------------------------------*/
 package org.deegree.uncoupled.jaxb;
 
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.TransformerException;
-
-import org.xml.sax.InputSource;
 
 /**
  * JAXB Catalog Resolver

--- a/uncoupled/deegree-jaxb-util/pom.xml
+++ b/uncoupled/deegree-jaxb-util/pom.xml
@@ -9,6 +9,12 @@
 	<packaging>jar</packaging>
 	<description>JAXB util to manipulate source tree related to deegree schema files</description>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<buildTimestamp>${maven.build.timestamp}</buildTimestamp>
+		<java.version>1.8</java.version>
+	</properties>
+
 	<repositories>
 		<repository>
 			<id>deegree-repo</id>
@@ -22,6 +28,14 @@
 		</repository>
 	</repositories>
 
+	<scm>
+		<connection>scm:git:git@github.com:deegree/deegree3.git</connection>
+		<developerConnection>scm:git:git@github.com:deegree/deegree3.git</developerConnection>
+		<url>https://github.com/deegree/deegree3</url>
+		<tag>HEAD</tag>
+	</scm>
+
+
 	<build>
 		<plugins>
 			<plugin>
@@ -33,21 +47,46 @@
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<tagNameFormat>jaxb-util-@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<buildTimestamp>${maven.build.timestamp}</buildTimestamp>
-		<java.version>1.8</java.version>
-	</properties>
 
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License (LGPL), version 2.1</name>
+			<url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<issueManagement>
+		<system>github</system>
+		<url>https://github.com/deegree/deegree3/issues</url>
+	</issueManagement>
+
+	<developers>
+		<developer>
+			<id>TMC</id>
+			<name>Technical Management Committee</name>
+			<organization>OSGeo deegree project</organization>
+			<organizationUrl>https://www.deegree.org</organizationUrl>
+			<email>tmc@deegree.org</email>
+		</developer>
+	</developers>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.30</version>
+			<version>1.7.36</version>
 		</dependency>
 		<dependency>
 			<groupId>info.picocli</groupId>
@@ -55,4 +94,9 @@
 			<version>4.6.1</version>
 		</dependency>
 	</dependencies>
+
+	<ciManagement>
+		<system>Jenkins CI</system>
+		<url>http://buildserver.deegree.org/</url>
+	</ciManagement>
 </project>

--- a/uncoupled/deegree-jaxb-util/pom.xml
+++ b/uncoupled/deegree-jaxb-util/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.deegree</groupId>
+	<artifactId>deegree-jaxb-util</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<name>deegree-jaxb-util</name>
+	<packaging>jar</packaging>
+	<description>JAXB util to manipulate source tree related to deegree schema files</description>
+
+	<repositories>
+		<repository>
+			<id>deegree-repo</id>
+			<url>http://repo.deegree.org/content/groups/public</url>
+			<releases>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<buildTimestamp>${maven.build.timestamp}</buildTimestamp>
+		<java.version>1.8</java.version>
+	</properties>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.30</version>
+		</dependency>
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+			<version>4.6.1</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/AbstractScanner.java
+++ b/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/AbstractScanner.java
@@ -1,3 +1,44 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2022 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
 package org.deegree.uncoupled.jaxbutil;
 
 import static java.util.Collections.emptyList;

--- a/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/AbstractScanner.java
+++ b/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/AbstractScanner.java
@@ -1,0 +1,113 @@
+package org.deegree.uncoupled.jaxbutil;
+
+import static java.util.Collections.emptyList;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import picocli.CommandLine.Option;
+
+public abstract class AbstractScanner {
+
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractScanner.class);
+
+	protected static final Pattern PAT_VERSION = Pattern.compile("^(VERSION|V|)[0-9]([._-][0-9]+)*(|-SNAPSHOT)$",
+			Pattern.CASE_INSENSITIVE);
+
+	@Option(names = { "-b", "--base" }, description = "Base path (where to start scanning)")
+	protected String path = "../../";
+
+	@Option(names = { "--schemas" }, //
+			description = "Location where to find schemas, default to http://schemas.deegree.org")
+	protected String schemasUrl = "http://schemas.deegree.org";
+
+	public static List<Path> getFilesMatching(Path basePath, String glob) throws IOException {
+		if (!Files.isDirectory(basePath)) {
+			return emptyList();
+		}
+
+		final PathMatcher mext = FileSystems.getDefault().getPathMatcher(glob);
+		final List<Path> res = new LinkedList<Path>();
+
+		Files.walkFileTree(basePath, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+
+				if (!attrs.isDirectory() && mext.matches(file.getFileName())) {
+					LOG.trace("Lookup Soruce file {} for test", file);
+					res.add(file);
+				}
+
+				return FileVisitResult.CONTINUE;
+			}
+		});
+
+		return res;
+	}
+
+	public static List<Path> getFilesMatchingCompletePath(Path basePath, String glob, String... excludes)
+			throws IOException {
+		if (!Files.isDirectory(basePath)) {
+			return emptyList();
+		}
+		FileSystem fs = FileSystems.getDefault();
+		final PathMatcher mext = fs.getPathMatcher(glob);
+		List<PathMatcher> mexcludes = Arrays.stream(excludes) //
+				.map(fs::getPathMatcher) //
+				.collect(Collectors.toList());
+		final List<Path> res = new LinkedList<Path>();
+
+		Files.walkFileTree(basePath, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				boolean exclude = false;
+				for (PathMatcher mexclude : mexcludes) {
+					if (mexclude.matches(file)) {
+						exclude = true;
+						break;
+					}
+				}
+
+				if (!attrs.isDirectory() && !exclude && mext.matches(file)) {
+					LOG.trace("Lookup Soruce file {} for test", file);
+					res.add(file);
+				}
+
+				return FileVisitResult.CONTINUE;
+			}
+		});
+
+		return res;
+	}
+
+	protected Path removeVersion(Path p) {
+		Path res = null;
+		for (int i = 0, len = p.getNameCount(); i < len; i++) {
+			String seg = p.getName(i).toString();
+			if (PAT_VERSION.matcher(seg).matches()) {
+				continue;
+			}
+			if (res == null) {
+				res = p.getName(i);
+			} else {
+				res = res.resolve(p.getName(i));
+			}
+		}
+		return res;
+	}
+}

--- a/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/MetaInfSchemasMigration.java
+++ b/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/MetaInfSchemasMigration.java
@@ -1,0 +1,304 @@
+package org.deegree.uncoupled.jaxbutil;
+
+import static java.util.stream.Collectors.joining;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "migrateschema", description = "Migrate Schemas to structure w/o version element")
+public class MetaInfSchemasMigration extends AbstractScanner implements Runnable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MetaInfSchemasMigration.class.getSimpleName());
+
+	@Option(names = { "-w", "--write" }, description = "Make changes to files")
+	private boolean write = false;
+
+	public static void main(String... args) {
+		new CommandLine(new MetaInfSchemasMigration()).execute(args);
+	}
+
+	public void run() {
+		try {
+			//moveSchemasAndExamples();
+			//convertMetaInfReferences();
+			convertRelative();
+			//convertImport();
+		} catch (Exception ex) {
+			LOG.error("Error {}", ex.getMessage());
+			LOG.warn("Execption", ex);
+		}
+	}
+
+	public void setWrite(boolean write) {
+		this.write = write;
+	}
+
+	/* move files into folders without version */
+
+	public void moveSchemasAndExamples() throws IOException {
+		Path base = Paths.get(path);
+		LOG.info("Base Path: {}", base);
+		List<Path> files = getFilesMatchingCompletePath(base, "glob:**/META-INF/schemas/**", // includes
+				"glob:**/uncoupled/**", // excludes
+				"glob:**/target/**");
+		LOG.info("Found {} files", files.size());
+
+		files.forEach(p -> {
+			Path relA = base.relativize(p);
+			try {
+				Path pathMove = makeMovePath(p);
+				if (!pathMove.equals(p)) {
+					Path relB = base.relativize(pathMove);
+					LOG.info("Moving {} -> {}", relA, relB);
+					if (write) {
+						if (!Files.isDirectory(pathMove.getParent())) {
+							Files.createDirectories(pathMove.getParent());
+						}
+						Files.move(p, pathMove);
+					}
+				}
+			} catch (Exception ex) {
+				LOG.warn("[{}] failed to move, {}", relA, ex.getMessage());
+				LOG.warn("Execption", ex);
+			}
+
+		});
+	}
+
+	/* convert internal meta-inf references */
+
+	public void convertMetaInfReferences() throws IOException {
+		Path base = Paths.get(path);
+		LOG.info("Base Path: {}", base);
+		List<Path> files = getFilesMatchingCompletePath(base, "glob:**/*.java", // includes
+				"glob:**/uncoupled/**", // excludes
+				"glob:**/target/**");
+		LOG.info("Found {} files", files.size());
+
+		Pattern match = Pattern.compile("\\/META-INF\\/schemas\\/[^ \"]+\\.xsd", Pattern.DOTALL);
+
+		files.forEach(p -> {
+			Path rel = base.relativize(p);
+			try {
+				String content = new String(Files.readAllBytes(p));
+				int lastIndex = 0;
+				StringBuilder output = new StringBuilder();
+
+				LOG.debug("- {} [size {}]", rel, content.length());
+				Matcher mLoc = match.matcher(content);
+				while (mLoc.find()) {
+					output.append(content, lastIndex, mLoc.start());
+
+					String stringOrg = mLoc.group();
+					Path pathRel = removeVersion(Paths.get(stringOrg));
+					String stringRep = StreamSupport.stream(pathRel.spliterator(), false) //
+							.map(Path::toString) //
+							.collect(joining("/", "/", ""));
+					if (!stringOrg.equals(stringRep)) {
+						LOG.info("[{}] reference {} <-> {}", rel, stringOrg, stringRep);
+						output.append(stringRep);
+					} else {
+						output.append(stringOrg);
+					}
+
+					lastIndex = mLoc.end();
+				}
+				if (lastIndex < content.length()) {
+					output.append(content, lastIndex, content.length());
+				}
+				if (write) {
+					Files.write(p, output.toString().getBytes());
+				}
+			} catch (Exception ex) {
+				LOG.warn("{} failed to read with {}", rel, ex.getMessage());
+				LOG.warn("Execption", ex);
+			}
+		});
+	}
+
+	// StringVisitor visitMeta = new
+	// StringVisitor("\\/META-INF\\/schemas\\/.*\\.xsd", Pattern.CASE_INSENSITIVE);
+
+	private Path makeMovePath(Path path) throws Exception {
+		Path match = Paths.get("META-INF/schemas");
+		for (int i = 0, len = path.getNameCount(); i < len - 1; i++) {
+			if (path.subpath(i, len - 1).startsWith(match)) {
+				Path sub = removeVersion(path.subpath(i + 2, len));
+				return path.subpath(0, i + 2).resolve(sub);
+			}
+		}
+		throw new Exception("Could not convert path");
+	}
+
+	/* import handling */
+	
+	public void convertRelative() throws IOException {
+		Path base = Paths.get(path);// .toAbsolutePath();
+		LOG.info("Base Path: {}", base);
+		List<Path> files = getFilesMatchingCompletePath(base, //
+				"glob:**/META-INF/schemas/**/*.xsd", // includes
+				"glob:**/uncoupled/**", // excludes
+				"glob:**/target/**");
+		LOG.info("Found {} files", files.size());
+
+		Pattern matchLocation = Pattern.compile("schemaLocation=\"([^\"]+)\"", Pattern.DOTALL);
+		Pattern matchRelative = Pattern.compile("^\\.\\.\\/[^ ]+\\.xsd$");
+		files.forEach(p -> {
+			Path rel = base.relativize(p);
+			try {
+				Path pathFile = makeSubpathNoVersion(p);
+
+				String content = new String(Files.readAllBytes(p));
+				int lastIndex = 0;
+				StringBuilder output = new StringBuilder();
+
+				LOG.debug("- {} [size {}]", rel, content.length());
+				Matcher mLoc = matchLocation.matcher(content);
+				while (mLoc.find()) {
+					output.append(content, lastIndex, mLoc.start(1));
+					String contentSub = mLoc.group(1);
+					if ( matchRelative.matcher(contentSub).matches() ) {
+						Path a = pathFile.getParent();
+						Path b = Paths.get(contentSub);
+						while ( b.getNameCount() > 1 && a.getNameCount() > 1 && "..".equals(b.getName(0).toString())) {
+							//LOG.info("Before {} / {}", a, b);
+							a = a.subpath(0, a.getNameCount() - 1);
+							b = b.subpath(1, b.getNameCount());
+							//LOG.info("After {} / {}", a, b);
+						}
+						Path pathRef;
+						if (a.getNameCount() == 1 &&  "..".equals(b.getName(0).toString())) {
+							pathRef = b.subpath(1, b.getNameCount());
+						} else {
+							pathRef = a.resolve(b); 
+						}
+						String stringBase = StreamSupport.stream(pathFile.getParent().spliterator(), false) //
+								.map(elem -> "..") //
+								.collect(joining("/"));
+						String stringRel = StreamSupport.stream(pathRef.spliterator(), false) //
+								.map(Path::toString) //
+								.collect(joining("/"));
+						String newUrl = stringBase + "/" + stringRel;
+						if ( !contentSub.equals(newUrl))
+							LOG.info( "[{}] \n {} -> {} ", rel, contentSub, newUrl );
+					} else {
+						output.append(contentSub);
+					}
+					lastIndex = mLoc.end(1);
+				}
+				if (lastIndex < content.length()) {
+					output.append(content, lastIndex, content.length());
+				}
+
+				if (write) {
+					Files.write(p, output.toString().getBytes());
+				}
+			} catch (Exception ex) {
+				LOG.warn("{} failed to read with {}", rel, ex.getMessage());
+				LOG.warn("Execption", ex);
+			}
+		});
+		
+	}
+
+	public void convertImport() throws IOException {
+		Path base = Paths.get(path);// .toAbsolutePath();
+		LOG.info("Base Path: {}", base);
+		List<Path> files = getFilesMatchingCompletePath(base, //
+				"glob:**/META-INF/schemas/**/*.xsd", // includes
+				"glob:**/uncoupled/**", // excludes
+				"glob:**/target/**");
+		LOG.info("Found {} files", files.size());
+
+		Pattern matchLocation = Pattern.compile("schemaLocation=\"([^\"]+)\"", Pattern.DOTALL);
+		Pattern matchSchemaUrl = Pattern.compile("(?:http|https)://schemas\\.deegree\\.org[^ \"]+\\.xsd");
+
+		files.forEach(p -> {
+			Path rel = base.relativize(p);
+			try {
+				Path pathFile = makeSubpathNoVersion(p);
+
+				String content = new String(Files.readAllBytes(p));
+				int lastIndex = 0;
+				StringBuilder output = new StringBuilder();
+
+				LOG.debug("- {} [size {}]", rel, content.length());
+				Matcher mLoc = matchLocation.matcher(content);
+				while (mLoc.find()) {
+					output.append(content, lastIndex, mLoc.start(1));
+
+					String contentSub = mLoc.group(1);
+					int lastIndexSub = 0;
+					LOG.trace("[{}] loc {}", rel, contentSub);
+					Matcher mUrl = matchSchemaUrl.matcher(contentSub);
+					while (mUrl.find()) {
+						output.append(contentSub, lastIndexSub, mUrl.start());
+
+						Path pathRef = makeSubpathNoVersion(mUrl.group());
+
+						String stringBase = StreamSupport.stream(pathFile.getParent().spliterator(), false) //
+								.map(elem -> "..") //
+								.collect(joining("/"));
+						String stringRel = StreamSupport.stream(pathRef.spliterator(), false) //
+								.map(Path::toString) //
+								.collect(joining("/"));
+						String newUrl = stringBase + "/" + stringRel;
+
+						LOG.info("[{}] Change Import {} -> {}", rel, mUrl.group(), newUrl);
+
+						output.append(newUrl);
+						lastIndexSub = mUrl.end();
+					}
+					if (lastIndexSub < contentSub.length()) {
+						output.append(contentSub, lastIndexSub, contentSub.length());
+					}
+
+					lastIndex = mLoc.end(1);
+				}
+				if (lastIndex < content.length()) {
+					output.append(content, lastIndex, content.length());
+				}
+
+				if (write) {
+					Files.write(p, output.toString().getBytes());
+				}
+			} catch (Exception ex) {
+				LOG.warn("{} failed to read with {}", rel, ex.getMessage());
+				LOG.warn("Execption", ex);
+			}
+		});
+	}
+
+	private Path makeSubpathNoVersion(String uri) throws Exception {
+		if (uri.startsWith(schemasUrl)) {
+			Path p = Paths.get(uri.substring(schemasUrl.length() + 1));
+			return removeVersion(p);
+		}
+		throw new Exception("Could not convert uri");
+	}
+
+	private Path makeSubpathNoVersion(Path path) throws Exception {
+		Path match = Paths.get("META-INF/schemas");
+		for (int i = 0, len = path.getNameCount(); i < len - 1; i++) {
+			if (path.subpath(i, len - 1).startsWith(match)) {
+				String sp = path.subpath(i + 2, len).toString();
+				// LOG.info("Subpath {}", sp);
+				return removeVersion(Paths.get(sp));
+			}
+		}
+		throw new Exception("Could not convert path");
+	}
+}

--- a/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/MetaInfSchemasMigration.java
+++ b/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/MetaInfSchemasMigration.java
@@ -1,3 +1,44 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2022 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
 package org.deegree.uncoupled.jaxbutil;
 
 import static java.util.stream.Collectors.joining;
@@ -32,10 +73,10 @@ public class MetaInfSchemasMigration extends AbstractScanner implements Runnable
 
 	public void run() {
 		try {
-			//moveSchemasAndExamples();
-			//convertMetaInfReferences();
+			moveSchemasAndExamples();
+			convertMetaInfReferences();
 			convertRelative();
-			//convertImport();
+			convertImport();
 		} catch (Exception ex) {
 			LOG.error("Error {}", ex.getMessage());
 			LOG.warn("Execption", ex);

--- a/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/UpdateSchema.java
+++ b/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/UpdateSchema.java
@@ -1,3 +1,44 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2022 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
 package org.deegree.uncoupled.jaxbutil;
 
 import static java.util.stream.Collectors.joining;

--- a/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/UpdateSchema.java
+++ b/uncoupled/deegree-jaxb-util/src/main/java/org/deegree/uncoupled/jaxbutil/UpdateSchema.java
@@ -1,0 +1,102 @@
+package org.deegree.uncoupled.jaxbutil;
+
+import static java.util.stream.Collectors.joining;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "updateschema", description = "Updates all found schema http(s)://schemas.deegree.org refernces")
+public class UpdateSchema extends AbstractScanner implements Runnable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(UpdateSchema.class.getSimpleName());
+
+	@Option(names = { "-w", "--write" }, description = "Make changes to files")
+	private boolean write = false;
+
+	@Parameters(index = "0", description = "Version to use in Schema references")
+	private String version;
+
+	public static void main(String... args) {
+		new CommandLine(new UpdateSchema()).execute(args);
+	}
+
+	@Override
+	public void run() {
+		try {
+			scanAndFix();
+		} catch (Exception ex) {
+			LOG.error("Error {}", ex.getMessage());
+			LOG.warn("Execption", ex);
+		}
+	}
+
+	public void setWrite(boolean write) {
+		this.write = write;
+	}
+
+	public void scanAndFix() throws IOException {
+		Path base = Paths.get(path);// .toAbsolutePath();
+		LOG.info("Base Path: {}", base);
+		List<Path> files = getFilesMatchingCompletePath(base, //
+				"glob:**/*.{adoc,java,se,sld,xml,xsd}", // includes
+				"glob:**/uncoupled/**", // excludes
+				"glob:**/target/**");
+		LOG.info("Found {} files", files.size());
+
+		Pattern match = Pattern.compile("((?:http|https)://schemas\\.deegree\\.org)([^ \"]+\\.xsd)");
+
+		files.forEach(p -> {
+			Path rel = base.relativize(p);
+			try {
+				String content = new String(Files.readAllBytes(p));
+				int lastIndex = 0;
+				StringBuilder output = new StringBuilder();
+
+				LOG.debug("- {} [size {}]", rel, content.length());
+				Matcher mLoc = match.matcher(content);
+				while (mLoc.find()) {
+					output.append(content, lastIndex, mLoc.start());
+
+					output.append(mLoc.group(1));
+					String stringOrg = mLoc.group(2);
+					Path pathRel = Paths.get("/" + version).resolve(removeVersion(Paths.get(stringOrg)));
+					String stringRep = StreamSupport.stream(pathRel.spliterator(), false) //
+							.map(Path::toString) //
+							.collect(joining("/", "/", ""));
+					if (!stringOrg.equals(stringRep)) {
+						LOG.info("[{}] loc {} <-> {}", rel, stringOrg, stringRep);
+						output.append(stringRep);
+					} else {
+						output.append(stringOrg);
+					}
+
+					lastIndex = mLoc.end();
+				}
+				if (lastIndex < content.length()) {
+					output.append(content, lastIndex, content.length());
+				}
+				if (write) {
+					Files.write(p, output.toString().getBytes());
+				}
+			} catch (Exception ex) {
+				LOG.warn("{} failed to read with {}", rel, ex.getMessage());
+				LOG.warn("Execption", ex);
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
This PR updates the catalog resolver to to implement the new xml schema version strategy https://github.com/deegree/deegree3/issues/953

It also provides utilities to update every schema reference in the source tree based on text replacements.

The branch https://github.com/deegree/deegree3/compare/master...gritGmbH:demo/new-schema-results shows what would have been changed when the migration utilities ran.
