### PR TITLE
Fixes download url using nexus 3 rest api

### DIFF
--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
@@ -376,7 +376,7 @@ public class WorkspaceBean implements Serializable {
                 + "repository=releases"
                 + "&maven.groupId=org.deegree"
                 + "&maven.artifactId=" + wsArtifactName
-                + "&version=LATEST"
+                + "&sort=version"
                 + "&maven.extension=zip";
         workspaceLocations.put( wsArtifactName, url );
         list.add( wsArtifactName );

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
@@ -374,8 +374,12 @@ public class WorkspaceBean implements Serializable {
     private void addWorkspaceLocation( String wsArtifactName, List<String> list ) {
         String repo = getVersion().endsWith( "SNAPSHOT" ) ? "snapshots" : "releases";
         String version = getVersion().endsWith( "SNAPSHOT" ) ? "LATEST" : getVersion();
-        String url = "https://repo.deegree.org/service/local/artifact/maven/redirect?r=" + repo + "&g=org.deegree&a="
-                     + wsArtifactName + "&v=" + version + "&e=deegree-workspace";
+        String url = "https://repo.deegree.org/service/rest/v1/search/assets/download?"
+                + "repository=" + repo
+                + "&maven.groupId=org.deegree"
+                + "&maven.artifactId=" + wsArtifactName
+                + "&version=" + version
+                + "&maven.extension=deegree-workspace";
         workspaceLocations.put( wsArtifactName, url );
         list.add( wsArtifactName );
     }

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
@@ -372,14 +372,12 @@ public class WorkspaceBean implements Serializable {
     }
 
     private void addWorkspaceLocation( String wsArtifactName, List<String> list ) {
-        String repo = getVersion().endsWith( "SNAPSHOT" ) ? "snapshots" : "releases";
-        String version = getVersion().endsWith( "SNAPSHOT" ) ? "LATEST" : getVersion();
         String url = "https://repo.deegree.org/service/rest/v1/search/assets/download?"
-                + "repository=" + repo
+                + "repository=releases"
                 + "&maven.groupId=org.deegree"
                 + "&maven.artifactId=" + wsArtifactName
-                + "&version=" + version
-                + "&maven.extension=deegree-workspace";
+                + "&version=LATEST"
+                + "&maven.extension=zip";
         workspaceLocations.put( wsArtifactName, url );
         list.add( wsArtifactName );
     }


### PR DESCRIPTION
This PR contains minor improvement of deegree console to download workspace from deegree nexus repo. This PR changes to nexus v3 REST API.

This PR relates to the changes introduced during migration to new server infrastructure as documented in issue #1130.
And download url needs to be updated to changes coming with issue #1063. 