### PR TITLE
Improved log message

### DIFF
--- a/deegree-core/deegree-core-theme/src/main/java/org/deegree/theme/persistence/standard/StandardThemeBuilder.java
+++ b/deegree-core/deegree-core-theme/src/main/java/org/deegree/theme/persistence/standard/StandardThemeBuilder.java
@@ -156,7 +156,7 @@ public class StandardThemeBuilder implements ResourceBuilder<Theme> {
 
         if ( lays.isEmpty() && themes.isEmpty() ) {
             LOG.warn( "Skipping theme or subtheme with id {} because it is empty (no subthemes and no layers).",
-                      current.getIdentifier() );
+                      current.getIdentifier() != null ? current.getIdentifier().getValue() : " - (no identifier)" );
             return null;
         }
 


### PR DESCRIPTION
Fixes `Skipping theme or subtheme with id org.deegree.theme.persistence.standard.jaxb.ThemeType$Identifier@40cd62e0 because it is empty (no subthemes and no layers).`by replacing org.deegree.theme.persistence.standard.jaxb.ThemeType$Identifier@40cd62e0 with the identifier.
