### PR TITLE
Improve curve linearization

### DIFF
--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/CurveLinearizer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/CurveLinearizer.java
@@ -654,18 +654,18 @@ public class CurveLinearizer {
         double angleStep = 2 * Math.acos( 1 - error / radius );
         int numPoints;
         if ( isCircle ) {
-            numPoints = (int) Math.ceil( 2 * Math.PI / angleStep ) + 1;
+            numPoints = (int) Math.ceil( 2 * Math.PI / angleStep ) + 2;
         } else {
             if ( !isClockwise( p0Shifted, p1Shifted, p2Shifted ) ) {
                 if ( endAngle < startAngle ) {
                     endAngle += 2 * Math.PI;
                 }
-                numPoints = (int) Math.ceil( ( endAngle - startAngle ) / angleStep ) + 1;
+                numPoints = (int) Math.ceil( ( endAngle - startAngle ) / angleStep ) + 2;
             } else {
                 if ( startAngle < endAngle ) {
                     startAngle += 2 * Math.PI;
                 }
-                numPoints = (int) Math.ceil( ( startAngle - endAngle ) / angleStep ) + 1;
+                numPoints = (int) Math.ceil( ( startAngle - endAngle ) / angleStep ) + 2;
             }
         }
         return numPoints;

--- a/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization/CurveLinearizerTest.java
+++ b/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization/CurveLinearizerTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.io.WKTReader;
+import org.deegree.geometry.io.WKTWriter;
 import org.deegree.geometry.points.Points;
 import org.deegree.geometry.primitive.Curve;
 import org.deegree.geometry.primitive.Point;
@@ -57,6 +58,8 @@ import org.deegree.geometry.standard.curvesegments.DefaultCubicSpline;
 import org.deegree.geometry.standard.points.PointsList;
 import org.deegree.geometry.standard.primitive.DefaultCurve;
 import org.deegree.geometry.standard.primitive.DefaultPoint;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -331,6 +334,23 @@ public class CurveLinearizerTest {
         Assert.assertEquals( p0[0], positions.get( 2 ).get0(), 1.0E-9 );
         Assert.assertEquals( p0[1], positions.get( 2 ).get1(), 1.0E-9 );
     }
+
+	/**
+	 * Tests the linearization of a circle with collinear control points (on a line).
+	 */
+	@Test
+	public void testLinearize() {
+		List<Point> pointList = new ArrayList<>();
+		pointList.add( geomFac.createPoint( null, 568088.299, 5932202.548, null ) );
+		pointList.add( geomFac.createPoint( null, 568080.921, 5932196.541, null ) );
+		pointList.add( geomFac.createPoint( null, 568074.760, 5932189.290, null ) );
+		Points points = geomFac.createPoints( pointList );
+		Curve curve = geomFac.createCurve( null, null, geomFac.createArcString( points ) );
+
+		Curve linearizedCurve = linearizer.linearize( curve, new MaxErrorCriterion( 1.0, 500 ) );
+		Points controlPoints = linearizedCurve.getControlPoints();
+		Assert.assertTrue( controlPoints.size() > 2 );
+	}
 
     /**
      * creates a circle or a an arc and outputs them to wkt.


### PR DESCRIPTION
This pull request ensure that at least three control points are created when curve linearization is executed.

Otherwise, problems can occur when linearizing an inner and outer ring.
With the current implementation it is possible that the the inner ring cuts the outer ring after linearization.
This pull request shall prevent such cases.