### PR TITLE
Allow to specify custom dialect provider on a data source level

### DIFF
--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/3.4.0/datasource.xsd
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/3.4.0/datasource.xsd
@@ -18,8 +18,8 @@
             <sequence>
               <element name="Argument" minOccurs="0" maxOccurs="unbounded">
                 <complexType>
-                  <attribute name="javaClass" use="required" />                
-                  <attribute name="value" use="required" />                  
+                  <attribute name="javaClass" use="required" />
+                  <attribute name="value" use="required" />
                 </complexType>
               </element>
             </sequence>
@@ -31,7 +31,12 @@
         <element name="Property" minOccurs="0" maxOccurs="unbounded">
           <complexType>
             <attribute name="name" use="required" />
-            <attribute name="value" use="required" />            
+            <attribute name="value" use="required" />
+          </complexType>
+        </element>
+        <element name="DialectProvider" minOccurs="0" maxOccurs="1">
+          <complexType>
+            <attribute name="javaClass" use="required" />
           </complexType>
         </element>
       </sequence>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -255,6 +255,8 @@ respected.
 object
 
 |Property |0..n |Complex |Configuration of javax.sql.DataSource object
+
+|DialectProvider |0..1 |Complex |Configuration of the dialect provider
 |===
 
 Technically, the _DataSource_ element defines how the
@@ -355,6 +357,17 @@ For completeness, here's the list of options of element _Property_:
 |Option |Cardinality |Value |Description
 |name |1..1 |String |Name of the property
 |value |1..1 |String |Property value
+|===
+
+For cases where deegree cannot automatically determine the dialect provider to use or
+a special dialect provider has to be used, a manual configuration can be done with 
+the element _DialectProvider_:
+
+[width="77%",cols="17%,25%,17%,41%",options="header",]
+|===
+|Option |Cardinality |Value |Description
+|javaClass |1..1 |String |Java class of the dialect provider (e.g.
+org.deegree.sqldialect.postgis.PostGISDialectProvider)
 |===
 
 ==== Legacy configuration format


### PR DESCRIPTION
This enhancement allows to either override the automatic SQL dialect provider selection, for customized dialects, or to specify the correct dialect if deegree cannot determine the correct provider based on the JDBC URL.