### PR TITLE
fix: GetCapabilities reflect if managing stored queries is enabled

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -856,15 +856,20 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             // GetPropertyValue
             addOperation( GetPropertyValue, getAndPost, post, get, operations );
 
-            // CreateStoredQuery
-
-            List<Domain> createStoredQueryParams = new ArrayList<Domain>();
-            createStoredQueryParams.add( new Domain( "language", Collections.singletonList(
-                                    "urn:ogc:def:queryLanguage:OGC-WFS::WFSQueryExpression" ) ) );
-            addOperation( CreateStoredQuery, createStoredQueryParams, getAndPost, post, get, operations );
-
-            // DropStoredQuery
-            addOperation( DropStoredQuery, getAndPost, post, get, operations );
+            // determine if managing stored queries is supported/enabled
+            boolean enableManageStoredQueries = master.getStoredQueryHandler().isManageStoredQueriesSupported();
+            
+            if (enableManageStoredQueries) {
+	            // CreateStoredQuery
+	
+	            List<Domain> createStoredQueryParams = new ArrayList<Domain>();
+	            createStoredQueryParams.add( new Domain( "language", Collections.singletonList(
+	                                    "urn:ogc:def:queryLanguage:OGC-WFS::WFSQueryExpression" ) ) );
+	            addOperation( CreateStoredQuery, createStoredQueryParams, getAndPost, post, get, operations );
+	
+	            // DropStoredQuery
+	            addOperation( DropStoredQuery, getAndPost, post, get, operations );
+            }
             
             if ( enableTransactions ) {
                 // Transaction
@@ -935,7 +940,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             constraints.add( new Domain( "ImplementsSpatialJoins", "FALSE" ) );
             constraints.add( new Domain( "ImplementsTemporalJoins", "FALSE" ) );
             constraints.add( new Domain( "ImplementsFeatureVersioning", "FALSE" ) );
-            constraints.add( new Domain( "ManageStoredQueries", "TRUE" ) );
+            constraints.add( new Domain( "ManageStoredQueries", String.valueOf(enableManageStoredQueries).toUpperCase() ) );
 
             // capacity constraints
             if ( master.getQueryMaxFeatures() != -1 ) {

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/StoredQueryHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/StoredQueryHandler.java
@@ -127,6 +127,15 @@ public class StoredQueryHandler {
         loadConfiguredStoredQueries( storedQueryTemplates );
         loadManagedStoredQueries( managedStoredQueryDirectory );
     }
+    
+    /**
+     * Determines if managing stored queries is supported.
+     * 
+     * @return <code>true</code> if managing stored queries is supported, <code>false</code> otherwise
+     */
+    public boolean isManageStoredQueriesSupported() {
+    	return managedStoredQueryDirectory != null && managedStoredQueryDirectory.exists();
+    }
 
     /**
      * Performs the given {@link CreateStoredQuery} request.


### PR DESCRIPTION
Managing stored queries is enabled based on the presence of a folder in
the workspace. This was not reflected in the capabilities, which always
stated that managing stored queries is supported.