### PR TITLE
Minor improvements of deegree webservice handbook

### DIFF
--- a/deegree-services/deegree-webservices-handbook/pom.xml
+++ b/deegree-services/deegree-webservices-handbook/pom.xml
@@ -70,7 +70,7 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.4</version>
           </dependency>
         </dependencies>
         <executions>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/installation.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/installation.adoc
@@ -12,14 +12,11 @@ installation, including:
 
 Supported Java SE 8 versions are
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[Oracle JDK 8]
-footnote:[Oracle JDK 7 and earlier versions are not supported
-anymore, be aware that those versions are out of maintenance and reached
-End-of-life.] and http://openjdk.java.net[OpenJDK 8]
+footnote:[Oracle JDK 8 and later requires a subscription from Oracle for use in production environments. Read further in https://www.oracle.com/java/java-se-subscription/[Oracle Java SE subscription].] and http://openjdk.java.net[OpenJDK 8]
 footnote:[OpenJDK binaries are provided by https://www.azul.com/downloads/zulu/[Azul Systems]
 or https://adoptopenjdk.net[AdoptOpenJDK].].
 
-NOTE: Newer Java SE versions may work, but are not officially supported by the deegree
-development team.
+NOTE: Newer Java SE versions such as the LTS versions 11 and 16 are currently not supported by deegree 3.4. Please check out our wiki page https://github.com/deegree/deegree3/wiki/Java-SE-11-Support[Java 11 support] for further information.
 
 === Downloading
 
@@ -36,12 +33,12 @@ required. We recommend using the latest http://tomcat.apache.org/[Apache
 Tomcat 8] release.]
 * _ZIP_: Distribution bundle with Apache Tomcat footnote:[As of deegree
 3.4.0 the ZIP distribution bundle is deprecated and the download links
-are removed from the website. Download the ZIP from the
-https://repo.deegree.org/content/groups/public/org/deegree/deegree-webservices-tomcat-bundle/[Nexus repository]
+have been removed from the website. Download the ZIP from the
+https://repo.deegree.org/#browse/search=attributes.maven2.artifactId%3Ddeegree-webservices-tomcat-bundle[Nexus repository]
 instead.]
 
 TIP: If you are confused by the options and unsure which version to pick,
-use the ZIP All variants contain exactly the same deegree webservices webapp,
+use the ZIP. All variants contain exactly the same deegree webservices webapp,
 they only differ in packaging.
 
 === Starting and stopping

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/intro.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/intro.adoc
@@ -3,7 +3,7 @@
 deegree webservices are implementations of the geospatial webservice
 specifications of the http://www.opengeospatial.org[Open Geospatial
 Consortium (OGC)] and the http://inspire.jrc.ec.europa.eu[INSPIRE
-Network Services]. deegree webservices 3.2 includes the following
+Network Services]. deegree webservices 3.4 includes the following
 services:
 
 * http://www.opengeospatial.org/standards/wfs[Web Feature Service

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/layers.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/layers.adoc
@@ -340,7 +340,7 @@ and optionally, what styles. Let's have a look at an example:
                xmlns:d='http://www.deegree.org/metadata/description'
                xmlns:s='http://www.deegree.org/metadata/spatial'
                xmlns:l='http://www.deegree.org/layers/base'
-               configVersion='3.2.0'>
+               configVersion='3.4.0'>
 
   <AutoLayers>
     <FeatureStoreId>myfeaturestore</FeatureStoreId>
@@ -371,7 +371,7 @@ The basic structure of a manual configuration looks like this:
                xmlns:d='http://www.deegree.org/metadata/description'
                xmlns:s='http://www.deegree.org/metadata/spatial'
                xmlns:l='http://www.deegree.org/layers/base'
-               configVersion='3.2.0'>
+               configVersion='3.4.0'>
   <FeatureStoreId>myfeaturestore</FeatureStoreId>
   <FeatureLayer>
   ...

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/metadatastores.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/metadatastores.adoc
@@ -22,7 +22,7 @@ The memory ISO metadata store implementation is transactional and works
 file based.
 
 The memory metadata store configuration is defined by schema file
-http://schemas.deegree.org/datasource/metadata/iso19139/3.2.0/memory.xsd
+http://schemas.deegree.org/datasource/metadata/iso19139/3.4.0/memory.xsd
 
 *Memory ISO Metadatastore config (skeleton)*
 
@@ -42,7 +42,7 @@ http://schemas.deegree.org/datasource/metadata/iso19139/3.2.0/memory.xsd
 ----
 
 The root element has to be _ISOMemoryMetadataStore_ and the config
-attribute must be _3.2.0_. The only mandatory element is:
+attribute must be _3.4.0_. The only mandatory element is:
 
 * _ISORecordDirectory_: A list of directories containing records
 loaded in the store during start of the store.
