### PR TITLE
Return exception when mandatory version parameter is missing WMS 1.3 GetMap request

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/3.4.0/wms_configuration.xsd
@@ -62,6 +62,7 @@
         <element name="LayerLimit" minOccurs="0" type="positiveInteger" />
         <element name="MaxWidth" minOccurs="0" type="positiveInteger" />
         <element name="MaxHeight" minOccurs="0" type="positiveInteger" />
+        <element name="Strict" minOccurs="0" type="boolean" default="false"/>
       </sequence>
       <attribute name="configVersion" use="required" type="wms:ConfigVersionType" />
     </complexType>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -851,6 +851,8 @@ unlimited
 
 |MaxHeight |0..1 |Integer |Maximum height in a GetMap request, default:
 unlimited
+
+|Strict |0..1 |Boolean | Indicates if the server should behave strictly as specified. default: false
 |===
 
 ==== Basic options


### PR DESCRIPTION
Fixes #1183.

Please see #1183 for further details.

A new configuration option was introduced to enable this strict behavior. Previous behavior is preserved otherwise.