### PR TITLE
Ensure that tmp files are deleted with enabled buffering in WFS and when a request is closed

### DIFF
--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/utils/HttpResponseBuffer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/utils/HttpResponseBuffer.java
@@ -312,9 +312,12 @@ public class HttpResponseBuffer extends HttpServletResponseWrapper {
             }
         }
         if ( buffer != null ) {
-            buffer.flush();
-            buffer.writeTo( super.getOutputStream() );
-            buffer.reset();
+            try {
+                buffer.flush();
+                buffer.writeTo( super.getOutputStream() );
+            } finally {
+                buffer.reset();
+            }
         }
         super.flushBuffer();
     }


### PR DESCRIPTION
When response buffering is enabled in WFS and a client has requested data by sending a WFS GetFeature request and then the request is closed on the client side, the temporarily created file  `storeXXX.tmp` in the systems tmp directory are not removed. 
This pull requests ensures that these files are deleted in case of sitituations when the request is aborted.