### PR TITLE
Changed access of deegree3 Demo to https

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/test/java/org/deegree/protocol/wms/client/WMSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/test/java/org/deegree/protocol/wms/client/WMSClientTest.java
@@ -75,7 +75,7 @@ public class WMSClientTest {
     public void testWMS111InstantiationFromUrl()
                             throws OWSExceptionReport, XMLStreamException, MalformedURLException, IOException {
         URL capaUrl = new URL(
-                               "http://deegree3-demo.deegree.org:80/utah-workspace/services?request=GetCapabilities&service=WMS&version=1.1.1" );
+                               "https://deegree3-demo.deegree.org/utah-workspace/services?request=GetCapabilities&service=WMS&version=1.1.1" );
         // TODO: check if demo WMS available
         new WMSClient( capaUrl );
     }


### PR DESCRIPTION
Fixes test org.deegree.protocol.wms.client.WMSClientTest.testWMS111InstantiationFromUrl: 
http://buildserver.deegree.org/job/deegree-3.4-pipeline/304/testReport/org.deegree.protocol.wms.client/WMSClientTest/testWMS111InstantiationFromUrl/

https://deegree3-demo.deegree.org:80/utah-workspace/services?request=GetCapabilities&service=WMS&version=1.1.1 returns `https://deegree3-demo.deegree.org:80:80/utah-workspace/services?request=DTD` as DTD schemaLoactaion (also 80:80 as DCP URLs).

This PR changes the URL to https and removes the port number.