### PR TITLE
Enhance GmlTool to reduce generated mapping

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
@@ -94,7 +94,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.apache.xerces.xs.XSComplexTypeDefinition.CONTENTTYPE_ELEMENT;
 import static org.apache.xerces.xs.XSComplexTypeDefinition.CONTENTTYPE_EMPTY;
@@ -138,7 +137,7 @@ public class AppSchemaMapper {
 
     private final int allowedCycleDepth;
 
-    private final boolean considerPropertiesOfReferenceData;
+    private final boolean useRefDataProps;
 
     /**
      * Creates a new {@link AppSchemaMapper} instance for the given schema.
@@ -212,19 +211,19 @@ public class AppSchemaMapper {
      *                         depth of the allowed cycles
      * @param  referenceData
      *                         describing the data stored in the features store
-     * @param considerPropertiesOfReferenceData
+     * @param useRefDataProps
      *                         <code>true</code> if only properties defined in reference data should be mapped
      */
     public AppSchemaMapper( AppSchema appSchema, boolean createBlobMapping, boolean createRelationalMapping,
                             GeometryStorageParams geometryParams, int maxLength, boolean usePrefixedSQLIdentifiers,
-                            boolean useIntegerFids, int allowedCycleDepth, ReferenceData referenceData, boolean considerPropertiesOfReferenceData ) {
+                            boolean useIntegerFids, int allowedCycleDepth, ReferenceData referenceData, boolean useRefDataProps ) {
         this.appSchema = appSchema;
         this.geometryParams = geometryParams;
         this.useIntegerFids = useIntegerFids;
         this.allowedCycleDepth = allowedCycleDepth;
         this.maxComplexityIndex = DEFAULT_COMPLEXITY_INDEX * ( allowedCycleDepth + 1 );
         this.referenceData = referenceData;
-        this.considerPropertiesOfReferenceData = considerPropertiesOfReferenceData;
+        this.useRefDataProps = useRefDataProps;
 
         List<FeatureType> ftList = appSchema.getFeatureTypes( null, false, false );
         List<FeatureType> blackList = new ArrayList<FeatureType>();
@@ -869,7 +868,7 @@ public class AppSchemaMapper {
     }
 
     private boolean referenceDataHasProperty( CycleAnalyser cycleAnalyser ) {
-        if ( referenceData == null || !considerPropertiesOfReferenceData )
+        if ( referenceData == null || !useRefDataProps )
             return true;
         List<QName> xpath = cycleAnalyser.getPath();
         QName featureTypeName = cycleAnalyser.getFeatureTypeName();

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceData.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceData.java
@@ -3,10 +3,10 @@ package org.deegree.feature.persistence.sql.mapper;
 import org.deegree.commons.tom.ElementNode;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.gml.property.Property;
+import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.feature.Feature;
 import org.deegree.feature.FeatureCollection;
-import org.deegree.feature.types.FeatureType;
 import org.deegree.gml.GMLInputFactory;
 import org.deegree.gml.GMLStreamReader;
 import org.deegree.gml.GMLVersion;
@@ -20,6 +20,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.deegree.commons.xml.CommonNamespaces.XSINS;
+import static org.deegree.commons.xml.CommonNamespaces.XSI_PREFIX;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -45,6 +48,18 @@ public class GmlReferenceData implements ReferenceData {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isPropertyNilled( QName featureTypeName, List<QName> xpath ) {
+        List<Feature> featuresOfType = this.features.get( featureTypeName );
+        if ( featuresOfType != null && !featuresOfType.isEmpty() ) {
+            for ( Feature feature : featuresOfType ) {
+                if ( !hasNilledPropertyOrIsMissing( feature, xpath ) )
+                    return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -89,6 +104,43 @@ public class GmlReferenceData implements ReferenceData {
             }
             return false;
         }
+    }
+
+    private boolean hasNilledPropertyOrIsMissing( Feature feature, List<QName> xpath ) {
+        if ( xpath.isEmpty() ) {
+            return true;
+        }
+        Iterator<QName> iterator = xpath.iterator();
+        QName firstProperty = iterator.next();
+        List<Property> properties = feature.getProperties( firstProperty );
+        return hasNilledPropertyOrIsMissing( iterator, properties );
+    }
+
+    private <T extends ElementNode> boolean hasNilledPropertyOrIsMissing( Iterator<QName> iterator,
+                                                                          List<T> properties ) {
+        if ( iterator.hasNext() ) {
+            QName next = iterator.next();
+            for ( ElementNode property : properties ) {
+                List<ElementNode> subProperties = getChildsByName( property, next );
+                if ( hasNilledPropertyOrIsMissing( iterator, subProperties ) )
+                    return true;
+            }
+        } else if ( !properties.isEmpty() ) {
+            for ( ElementNode property : properties ) {
+                if ( !isNilTrue( property ) )
+                    return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isNilTrue( ElementNode property ) {
+        Map<QName, PrimitiveValue> attributes = property.getAttributes();
+        PrimitiveValue nil = attributes.get( new QName( XSINS, "nil", XSI_PREFIX ) );
+        if ( nil == null )
+            return false;
+        return Boolean.parseBoolean( nil.getAsText() );
     }
 
     private boolean hasMoreThanOne( Feature feature, List<QName> xpath ) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceData.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceData.java
@@ -36,6 +36,18 @@ public class GmlReferenceData implements ReferenceData {
     }
 
     @Override
+    public boolean hasProperty( QName featureTypeName, List<QName> xpath ) {
+        List<Feature> featuresOfType = this.features.get( featureTypeName );
+        if ( featuresOfType != null && !featuresOfType.isEmpty() ) {
+            for ( Feature feature : featuresOfType ) {
+                if ( hasProperty( feature, xpath ) )
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean hasZeroOrOneProperty( QName featureTypeName, List<QName> xpath ) {
         List<Feature> featuresOfType = this.features.get( featureTypeName );
         if ( featuresOfType != null && !featuresOfType.isEmpty() ) {
@@ -51,6 +63,32 @@ public class GmlReferenceData implements ReferenceData {
     @Override
     public boolean shouldFeatureTypeMapped( QName featureTypeName ) {
         return features.containsKey( featureTypeName );
+    }
+
+    private boolean hasProperty( Feature feature, List<QName> xpath ) {
+        if ( xpath.isEmpty() )
+            return true;
+        Iterator<QName> iterator = xpath.iterator();
+        QName firstProperty = iterator.next();
+        List<Property> properties = feature.getProperties( firstProperty );
+        return hasProperty( iterator, properties );
+    }
+
+    private <T extends ElementNode> boolean hasProperty( Iterator<QName> iterator, List<T> properties ) {
+        if ( !iterator.hasNext() ) {
+            if ( properties.size() >= 1 )
+                return true;
+            else
+                return false;
+        } else {
+            QName next = iterator.next();
+            for ( ElementNode property : properties ) {
+                List<ElementNode> subProperties = getChildsByName( property, next );
+                if ( hasProperty( iterator, subProperties ) )
+                    return true;
+            }
+            return false;
+        }
     }
 
     private boolean hasMoreThanOne( Feature feature, List<QName> xpath ) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/ReferenceData.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/ReferenceData.java
@@ -22,6 +22,15 @@ public interface ReferenceData {
      *                 the name of the feature type, never <code>null</code>
      * @param xpath
      *                 the steps describing the path to the feature, may be empty. but never <code>null</code>
+     * @return <code>true</code> if the property identified by the path occurs at least one time has AND is nilled and contains no value, <code>false</code> otherwise
+     */
+    boolean isPropertyNilled( QName featureTypeName, List<QName> xpath );
+
+    /**
+     * @param featureTypeName
+     *                 the name of the feature type, never <code>null</code>
+     * @param xpath
+     *                 the steps describing the path to the feature, may be empty. but never <code>null</code>
      * @return <code>true</code> if the property identified by the path occurs one or zero times, <code>false</code> otherwise
      */
     boolean hasZeroOrOneProperty( QName featureTypeName, List<QName> xpath );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/ReferenceData.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/ReferenceData.java
@@ -13,6 +13,15 @@ public interface ReferenceData {
      *                 the name of the feature type, never <code>null</code>
      * @param xpath
      *                 the steps describing the path to the feature, may be empty. but never <code>null</code>
+     * @return <code>true</code> if the property identified by the path occurs at least one time, <code>false</code> otherwise
+     */
+    boolean hasProperty( QName featureTypeName, List<QName> xpath );
+
+    /**
+     * @param featureTypeName
+     *                 the name of the feature type, never <code>null</code>
+     * @param xpath
+     *                 the steps describing the path to the feature, may be empty. but never <code>null</code>
      * @return <code>true</code> if the property identified by the path occurs one or zero times, <code>false</code> otherwise
      */
     boolean hasZeroOrOneProperty( QName featureTypeName, List<QName> xpath );
@@ -23,5 +32,4 @@ public interface ReferenceData {
      * @return <code>true</code> if the feature type with this name should be mapped, <code>false</code> otherwise
      */
     boolean shouldFeatureTypeMapped( QName featureTypeName );
-
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapperTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapperTest.java
@@ -11,6 +11,7 @@ import org.deegree.feature.persistence.sql.rules.Mapping;
 import org.deegree.feature.persistence.sql.rules.PrimitiveMapping;
 import org.deegree.feature.types.AppSchema;
 import org.deegree.gml.schema.GMLAppSchemaReader;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,7 +31,7 @@ import static org.deegree.feature.types.property.GeometryPropertyType.Coordinate
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -471,7 +472,7 @@ public class AppSchemaMapperTest {
 
         CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
         GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
-        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, null );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, null, false );
 
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -502,7 +503,7 @@ public class AppSchemaMapperTest {
 
         CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
         GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
-        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData, false );
 
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -543,7 +544,7 @@ public class AppSchemaMapperTest {
 
         CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
         GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
-        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData, false );
 
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -590,7 +591,7 @@ public class AppSchemaMapperTest {
 
         CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
         GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
-        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData, false );
 
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -636,7 +637,7 @@ public class AppSchemaMapperTest {
 
         CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
         GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
-        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData, false );
 
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -684,7 +685,7 @@ public class AppSchemaMapperTest {
 
         CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
         GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
-        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData, false );
 
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -705,6 +706,37 @@ public class AppSchemaMapperTest {
         assertThat( getPrimitive( mappingsA, "prop_A1" ).getJoinedTable(), is( notNullValue() ) );
         assertThat( getPrimitive( mappingsA, "prop_A2" ).getJoinedTable(), is( nullValue() ) );
         assertThat( getPrimitive( mappingsA, "prop_A3" ).getJoinedTable(), is( nullValue() ) );
+    }
+
+    @Test
+    public void testWithReferenceDataAndConsiderProperties()
+                    throws Exception {
+        GMLAppSchemaReader xsdDecoder = new GMLAppSchemaReader( null, null, schemaForSampleValues );
+        AppSchema appSchema = xsdDecoder.extractAppSchema();
+
+        QName featureTypeName = new QName( "http://test.de/schema", "FeatureA", "te" );
+        ReferenceData referenceData = mock( ReferenceData.class );
+        when( referenceData.shouldFeatureTypeMapped( featureTypeName ) ).thenReturn( true );
+        QName propA1 = new QName( "http://test.de/schema", "prop_A1", "te" );
+        when( referenceData.hasProperty( featureTypeName, Collections.singletonList( propA1 ) ) ).thenReturn( false );
+        QName propA3 = new QName( "http://test.de/schema", "prop_A3", "te" );
+        when( referenceData.hasProperty( featureTypeName, Collections.singletonList( propA3 ) ) ).thenReturn( false );
+
+        CRSRef storageCrs = CRSManager.getCRSRef( "EPSG:4326" );
+        GeometryStorageParams geometryParams = new GeometryStorageParams( storageCrs, "0", DIM_2 );
+        AppSchemaMapper mapper = new AppSchemaMapper( appSchema, false, true, geometryParams, 63, true, true, 0, referenceData, true );
+
+        MappedAppSchema mappedSchema = mapper.getMappedSchema();
+
+        Map<QName, FeatureTypeMapping> ftMappings = mappedSchema.getFtMappings();
+        assertThat( ftMappings.size(), is( 1 ) );
+
+        FeatureTypeMapping featureA = mappedSchema.getFtMapping( FEATURE_A );
+        List<Mapping> mappings = featureA.getMappings();
+        assertThat( mappings.size(), is( 3 ) );
+        assertThat( getPrimitive( mappings, "prop_A1" ), is( notNullValue() ) );
+        assertThat( getPrimitive( mappings, "prop_A2" ), is( notNullValue() ) );
+        assertThat( getPrimitive( mappings, "prop_A3" ), is( nullValue() ) );
     }
 
     private CompoundMapping getFeatureC( List<Mapping> mappings ) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceDataTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceDataTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -199,4 +199,30 @@ public class GmlReferenceDataTest {
         assertThat( hasMaxOnePosSpec, is( true ) );
     }
 
+    @Test
+    public void test_Inspire_hasProperty()
+                    throws Exception {
+        URL resource = getClass().getResource( "data/Inspire-Adress.xml" );
+        GmlReferenceData gmlReferenceData = new GmlReferenceData( resource );
+
+        QName AdressFeatureTypeName = new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "Address", "ad" );
+        QName inspireId = new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "inspireId", "ad" );
+
+        List<QName> posSpec = new ArrayList<>();
+        posSpec.add( inspireId );
+        posSpec.add( new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "Identifier", "ad" ) );
+        posSpec.add( new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "localId", "ad" ) );
+
+        boolean hasProperty = gmlReferenceData.hasProperty( AdressFeatureTypeName,
+                                                            Collections.singletonList( inspireId ) );
+        assertThat( hasProperty, is( true ) );
+
+        boolean hasPropertyPosSpec = gmlReferenceData.hasZeroOrOneProperty( AdressFeatureTypeName, posSpec );
+        assertThat( hasPropertyPosSpec, is( true ) );
+
+        QName unknown = new QName( "http://test.de/schema", "unknown", "te" );
+        boolean hasPropertyUnknown = gmlReferenceData.hasProperty( AdressFeatureTypeName,
+                                                                   Collections.singletonList( unknown ) );
+        assertThat( hasPropertyUnknown, is( false ) );
+    }
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceDataTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceDataTest.java
@@ -210,8 +210,8 @@ public class GmlReferenceDataTest {
 
         List<QName> posSpec = new ArrayList<>();
         posSpec.add( inspireId );
-        posSpec.add( new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "Identifier", "ad" ) );
-        posSpec.add( new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "localId", "ad" ) );
+        posSpec.add( new QName( "http://inspire.ec.europa.eu/schemas/base/3.3", "Identifier", "ad" ) );
+        posSpec.add( new QName( "http://inspire.ec.europa.eu/schemas/base/3.3", "localId", "ad" ) );
 
         boolean hasProperty = gmlReferenceData.hasProperty( AdressFeatureTypeName,
                                                             Collections.singletonList( inspireId ) );
@@ -225,4 +225,32 @@ public class GmlReferenceDataTest {
                                                                    Collections.singletonList( unknown ) );
         assertThat( hasPropertyUnknown, is( false ) );
     }
+
+    @Test
+    public void test_Inspire_isPropertyNilled()
+                    throws Exception {
+        URL resource = getClass().getResource( "data/Inspire-Adress.xml" );
+        GmlReferenceData gmlReferenceData = new GmlReferenceData( resource );
+
+        QName adressFeatureTypeName = new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "Address", "ad" );
+        QName inspireId = new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "inspireId", "ad" );
+
+        List<QName> versionId = new ArrayList<>();
+        versionId.add( inspireId );
+        versionId.add( new QName( "http://inspire.ec.europa.eu/schemas/base/3.3", "Identifier", "ad" ) );
+        versionId.add( new QName( "http://inspire.ec.europa.eu/schemas/base/3.3", "versionId", "ad" ) );
+
+        boolean propertyIsNilled = gmlReferenceData.isPropertyNilled( adressFeatureTypeName,
+                                                                      Collections.singletonList( inspireId ) );
+        assertThat( propertyIsNilled, is( false ) );
+
+        boolean propertyIsNilledVersionId = gmlReferenceData.isPropertyNilled( adressFeatureTypeName, versionId );
+        assertThat( propertyIsNilledVersionId, is( true ) );
+
+        QName status = new QName( "http://inspire.ec.europa.eu/schemas/ad/4.0", "status", "ad" );
+        boolean propertyIsNilledStatus = gmlReferenceData.isPropertyNilled( adressFeatureTypeName,
+                                                                            Collections.singletonList( status ) );
+        assertThat( propertyIsNilledStatus, is( true ) );
+    }
+
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/resources/org/deegree/feature/persistence/sql/mapper/schemaWithNilValues.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/resources/org/deegree/feature/persistence/sql/mapper/schemaWithNilValues.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:te="http://test.de/schema"
+        xmlns:gml="http://www.opengis.net/gml/3.2" elementFormDefault="qualified"
+        targetNamespace="http://test.de/schema" version="4.0">
+
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+
+  <element name="FeatureA" substitutionGroup="gml:AbstractFeature" type="te:FeatureAType"/>
+  <complexType name="FeatureAType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="prop_A1" type="string" maxOccurs="unbounded"/>
+          <element name="prop_A2" type="int"/>
+          <element name="prop_A3" minOccurs="0" maxOccurs="unbounded" nillable="true">
+            <complexType>
+              <simpleContent>
+                <extension base="int">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="complex_A4" maxOccurs="unbounded" nillable="true">
+            <complexType>
+              <sequence>
+                <element name="prop_A4_1" type="string" maxOccurs="unbounded" nillable="true"/>
+                <element name="prop_A4_2" type="int" nillable="true"/>
+                <element name="prop_A4_3" type="int" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>
+

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
@@ -48,6 +48,7 @@ options:
  -cycledepth=INT, positive integer value to specify the depth of cycles, default=0
  -listOfPropertiesWithPrimitiveHref=<path/to/file>, not set by default
  -referenceData=<path/to/file> (GML Feature collection containing reference features. The generated config is simplified to map this feature collection.)
+ - useRefDataProps={true|false}, default: false (true if mapping should be created only for properties defined in referenceData)
 
 The option listOfPropertiesWithPrimitiveHref references a file listing properties which are written with primitive instead of feature mappings (see deegree-webservices documentation and README of this tool for further information):
 ---------- begin file ----------
@@ -152,6 +153,13 @@ Example content of the referenced file:
   </gml:featureMember>
 </gml:FeatureCollection>
 ----
+
+==== Usage of option useRefDataProps
+
+The option useRefDataProps must be used with the option referenceData and results in a more reduced mapping:
+
+ * Mapping of optional properties not in the referenceData is omitted.
+ * Mapping of properties with xsi:nil="true" in the referenceData is reduced to the mapping of @xsi:nil and @nilReason.
 
 Using the GmlLoader CLI:
 

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
@@ -8,36 +8,18 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 2.1 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package org.deegree.tools.featurestoresql.config;
-
-import static org.deegree.feature.types.property.GeometryPropertyType.CoordinateDimension.DIM_2;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import java.io.BufferedWriter;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-
-import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
 
 import org.deegree.commons.xml.stax.IndentingXMLStreamWriter;
 import org.deegree.cs.persistence.CRSManager;
@@ -54,9 +36,26 @@ import org.deegree.sqldialect.postgis.PostGISDialect;
 import org.slf4j.Logger;
 import org.springframework.batch.item.ItemWriter;
 
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import static org.deegree.feature.types.property.GeometryPropertyType.CoordinateDimension.DIM_2;
+import static org.slf4j.LoggerFactory.getLogger;
+
 /**
  * Item writer creating FeatureStore config file.
- * 
+ *
  * @author Juergen Weichand
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
  */
@@ -72,7 +71,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
 
     @Override
     public void write( List<? extends AppSchema> appSchemas )
-                            throws Exception {
+                    throws Exception {
         if ( appSchemas.isEmpty() )
             return;
 
@@ -85,11 +84,12 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
                                                       loadParameter.isRelationalMapping(), geometryParams,
                                                       sqlDialect.getMaxColumnNameLength(), true,
                                                       loadParameter.isUseIntegerFids(), loadParameter.getDepth(),
-                                                      loadParameter.getReferenceData() );
+                                                      loadParameter.getReferenceData(),
+                                                      loadParameter.isConsiderPropertiesOfReferenceData() );
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
         SQLFeatureStoreConfigWriter configWriter = new SQLFeatureStoreConfigWriter(
-                                                                                    mappedSchema,
-                                                                                    loadParameter.getPropertiesWithPrimitiveHref() );
+                        mappedSchema,
+                        loadParameter.getPropertiesWithPrimitiveHref() );
         String uriPathToSchema = new URI( loadParameter.getSchemaUrl() ).getPath();
         String schemaFileName = uriPathToSchema.substring( uriPathToSchema.lastIndexOf( '/' ) + 1 );
         String fileName = schemaFileName.replaceFirst( "[.][^.]+$", "" );
@@ -106,12 +106,12 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
     }
 
     private void writeSqlDdlFile( MappedAppSchema mappedSchema, String fileName, SQLDialect sqlDialect )
-                            throws IOException {
+                    throws IOException {
         String[] createStmts = DDLCreator.newInstance( mappedSchema, sqlDialect ).getDDL();
         String sqlOutputFilename = fileName + ".sql";
         Path pathToSqlOutputFile = Paths.get( sqlOutputFilename );
         LOG.info( "Writing SQL DDL into file: " + pathToSqlOutputFile.toUri() );
-        try (BufferedWriter writer = Files.newBufferedWriter( pathToSqlOutputFile )) {
+        try ( BufferedWriter writer = Files.newBufferedWriter( pathToSqlOutputFile ) ) {
             for ( String sqlStatement : createStmts ) {
                 writer.write( sqlStatement + ";" + System.getProperty( "line.separator" ) );
             }
@@ -119,7 +119,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
     }
 
     private void writeXmlConfigFile( SQLFeatureStoreConfigWriter configWriter, String fileName )
-                            throws XMLStreamException, IOException {
+                    throws XMLStreamException, IOException {
         List<String> configUrls = Collections.singletonList( loadParameter.getSchemaUrl() );
         String xmlOutputFilename = fileName + ".xml";
         Path pathToXmlOutputFile = Paths.get( xmlOutputFilename );

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
@@ -85,7 +85,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
                                                       sqlDialect.getMaxColumnNameLength(), true,
                                                       loadParameter.isUseIntegerFids(), loadParameter.getDepth(),
                                                       loadParameter.getReferenceData(),
-                                                      loadParameter.isConsiderPropertiesOfReferenceData() );
+                                                      loadParameter.isUseRefDataProps() );
         MappedAppSchema mappedSchema = mapper.getMappedSchema();
         SQLFeatureStoreConfigWriter configWriter = new SQLFeatureStoreConfigWriter(
                         mappedSchema,

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameter.java
@@ -52,7 +52,7 @@ public class LoadParameter {
 
     private int depth;
 
-    private boolean considerPropertiesOfReferenceData;
+    private boolean useRefDataProps;
 
     LoadParameter() {
     }
@@ -129,11 +129,11 @@ public class LoadParameter {
         return depth;
     }
 
-    public boolean isConsiderPropertiesOfReferenceData() {
-        return considerPropertiesOfReferenceData;
+    public boolean isUseRefDataProps() {
+        return useRefDataProps;
     }
 
-    public void setConsiderPropertiesOfReferenceData( boolean considerPropertiesOfReferenceData ) {
-        this.considerPropertiesOfReferenceData = considerPropertiesOfReferenceData;
+    public void setUseRefDataProps( boolean useRefDataProps ) {
+        this.useRefDataProps = useRefDataProps;
     }
 }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameter.java
@@ -52,6 +52,8 @@ public class LoadParameter {
 
     private int depth;
 
+    private boolean considerPropertiesOfReferenceData;
+
     LoadParameter() {
     }
 
@@ -127,4 +129,11 @@ public class LoadParameter {
         return depth;
     }
 
+    public boolean isConsiderPropertiesOfReferenceData() {
+        return considerPropertiesOfReferenceData;
+    }
+
+    public void setConsiderPropertiesOfReferenceData( boolean considerPropertiesOfReferenceData ) {
+        this.considerPropertiesOfReferenceData = considerPropertiesOfReferenceData;
+    }
 }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameterBuilder.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameterBuilder.java
@@ -151,16 +151,16 @@ public class LoadParameterBuilder {
         return this;
     }
 
-    public LoadParameterBuilder setConsiderPropertiesOfReferenceData( String considerPropertiesOfReferenceData ) {
-        if ( considerPropertiesOfReferenceData != null && !considerPropertiesOfReferenceData.isEmpty() ) {
-            if ( !"true".equalsIgnoreCase( considerPropertiesOfReferenceData ) && !"false".equalsIgnoreCase(
-                            considerPropertiesOfReferenceData ) ) {
-                throw new IllegalArgumentException( "Invalid value of parameter considerPropertiesOfReferenceData: "
-                                                    + considerPropertiesOfReferenceData
+    public LoadParameterBuilder setuseRefDataProps( String useRefDataProps ) {
+        if ( useRefDataProps != null && !useRefDataProps.isEmpty() ) {
+            if ( !"true".equalsIgnoreCase( useRefDataProps ) && !"false".equalsIgnoreCase(
+                            useRefDataProps ) ) {
+                throw new IllegalArgumentException( "Invalid value of parameter useRefDataProps: "
+                                                    + useRefDataProps
                                                     + ". Must be true or false" );
             }
-            loadParameter.setConsiderPropertiesOfReferenceData(
-                            Boolean.parseBoolean( considerPropertiesOfReferenceData ) );
+            loadParameter.setUseRefDataProps(
+                            Boolean.parseBoolean( useRefDataProps ) );
         }
         return this;
     }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameterBuilder.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameterBuilder.java
@@ -57,8 +57,8 @@ public class LoadParameterBuilder {
     }
 
     public LoadParameterBuilder setSchemaUrl( String schemaUrl ) {
-        if (schemaUrl == null || schemaUrl.isEmpty())
-            throw new IllegalArgumentException("Value for option 'schemaUrl' must not be null. Option is mandatory.");
+        if ( schemaUrl == null || schemaUrl.isEmpty() )
+            throw new IllegalArgumentException( "Value for option 'schemaUrl' must not be null. Option is mandatory." );
         loadParameter.setSchemaUrl( schemaUrl );
         return this;
     }
@@ -123,10 +123,12 @@ public class LoadParameterBuilder {
         return this;
     }
 
-    public LoadParameterBuilder setListOfPropertiesWithPrimitiveHref( String pathToFileWithPropertiesWithPrimitiveHref ) {
+    public LoadParameterBuilder setListOfPropertiesWithPrimitiveHref(
+                    String pathToFileWithPropertiesWithPrimitiveHref ) {
         if ( pathToFileWithPropertiesWithPrimitiveHref != null ) {
             PropertyNameParser propertyNameParser = new PropertyNameParser();
-            List<QName> propertiesWithPrimitiveHref = propertyNameParser.parsePropertiesWithPrimitiveHref( pathToFileWithPropertiesWithPrimitiveHref );
+            List<QName> propertiesWithPrimitiveHref = propertyNameParser.parsePropertiesWithPrimitiveHref(
+                            pathToFileWithPropertiesWithPrimitiveHref );
             loadParameter.setPropertiesWithPrimitiveHref( propertiesWithPrimitiveHref );
         }
         return this;
@@ -145,6 +147,20 @@ public class LoadParameterBuilder {
                 throw new IllegalArgumentException( "Invalid value of parameter referenceData: " + referenceData
                                                     + ". Could not be parsed as GML 3.2." );
             }
+        }
+        return this;
+    }
+
+    public LoadParameterBuilder setConsiderPropertiesOfReferenceData( String considerPropertiesOfReferenceData ) {
+        if ( considerPropertiesOfReferenceData != null && !considerPropertiesOfReferenceData.isEmpty() ) {
+            if ( !"true".equalsIgnoreCase( considerPropertiesOfReferenceData ) && !"false".equalsIgnoreCase(
+                            considerPropertiesOfReferenceData ) ) {
+                throw new IllegalArgumentException( "Invalid value of parameter considerPropertiesOfReferenceData: "
+                                                    + considerPropertiesOfReferenceData
+                                                    + ". Must be true or false" );
+            }
+            loadParameter.setConsiderPropertiesOfReferenceData(
+                            Boolean.parseBoolean( considerPropertiesOfReferenceData ) );
         }
         return this;
     }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorConfiguration.java
@@ -60,13 +60,13 @@ public class SqlFeatureStoreConfigCreatorConfiguration {
                                             @Value("#{jobParameters[cycledepth]}") String depth,
                                             @Value("#{jobParameters[listOfPropertiesWithPrimitiveHref]}") String listOfPropertiesWithPrimitiveHref,
                                             @Value("#{jobParameters[referenceData]}") String referenceData,
-                                            @Value("#{jobParameters[considerPropertiesOfReferenceData]}") String considerPropertiesOfReferenceData ) {
+                                            @Value("#{jobParameters[useRefDataProps]}") String useRefDataProps ) {
         return new LoadParameterBuilder().setSchemaUrl( schemaUrl ).setFormat( format ).setSrid( srid ).setIdType(
                         idtype ).setMappingType( mapping ).setDialect( dialect ).setDepth(
                         depth ).setListOfPropertiesWithPrimitiveHref(
                         listOfPropertiesWithPrimitiveHref ).setReferenceData(
-                        referenceData ).setConsiderPropertiesOfReferenceData(
-                        considerPropertiesOfReferenceData ).build();
+                        referenceData ).setuseRefDataProps(
+                        useRefDataProps ).build();
     }
 
     @StepScope

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorConfiguration.java
@@ -59,11 +59,14 @@ public class SqlFeatureStoreConfigCreatorConfiguration {
                                             @Value("#{jobParameters[dialect]}") String dialect,
                                             @Value("#{jobParameters[cycledepth]}") String depth,
                                             @Value("#{jobParameters[listOfPropertiesWithPrimitiveHref]}") String listOfPropertiesWithPrimitiveHref,
-                                            @Value("#{jobParameters[referenceData]}") String referenceData ) {
+                                            @Value("#{jobParameters[referenceData]}") String referenceData,
+                                            @Value("#{jobParameters[considerPropertiesOfReferenceData]}") String considerPropertiesOfReferenceData ) {
         return new LoadParameterBuilder().setSchemaUrl( schemaUrl ).setFormat( format ).setSrid( srid ).setIdType(
                         idtype ).setMappingType( mapping ).setDialect( dialect ).setDepth(
                         depth ).setListOfPropertiesWithPrimitiveHref(
-                        listOfPropertiesWithPrimitiveHref ).setReferenceData( referenceData ).build();
+                        listOfPropertiesWithPrimitiveHref ).setReferenceData(
+                        referenceData ).setConsiderPropertiesOfReferenceData(
+                        considerPropertiesOfReferenceData ).build();
     }
 
     @StepScope
@@ -80,12 +83,14 @@ public class SqlFeatureStoreConfigCreatorConfiguration {
 
     @Bean
     public Step step( AppSchemaReader appSchemaReader, FeatureStoreConfigWriter featureStoreConfigWriter ) {
-        return stepBuilderFactory.get( "featureStoreConfigLoaderStep" ).<AppSchema, AppSchema> chunk( 1 ).reader( appSchemaReader ).writer( featureStoreConfigWriter ).build();
+        return stepBuilderFactory.get( "featureStoreConfigLoaderStep" ).<AppSchema, AppSchema>chunk( 1 ).reader(
+                        appSchemaReader ).writer( featureStoreConfigWriter ).build();
     }
 
     @Bean
     public Job job( Step step ) {
-        return jobBuilderFactory.get( "featureStoreConfigLoaderJob" ).incrementer( new RunIdIncrementer() ).start( step ).build();
+        return jobBuilderFactory.get( "featureStoreConfigLoaderJob" ).incrementer( new RunIdIncrementer() ).start(
+                        step ).build();
     }
 
 }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorUsagePrinter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorUsagePrinter.java
@@ -43,6 +43,8 @@ public class SqlFeatureStoreConfigCreatorUsagePrinter {
         System.out.println( " -cycledepth=INT, positive integer value to specify the depth of cycles, default=0" );
         System.out.println( " -listOfPropertiesWithPrimitiveHref=<path/to/file>, not set by default" );
         System.out.println( " -referenceData=<path/to/file> (GML Feature collection containing reference features. The generated config is simplified to map this feature collection.)" );
+        System.out.println( " -considerPropertiesOfReferenceData={true|false}, default: false (true if mapping should be created only for properties defined in referenceData)" );
+
         System.out.println();
         System.out.println( "The option listOfPropertiesWithPrimitiveHref references a file listing properties which are written with primitive instead of feature mappings (see deegree-webservices documentation and README of this tool for further information):" );
         System.out.println( "---------- begin file ----------" );

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorUsagePrinter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorUsagePrinter.java
@@ -43,7 +43,7 @@ public class SqlFeatureStoreConfigCreatorUsagePrinter {
         System.out.println( " -cycledepth=INT, positive integer value to specify the depth of cycles, default=0" );
         System.out.println( " -listOfPropertiesWithPrimitiveHref=<path/to/file>, not set by default" );
         System.out.println( " -referenceData=<path/to/file> (GML Feature collection containing reference features. The generated config is simplified to map this feature collection.)" );
-        System.out.println( " -considerPropertiesOfReferenceData={true|false}, default: false (true if mapping should be created only for properties defined in referenceData)" );
+        System.out.println( " -useRefDataProps={true|false}, default: false (true if mapping should be created only for properties defined in referenceData)" );
 
         System.out.println();
         System.out.println( "The option listOfPropertiesWithPrimitiveHref references a file listing properties which are written with primitive instead of feature mappings (see deegree-webservices documentation and README of this tool for further information):" );


### PR DESCRIPTION
This pull requests adds the option useRefDataProps to the SqlFeatureStoreConfigCreator of the GmlTool to reduce the mapping dependent of the referenceData:

 * Mapping of optional properties not in the referenceData are omitted.
 * Mapping of properties with xsi:nil="true" in the referenceData is reduced to the mapping of @xsi:nil and @nilReason.