### PR TITLE
Bump log4j2 to v2.17.1 to resolve CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1087,7 +1087,7 @@
     <spring-boot.version>2.4.12</spring-boot.version>
     <spring-batch.version>4.3.3</spring-batch.version>
     <spring-framework.version>5.3.12</spring-framework.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <slf4j.version>1.7.32</slf4j.version>
   </properties>
 


### PR DESCRIPTION
see https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832