### PR TITLE
fix: don't write attributes w/ unbound namespace prefix

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -414,10 +414,11 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
                 for ( Entry<QName, PrimitiveValue> attr : attributes.entrySet() ) {
                     QName attrKey = attr.getKey();
                     PrimitiveValue attrValue = attr.getValue();
-                    if ( XSI_NIL.equals( attrKey ) )
+                    if ( attrKey.getNamespaceURI() != null ) {
                         writeAttributeWithNS( attrKey.getNamespaceURI(), attrKey.getLocalPart(), attrValue.getAsText() );
-                    else
+                    } else {
                         writeAttribute( writer, attrKey, attrValue.getAsText() );
+                    }
                 }
             }
             if ( property.getChildren() != null ) {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/StAXExportingHelper.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/StAXExportingHelper.java
@@ -59,6 +59,8 @@ public class StAXExportingHelper {
 
     public static void writeAttribute( XMLStreamWriter xmlStream, QName name, String value )
                             throws XMLStreamException {
+        // Note: These methods will not automatically define namespaces if they are not yet defined
+        // This can result in unbound prefixes being used
         if ( name.getNamespaceURI() == null ) {
             xmlStream.writeAttribute( name.getLocalPart(), value );
         } else if ( name.getPrefix() == null ) {


### PR DESCRIPTION
In case of CustomPropertyTypes with attributes it could happen that an
attribute was written w/o a respective namespace declaration being
present.

refs #600