### PR TITLE
Added log4j configuration files for WMS and WMTS integration tests 

### DIFF
--- a/deegree-tests/deegree-wms-similarity-tests/src/test/resources/log4j.properties
+++ b/deegree-tests/deegree-wms-similarity-tests/src/test/resources/log4j.properties
@@ -1,0 +1,13 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{HH:mm:ss}] %5p: [%c{1}] %m%n
+
+log4j.logger.org.deegree=WARN
+log4j.logger.org.deegree.commons.utils.net=DEBUG
+log4j.logger.org.deegree.services.wms=DEBUG
+log4j.logger.org.apache.http=INFO
+log4j.logger.org.apache.http.wire=OFF
+
+

--- a/deegree-tests/deegree-wmts-tests/src/test/resources/log4j.properties
+++ b/deegree-tests/deegree-wmts-tests/src/test/resources/log4j.properties
@@ -1,0 +1,13 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{HH:mm:ss}] %5p: [%c{1}] %m%n
+
+log4j.logger.org.deegree=WARN
+log4j.logger.org.deegree.commons.utils.net=DEBUG
+log4j.logger.org.deegree.services.wmts=DEBUG
+log4j.logger.org.apache.http=INFO
+log4j.logger.org.apache.http.wire=OFF
+
+


### PR DESCRIPTION
Currently the build console log is cluttered with Apache HttpClient debug information such as the HTTP traffic. 
This has no use for fault analysis on the CI system, thus it should be turned off. 
This PR provides the log4j config files to turn off Apache HttpClient logging on `wire`.

Example of the output:
```
[19:00:42] DEBUG: [DefaultHttpClient] Connection can be kept alive for 60000 MILLISECONDS
[19:00:42] DEBUG: [wire]  << "1458[\r][\n]"
[19:00:42] DEBUG: [wire]  << "[0x89]PNG[\r][\n]"
[19:00:42] DEBUG: [wire]  << "[0x1a][\n]"
[19:00:42] DEBUG: [wire]  << "[0x0][0x0][0x0][\r]IHDR[0x0][0x0][0x1][0xd2][0x0][0x0][0x1]\[0x8][0x6][0x0][0x0][0x0]|[0xda]?[0x9e][0x0][0x0][0x14][0x1f]IDATx[0xda][0xed][0xdd][0x8b][0x8e]#7[0xae][0x0]P}z[0xfe][0xdc][0xbb][0xc1]bf[0xa7][0xa7][0x1f][0xae]*[0xbd]H[0xea][0x1c]`q[0x3]#7[0xdd][0x96](R%[0xb3][0xe5][0xd6][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0][0x0]`[0x95][0xfe][0xf9][0xe7][0xf5][0xef][0xff][0x8c]D[0xcc][0xb9][0xf9][0xef][0xff][0xf9][0xf5]?[0xf1][0x6][0x10][0xcc][0xeb][0x8f][0xa4]&[0xb1][0x5][0x9d][0xa3]o[0xfe]Y[0xbc][0x1][0x4]J[0xd4][0x92]Z[0xfc]"Ze[0xbe][0xc4][0x1b][0xa0][0x90][0xb2]u^[0x14]R[0x80]@O9[0xdf][0x1d][0xb5]It[0x9b]}7/[0x99][0x8e]F[0xb3][0xff][0xfe][0xb]N[0x17][0x80][0x8c][0x89][0xf9][0xcf][0xe6][0x95]?_[0xfb][0xea]u[0xa3][0xb6][0xae][0xae][0xcc]W[0x85]x;h[0xdd][0x1]'$[0xe6][0xbf]^#[0xf6]|ey[0xaa]>m[0xe3][0x96]j[0xe3][0x3][0xdc]Oj[0x9f][0x16][0xfb][0xf][0xaf][0xb3]1[0x9][0xb7][0xfc]G[0xa3][0x97][0xe3][0xad][0xca][0xdc]%[0x9f]/[0xe0][0xc6]"[0xff][0xf3][0xb5][0xd7][0xc5][0x97][0xb5]suR[0xb3][0xd1][0xcb]|[0x1][0xd5][\n]"
```

