### PR TITLE
WMS 1.3: Throw correct exception type when requesting erroneous version in GetMap request

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -341,7 +341,15 @@ public class WMSController extends AbstractOWS {
                        List<FileItem> multiParts )
                             throws ServletException, IOException {
         String v = getVersionValueFromRequest( map );
-        Version version = v == null ? highestVersion : Version.parseVersion( v );
+        Version version;
+        try {
+            version = v == null ? highestVersion : Version.parseVersion( v );
+        } catch ( InvalidParameterValueException e ) {
+            controllers.get( highestVersion ).sendException( new OWSException( get( "WMS.VERSION_UNSUPPORTED", v ),
+                                                                               OWSException.INVALID_PARAMETER_VALUE ),
+                                                             response, this );
+            return;
+        }
 
         WMSRequestType req;
         String requestName = map.get( "REQUEST" );


### PR DESCRIPTION
Description of bug: https://github.com/deegree/deegree3/issues/1235

Fixes https://github.com/deegree/deegree3/issues/1235.