### PR TITLE
Fixed position of SupportedRequests in deegreeWFS configuration

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -80,14 +80,6 @@ A more complex configuration example looks like this:
     <Version>1.1.0</Version>
   </SupportedVersions>
 
-  <FeatureStoreId>inspire-ad</FeatureStoreId>
-
-  <EnableTransactions idGen="UseExisting">true</EnableTransactions>
-  <EnableResponseBuffering>false</EnableResponseBuffering>
-  <DisabledResources>
-    <Pattern>http://inspire.ec.europa.eu/codelist</Pattern>
-  </DisabledResources>
-
   <SupportedRequests>
     <SupportedEncodings>kvp</SupportedEncodings>
      <GetCapabilities>
@@ -98,6 +90,14 @@ A more complex configuration example looks like this:
       <SupportedEncodings>xml</SupportedEncodings>
     </GetFeature>
   </SupportedRequests>
+
+  <FeatureStoreId>inspire-ad</FeatureStoreId>
+
+  <EnableTransactions idGen="UseExisting">true</EnableTransactions>
+  <EnableResponseBuffering>false</EnableResponseBuffering>
+  <DisabledResources>
+    <Pattern>http://inspire.ec.europa.eu/codelist</Pattern>
+  </DisabledResources>
 
   <QueryCRS>urn:ogc:def:crs:EPSG::4258</QueryCRS>
   <QueryCRS>urn:ogc:def:crs:EPSG::4326</QueryCRS>


### PR DESCRIPTION
The example in the handbook contains a complex example of the deegreWFS configuration with is not schema valid (http://schemas.deegree.org/services/wfs/3.4.0/wfs_configuration.xsd).

This PR fixes the position of the element `SupportedRequests` in the example of the configuration.