### PR TITLE
Remove oracle profile from deegree-tools-gml and deegree-featurestore-sql

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -47,6 +47,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <artifactId>deegree-sqldialect-oracle</artifactId>
+      <groupId>org.deegree</groupId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -87,25 +93,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <profile>
-      <id>oracle</id>
-      <repositories>
-        <repository>
-          <id>deegree-restricted</id>
-          <name>deegree-restricted</name>
-          <url>https://repo.deegree.org/content/repositories/private3rdparty</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <artifactId>deegree-sqldialect-oracle</artifactId>
-          <groupId>org.deegree</groupId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 
 </project>
-

--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -115,6 +115,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-sqldialect-oracle</artifactId>
+      <version>${project.version}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -187,19 +193,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>oracle</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.deegree</groupId>
-          <artifactId>deegree-sqldialect-oracle</artifactId>
-          <version>${project.version}</version>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
Fixes #1268.

Module deegree-sqldialect-oracle is not behind a profile anymore as the dependencies are available publicly.

Problem documented in #1268 was solved by removing the profile containing artifact deegree-sqldialect-oracle and adding the artifact to the dependency list.
Also, the oracle profile in module deegree-featurestore-sql was removed.