### PR TITLE
Redirect INSPIRE schemas from HTTP to HTTPS

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
@@ -60,6 +60,8 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 
     private static final String SCHEMAS_OPENGIS_NET_URL = "http://schemas.opengis.net/";
 
+    public static final String INSPIRE_SCHEMAS_URL = "http://inspire.ec.europa.eu/schemas";
+
     private static final String ROOT = "/META-INF/SCHEMAS_OPENGIS_NET/";
 
     private static final URL baseURL;
@@ -88,6 +90,8 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
                 LOG.debug( "Local hit: " + systemId );
                 return u.toString();
             }
+        } else if ( systemId.startsWith( INSPIRE_SCHEMAS_URL ) ) {
+            return systemId.replaceFirst( "http://", "https://" );
         } else if ( systemId.equals( "http://www.w3.org/2001/xml.xsd" ) ) {
             // workaround for schemas that include the xml base schema...
             return RedirectingEntityResolver.class.getResource( "/w3c/xml.xsd" ).toString();

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/xml/schema/RedirectingEntityResolverTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/xml/schema/RedirectingEntityResolverTest.java
@@ -1,0 +1,32 @@
+package org.deegree.commons.xml.schema;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class RedirectingEntityResolverTest {
+
+    private RedirectingEntityResolver redirectingEntityResolver = new RedirectingEntityResolver();
+
+    @Test
+    public void test_redirect_schemasOpengisNet_to_local() {
+        String systemId = "http://schemas.opengis.net/csw/2.0.2/record.xsd";
+        String redirected = redirectingEntityResolver.redirect(systemId);
+
+        assertThat(redirected, endsWith("/META-INF/SCHEMAS_OPENGIS_NET/csw/2.0.2/record.xsd"));
+    }
+
+    @Test
+    public void test_redirect_inspire_http_to_https() {
+        String systemId = "http://inspire.ec.europa.eu/schemas/base/3.3/BaseTypes.xsd";
+        String redirected = redirectingEntityResolver.redirect(systemId);
+
+        assertThat(redirected, is("https://inspire.ec.europa.eu/schemas/base/3.3/BaseTypes.xsd"));
+    }
+
+}


### PR DESCRIPTION
Background was discussed here: https://github.com/deegree/deegree3/issues/1064

This pull request enables correct resolving of INSPIRE schemas which are now just accessible via HTTPS.

Fixes https://github.com/deegree/deegree3/issues/1064