@@ -55,7 +55,7 @@ of the directories declared in the element _ISORecordDirectory_.
 === SQL ISO Metadata store
 
 The SQL metadata store configuration is defined by schema file
-http://schemas.deegree.org/datasource/metadata/iso19115/3.2.0/iso19115.xsd
+http://schemas.deegree.org/datasource/metadata/iso19115/3.4.0/iso19115.xsd
 
 *SQL ISO Metadatastore config (skeleton)*
 
@@ -99,7 +99,7 @@ http://schemas.deegree.org/datasource/metadata/iso19115/3.2.0/iso19115.xsd
 ----
 
 The root element has to be _ISOMetadataStore_ and the config attribute
-must be _3.2.0_. The only mandatory element is:
+must be _3.4.0_. The only mandatory element is:
 
 * _JDBCConnId_: Id of the JDBC connection to use (see ...)
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -881,7 +881,7 @@ Here is a snippet for quick copy & paste:
 [source,xml]
 ----
 <SupportedVersions>
-  <SupportedVersion>1.1.1</SupportedVersion>
+  <Version>1.1.1</Version>
 </SupportedVersions>
 <MetadataStoreId>mdstore</MetadataStoreId>
 <MetadataURLTemplate>http://discovery.eu/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;id=${metadataSetId}&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full</MetadataURLTemplate>
@@ -1062,7 +1062,7 @@ deegree templating based format:
   <GetFeatureInfoFormat>
     <File>../customformat.gfi</File>
     <Format>text/html</Format>
-    <Property name="customname" value="customvalue" \>
+    <Property name="customname" value="customvalue" />
   </GetFeatureInfoFormat>
 </FeatureInfoFormats>
 ----
@@ -1075,7 +1075,7 @@ The configuration for the XSLT approach looks like this:
   <GetFeatureInfoFormat>
     <XSLTFile gmlVersion="GML_32">../customformat.xsl</XSLTFile>
     <Format>text/html</Format>
-    <Property name="customname" value="customvalue" \>
+    <Property name="customname" value="customvalue" />
   </GetFeatureInfoFormat>
 </FeatureInfoFormats>
 ----

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -1816,8 +1816,8 @@ like this:
 ==== Configuration overview
 
 The deegree WMTS config file format is defined by schema file
-http://schemas.deegree.org/services/wmts/3.2.0/wmts.xsd. The root
-element is _deegreeWMTS_ and the config attribute must be _3.2.0_.
+http://schemas.deegree.org/services/wmts/3.4.0/wmts.xsd. The root
+element is _deegreeWMTS_ and the config attribute must be _3.4.0_.
 
 The following table lists all available configuration options. When
 specifying them, their order must be respected.
@@ -1828,7 +1828,7 @@ specifying them, their order must be respected.
 |MetadataURLTemplate |0..1 |String |Template for generating URLs to
 layer metadata
 
-|ThemeId |0..n |String |Limits themes to use
+|ThemeId |0..n |String |Limit the themes to use
 |===
 
 Below the _ServiceConfiguration_ section you can specify custom
@@ -1837,10 +1837,12 @@ featureinfo format handlers:
 [source,xml]
 ----
 ...
+<ServiceConfiguration>
+...
 </ServiceConfiguration>
 <FeatureInfoFormats>
 ...
-</FeatureInfoFormats>]
+</FeatureInfoFormats>
 ----
 
 Have a look at section <<anchor-featureinfo-configuration>> (in the WMS
@@ -1886,9 +1888,9 @@ example looks like this:
 ==== Configuration overview
 
 The deegree CSW config file format is defined by schema file
-http://schemas.deegree.org/services/csw/3.2.0/csw_configuration.xsd. The
+http://schemas.deegree.org/services/csw/3.4.0/csw_configuration.xsd. The
 root element is _deegreeCSW_ and the config attribute must be
-_3.2.0_.
+_3.4.0_.
 
 The following table lists all available configuration options. When
 specifiying them, their order must be respected.
@@ -2148,9 +2150,9 @@ configuration works for all types of service alike.
 ----
 
 The metadata config file format is defined by schema file
-http://schemas.deegree.org/services/metadata/3.2.0/metadata.xsd. The
+http://schemas.deegree.org/services/metadata/3.4.0/metadata.xsd. The
 root element is _deegreeServicesMetadata_ and the config attribute
-must be _3.2.0_. The following table lists all available configuration
+must be _3.4.0_. The following table lists all available configuration
 options (complex ones contain nested options themselves). When
 specifiying them, their order must be respected.
 

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <plugin>
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
-          <version>2.1.0</version>
+          <version>2.1.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This PR contains minor improvements of deegree webservice handbook:

- [x] fixing schema version used in documentation (was 3.2.0, set to 3.4.0)
- [x] improved description of compatible Java versions 
- [x] upgrading asciidoc plugin
- [x] fixes for layout and typos