### PR TITLE
Migrated findbugs plugin to spotbugs plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         }
         stage ('Build') {
             steps {
-               echo 'Building'
+               echo 'Unit testing'
                sh 'mvn -B -C -Poracle,mssql clean test-compile'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         }
         stage ('Build') {
             steps {
-               echo 'Unit testing'
+               echo 'Building'
                sh 'mvn -B -C -Poracle,mssql clean test-compile'
             }
         }
@@ -45,11 +45,11 @@ pipeline {
             }
             steps {
                 echo 'Quality checking'
-                sh 'mvn -B -C -fae -Poracle,mssql findbugs:findbugs checkstyle:checkstyle javadoc:javadoc'
+                sh 'mvn -B -C -fae -Poracle,mssql com.github.spotbugs:spotbugs-maven-plugin:spotbugs checkstyle:checkstyle javadoc:javadoc'
             }
             post {
                 success {
-                    findbugs canComputeNew: false, defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', pattern: '**/findbugsXml.xml', unHealthy: ''
+                    findbugs canComputeNew: false, defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', pattern: '**/spotbugsXml.xml', unHealthy: ''
                     checkstyle canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: '**/checkstyle-result.xml', unHealthy: ''
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1130,19 +1130,18 @@
       <reporting>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
-            <version>2.5.2</version>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <version>4.1.3</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
-              <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-              <findbugsXmlOutput>true</findbugsXmlOutput>
+              <spotbugsXmlOutput>true</spotbugsXmlOutput>
             </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-pmd-plugin</artifactId>
-            <version>2.7.1</version>
+            <version>3.14.0</version>
             <configuration>
               <linkXref>true</linkXref>
               <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>


### PR DESCRIPTION
The findbugs project was dead after the project lead left. It's successor is the spotbugs project, see https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2017-September/004383.html for further information.
This PR changes the plugins and this is also required for supporting Java 11.