### PR TITLE
Fix GetFeatureInfo with non standard PIXELSIZE/DPI

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetFeatureInfo.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetFeatureInfo.java
@@ -118,8 +118,9 @@ public class GetFeatureInfo extends RequestBase {
         if ( version.equals( VERSION_130 ) ) {
             parse130( map );
         }
+        handlePixelSize( map );
         parameterMap.putAll( map );
-        scale = RenderHelper.calcScaleWMS130( width, height, bbox, crs, DEFAULT_PIXEL_SIZE );
+        scale = RenderHelper.calcScaleWMS130( width, height, bbox, crs, pixelSize );
     }
 
     public GetFeatureInfo( List<String> layers, int width, int height, int x, int y, Envelope envelope, ICRS crs,
@@ -132,7 +133,7 @@ public class GetFeatureInfo extends RequestBase {
         this.bbox = envelope;
         this.crs = crs;
         this.featureCount = featureCount;
-        scale = RenderHelper.calcScaleWMS130( width, height, bbox, crs, DEFAULT_PIXEL_SIZE );
+        scale = RenderHelper.calcScaleWMS130( width, height, bbox, crs, pixelSize );
     }
 
     public GetFeatureInfo( List<LayerRef> layers, List<StyleRef> styles, List<String> queryLayers, int width,
@@ -151,7 +152,8 @@ public class GetFeatureInfo extends RequestBase {
         this.infoFormat = infoFormat;
         this.dimensions.putAll( dimensions );
         this.parameterMap.putAll( parameterMap );
-        this.scale = RenderHelper.calcScaleWMS130( width, height, bbox, crs, DEFAULT_PIXEL_SIZE );
+        handlePixelSize( parameterMap );
+        this.scale = RenderHelper.calcScaleWMS130( width, height, bbox, crs, pixelSize );
     }
 
     private void parse111( Map<String, String> map )
@@ -469,4 +471,10 @@ public class GetFeatureInfo extends RequestBase {
         return false;
     }
 
+    /**
+     * @return the value of the pixel size parameter (default is 0.00028 m).
+     */
+    public double getPixelSize() {
+        return pixelSize;
+    }
 }

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetMap.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetMap.java
@@ -125,8 +125,6 @@ public class GetMap extends RequestBase {
 
     private double scale;
 
-    private double pixelSize = 0.00028;
-
     private double resolution;
 
     private MapOptionsMaps extensions = new MapOptionsMaps();
@@ -335,53 +333,6 @@ public class GetMap extends RequestBase {
         }
 
         return styles;
-    }
-
-    private void handlePixelSize( Map<String, String> map ) {
-        String psize = map.get( "PIXELSIZE" );
-        if ( psize != null ) {
-            try {
-                pixelSize = Double.parseDouble( psize ) / 1000;
-            } catch ( NumberFormatException e ) {
-                LOG.warn( "The value of PIXELSIZE could not be parsed as a number." );
-                LOG.trace( "Stack trace:", e );
-            }
-        } else {
-            String key = "RES";
-            String pdpi = map.get( key );
-
-            if ( pdpi == null ) {
-                key = "DPI";
-                pdpi = map.get( key );
-            }
-            if ( pdpi == null ) {
-                key = "MAP_RESOLUTION";
-                pdpi = map.get( key );
-            }
-            if ( pdpi == null ) {
-                for ( String word : splitEscaped( map.get( "FORMAT_OPTIONS" ), ';', 0 ) ) {
-                    List<String> keyValue = StringUtils.splitEscaped( word, ':', 2 );
-
-                    if ( "dpi".equalsIgnoreCase( keyValue.get( 0 ) ) ) {
-                        key = "FORMAT_OPTIONS=dpi";
-                        pdpi = keyValue.size() == 1 ? null : StringUtils.unescape( keyValue.get( 1 ) );
-                        break;
-                    }
-                }
-            }
-            if ( pdpi == null ) {
-                key = "X-DPI";
-                pdpi = map.get( key );
-            }
-            if ( pdpi != null ) {
-                try {
-                    pixelSize = 0.0254d / Double.parseDouble( pdpi );
-                } catch ( Exception e ) {
-                    LOG.warn( "The value of {} could not be parsed as a number.", key );
-                    LOG.trace( "Stack trace:", e );
-                }
-            }
-        }
     }
     
     private void handleCommon( Map<String, String> map, MapOptionsMaps exts )

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/MapService.java
@@ -284,8 +284,7 @@ public class MapService {
         List<LayerData> list = new ArrayList<LayerData>();
 
         double scale = calcScaleWMS130( gfi.getWidth(), gfi.getHeight(), gfi.getEnvelope(), gfi.getCoordinateSystem(),
-                                        DEFAULT_PIXEL_SIZE );
-
+                                        gfi.getPixelSize() );
         ListIterator<LayerQuery> queryIter = queries.listIterator();
         for ( LayerRef n : gfi.getQueryLayers() ) {
             LayerQuery query = queryIter.next();

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -852,18 +852,9 @@ public class WMSController extends AbstractOWS {
         boolean geometries = fi.returnGeometries();
         List<String> queryLayers = map( fi.getQueryLayers(), CollectionUtils.<LayerRef> getToStringMapper() );
 
-        RenderingInfo info = new RenderingInfo( fi.getInfoFormat(), fi.getWidth(), fi.getHeight(), false, null,
-                                                fi.getEnvelope(), 0.28, map );
         String format = fi.getInfoFormat();
-        info.setFormat( format );
-        info.setFeatureCount( fi.getFeatureCount() );
-        info.setX( fi.getX() );
-        info.setY( fi.getY() );
         LinkedList<String> headers = new LinkedList<String>();
-        Pair<FeatureCollection, LinkedList<String>> pair = new Pair<FeatureCollection, LinkedList<String>>(
-                                                                                                            service.getFeatures( fi,
-                                                                                                                                 headers ),
-                                                                                                            headers );
+        Pair<FeatureCollection, LinkedList<String>> pair = new Pair<>( service.getFeatures( fi, headers ), headers );
 
         FeatureCollection col = pair.first;
         addHeaders( response, pair.second );

--- a/deegree-tests/deegree-wms-similarity-tests/src/test/java/org/deegree/services/wms/GetFeatureInfoIntegrationTest.java
+++ b/deegree-tests/deegree-wms-similarity-tests/src/test/java/org/deegree/services/wms/GetFeatureInfoIntegrationTest.java
@@ -1,0 +1,103 @@
+package org.deegree.services.wms;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import org.deegree.commons.utils.net.HttpUtils;
+import org.junit.Test;
+
+public class GetFeatureInfoIntegrationTest {
+
+    public static final String GFI_BASE = "/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetFeatureInfo&QUERY_LAYERS=satellite_provo_scalelimit&SRS=EPSG%3A26912&LAYERS=satellite_provo_scalelimit&STYLES=default&FORMAT=image%2Fpng&TRANSPARENT=FALSE&INFO_FORMAT=text%2Fplain";
+
+    @Test
+    public void test96dpiNoResult()
+                            throws IOException {
+        // layer has scale 1:6900 - 1:7100
+        assertThat( "1:6895 < min scale",
+                    get( GFI_BASE
+                         + "&X=250&Y=250&WIDTH=500&HEIGHT=500&BBOX=445088.216145833,4448605.21614583,445735.783854167,4449252.78385417&DPI=96" ),
+                    not( containsString( "data:" ) ) );
+
+        assertThat( "1:7105 > max sacle",
+                    get( GFI_BASE
+                         + "&X=250&Y=250&WIDTH=500&HEIGHT=500&BBOX=444942.033854167,4448459.03385417,445881.966145833,4449398.96614583&DPI=96" ),
+                    not( containsString( "data:" ) ) );
+
+    }
+
+    @Test
+    public void test96dpiWithResult()
+                            throws IOException {
+        // layer has scale 1:6900 - 1:7100
+        assertThat( "1:6905 > min scale",
+                    get( GFI_BASE
+                         + "&X=250&Y=250&WIDTH=500&HEIGHT=500&BBOX=444955.263020833,4448472.26302083,445868.736979167,4449385.73697917&DPI=96" ),
+                    containsString( "data:" ) );
+
+        assertThat( "1:7095 < max scale",
+                    get( GFI_BASE
+                         + "&X=250&Y=250&WIDTH=500&HEIGHT=500&BBOX=444942.6953125,4448459.6953125,445881.3046875,4449398.3046875&DPI=96" ),
+                    containsString( "data:" ) );
+    }
+
+    @Test
+    public void test192dpiNoResult()
+                            throws IOException {
+        // layer has scale 1:6900 - 1:7100
+        assertThat( "1:6895 < min scale",
+                    get( GFI_BASE
+                         + "&X=500&Y=500&WIDTH=1000&HEIGHT=1000&BBOX=445088.216145833,4448605.21614583,445735.783854167,4449252.78385417&DPI=192" ),
+                    not( containsString( "data:" ) ) );
+
+        assertThat( "1:7105 > max sacle",
+                    get( GFI_BASE
+                         + "&X=500&Y=500&WIDTH=1000&HEIGHT=1000&BBOX=444942.033854167,4448459.03385417,445881.966145833,4449398.96614583&DPI=192" ),
+                    not( containsString( "data:" ) ) );
+
+    }
+
+    @Test
+    public void test192dpiWithResult()
+                            throws IOException {
+        // layer has scale 1:6900 - 1:7100
+        assertThat( "1:6905 > min scale",
+                    get( GFI_BASE
+                         + "&X=500&Y=500&WIDTH=1000&HEIGHT=1000&BBOX=444955.263020833,4448472.26302083,445868.736979167,4449385.73697917&DPI=192" ),
+                    containsString( "data:" ) );
+
+        assertThat( "1:7095 < max scale",
+                    get( GFI_BASE
+                         + "&X=500&Y=500&WIDTH=1000&HEIGHT=1000&BBOX=444942.6953125,4448459.6953125,445881.3046875,4449398.3046875&DPI=192" ),
+                    containsString( "data:" ) );
+    }
+
+    private String get( String request )
+                            throws IOException {
+        String base = "http://localhost:" + System.getProperty( "portnumber", "8080" ) + "/";
+        base += System.getProperty( "deegree-wms-similarity-webapp", "deegree-wms-similarity-tests" );
+        base += "/services" + request;
+
+        return HttpUtils.get( new HttpUtils.Worker<String>() {
+
+            @Override
+            public String work( InputStream in )
+                                    throws IOException {
+                try (Reader isr = new InputStreamReader( in, StandardCharsets.UTF_8 )) {
+                    String text = new BufferedReader( isr ).lines().collect( Collectors.joining( "\n" ) );
+                    return text;
+                }
+            }
+
+        }, base, null );
+    }
+}


### PR DESCRIPTION
This PR enables that GetFeatureInfo does not ignore configured PIXELSIZE and DPI.

In addition, integration tests were added.