### PR TITLE
Add an extension to the oracle dialect that works analog to the FeatureInspector

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
@@ -1,9 +1,11 @@
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
- Copyright (C) 2001-2014 by:
+ Copyright (C) 2001-2022 by:
  - Department of Geography, University of Bonn -
  and
  - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
 
  This library is free software; you can redistribute it and/or modify it under
  the terms of the GNU Lesser General Public License as published by the Free
@@ -30,6 +32,11 @@
  Germany
  http://www.geographie.uni-bonn.de/deegree/
 
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
 package org.deegree.sqldialect.oracle;
@@ -40,16 +47,17 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import oracle.jdbc.OracleConnection;
-import oracle.sql.STRUCT;
-
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryTransformer;
 import org.deegree.geometry.utils.GeometryParticleConverter;
 import org.deegree.sqldialect.oracle.sdo.SDOGeometryConverter;
+import org.deegree.sqldialect.oracle.sdo.SDOInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import oracle.jdbc.OracleConnection;
+import oracle.sql.STRUCT;
 
 /**
  * {@link GeometryParticleConverter} for Oracle Spatial.
@@ -70,6 +78,8 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
     private final String srid;
 
     private int isrid;
+
+    private SDOInspector sdoInspector;
 
     /**
      * Creates a new {@link OracleGeometryConverter} instance.
@@ -115,7 +125,7 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
             return null;
         }
         try {
-            return new SDOGeometryConverter().toGeometry( (STRUCT) sqlValue, crs );
+            return new SDOGeometryConverter( sdoInspector ).toGeometry( (STRUCT) sqlValue, crs );
         } catch ( Throwable t ) {
             throw new IllegalArgumentException(t);
         }
@@ -137,7 +147,7 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
                 // compatible = compatible.getConvexHull();
                 // }
                 OracleConnection ocon = getOracleConnection( stmt.getConnection() );
-                Object struct = new SDOGeometryConverter().fromGeometry( ocon, isrid, compatible, true );
+                Object struct = new SDOGeometryConverter(sdoInspector).fromGeometry( ocon, isrid, compatible, true );
                 stmt.setObject( paramIndex, struct );
             }
         } catch ( Throwable t ) {
@@ -187,5 +197,9 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
     @Override
     public ICRS getCrs() {
         return crs;
+    }
+
+    public void setSdoInsepctor( SDOInspector sdoInspector ) {
+        this.sdoInspector = sdoInspector;
     }
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/OracleObjectTools.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/OracleObjectTools.java
@@ -117,11 +117,11 @@ public class OracleObjectTools {
         return fromDoubleArray( struct.getOracleAttributes(), defaultValue );
     }
 
-    protected static STRUCT toSDOGeometry( GeomHolder h, OracleConnection conn ) 
+    protected static STRUCT toSDOGeometry( SDOGeometry h, OracleConnection conn ) 
                             throws SQLException {
         return toSDOGeometry( h.gtype, h.srid, h.elem_info, h.ordinates, conn);
     }
-    
+
     /**
      * Convert SDO_Geometry informations into Oracle JDBC STRUCT element
      */

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometry.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometry.java
@@ -1,0 +1,67 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2022 by:
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.sqldialect.oracle.sdo;
+
+/**
+ * Holder for a native representation of Oracle Geometries in plain Java types
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ */
+public class SDOGeometry {
+    public int gtype;
+
+    public int srid;
+
+    public double point[];
+
+    public int[] elem_info;
+
+    public double[] ordinates;
+
+    public SDOGeometry( int gtype, int srid, double point[], int[] elem_info, double[] ordinates ) {
+        this.gtype = gtype;
+        this.srid = srid;
+        this.point = point;
+        this.elem_info = elem_info;
+        this.ordinates = ordinates;
+    }
+
+    public SDOGeometry() {
+
+    }
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
@@ -96,8 +96,15 @@ import org.slf4j.LoggerFactory;
 public class SDOGeometryConverter {
     static final Logger LOG = LoggerFactory.getLogger( SDOGeometryConverter.class );
 
-    public SDOGeometryConverter() {
+    private final SDOInspector inspector;
 
+    public SDOGeometryConverter() {
+        this.inspector = null;
+    }
+
+    public SDOGeometryConverter(SDOInspector inspector)
+    {
+        this.inspector = inspector;
     }
 
     private GeometryFactory _gf = new GeometryFactory();
@@ -794,7 +801,7 @@ public class SDOGeometryConverter {
             int gtyp = ( 1000 * dim ) + gtypett;
             LOG.trace( "fromGeometry: MDSYS.SDO_GEOMETRY( {}, {}, NULL, MDSYS.SDO_ELEM_INFO_ARRAY{}, MDSYS.SDO_ORDINATE_ARRAY{} )",
                        gtyp, srid, elemInfo, ordinates );
-            return SDOGeometry( gtyp, srid, null, elemInfo, ordinates );
+            return new SDOGeometry( gtyp, srid, null, elemInfo, ordinates );
         }
 
         // no parse able geometry found

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOInspector.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOInspector.java
@@ -1,0 +1,64 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2022 by:
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.sqldialect.oracle.sdo;
+
+/**
+ * Inspector interface to allow inspection of Geometries
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ */
+public interface SDOInspector {
+
+    /**
+     * Inspect SDO before conversion to oracle object
+     * 
+     * @param holder
+     */
+    default void fromGeometry( SDOGeometry geom ) {
+        // do nothing by default
+    }
+
+    /**
+     * Inspect SDO before conversion to geometry object
+     * 
+     * @param holder
+     */
+    default void toGeometry( SDOGeometry geom ) {
+        // do nothing by default
+    }
+}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/test/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverterExampleTests.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/test/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverterExampleTests.java
@@ -103,14 +103,14 @@ public class SDOGeometryConverterExampleTests {
     @Test
     public void testConvertSdoGeometryAndBack()
                             throws Exception {
-        GeomHolder sdo = loadFromFile( sdoFile );
+        SDOGeometry sdo = loadFromFile( sdoFile );
         // inspector.reset();
         Geometry geom = readGMLGeometry( gmlFile );
 
         // Test SDO -> Geom -> SDO
         // inspector.reset();
         Geometry sdoGeom = converter.toGeometry( sdo, null );
-        GeomHolder sdoGeomSdo = converter.fromGeometry( sdo.srid, sdoGeom, false );
+        SDOGeometry sdoGeomSdo = converter.fromGeometry( sdo.srid, sdoGeom, false );
 
         String sdoGeomString = writeGMLGeometry( sdoGeom );
         String sdoString = toString( sdo );
@@ -122,7 +122,7 @@ public class SDOGeometryConverterExampleTests {
         }
 
         // Test Geom -> SDO -> Geom
-        GeomHolder geomSdo = converter.fromGeometry( sdo.srid, geom, false );
+        SDOGeometry geomSdo = converter.fromGeometry( sdo.srid, geom, false );
         // inspector.reset();
         Geometry geomSdoGeom = converter.toGeometry( geomSdo, null );
 
@@ -173,7 +173,7 @@ public class SDOGeometryConverterExampleTests {
         return replaceGmlIDs( memoryWriter.toString() );
     }
 
-    private GeomHolder loadFromFile( File f )
+    private SDOGeometry loadFromFile( File f )
                             throws IOException {
         @SuppressWarnings("resource")
         String output = new Scanner( f ).useDelimiter( "\\Z" ).next().replaceAll( "[\r\n]+", " " );
@@ -225,12 +225,12 @@ public class SDOGeometryConverterExampleTests {
                     ordinates[i] = lst.get( i );
                 }
             }
-            return new GeomHolder( gtype, srid, point, elem_info, ordinates, null );
+            return new SDOGeometry( gtype, srid, point, elem_info, ordinates );
         }
         return null;
     }
 
-    private String toString( GeomHolder h ) {
+    private String toString( SDOGeometry h ) {
         StringBuilder sb = new StringBuilder();
         sb.append( "MDSYS.SDO_GEOMETRY( " );
         sb.append( h.gtype ).append( ", " );

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/test/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverterTest.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/test/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverterTest.java
@@ -1,7 +1,6 @@
-//$HeadURL$
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
- Copyright (C) 2013 by:
+ Copyright (C) 2013-2022 by:
 
  IDgis bv
 
@@ -805,8 +804,7 @@ public class SDOGeometryConverterTest {
     private void testMultiPolygon( int expectedPolygons, int[] expectedInteriorRings, int gtype, int srid,
                                    int[] elemInfo, double[] ordinates )
                             throws SQLException {
-        Geometry geometry = converter.toGeometry( new SDOGeometryConverter.GeomHolder( gtype, srid, null, elemInfo,
-                                                                                       ordinates, null ), null );
+        Geometry geometry = converter.toGeometry( new SDOGeometry( gtype, srid, null, elemInfo, ordinates ), null );
         assertNotNull( "null geometry", geometry );
         assertTrue( "not a multi polygon", geometry instanceof MultiPolygon );
 
@@ -822,8 +820,7 @@ public class SDOGeometryConverterTest {
 
     private void testPolygon( int expectedInteriorRings, int gtype, int srid, int[] elemInfo, double[] ordinates )
                             throws SQLException {
-        Geometry geometry = converter.toGeometry( new SDOGeometryConverter.GeomHolder( gtype, srid, null, elemInfo,
-                                                                                       ordinates, null ), null );
+        Geometry geometry = converter.toGeometry( new SDOGeometry( gtype, srid, null, elemInfo, ordinates ), null );
         assertNotNull( "null geometry", geometry );
         assertTrue( "not a polygon", geometry instanceof Polygon );
         Polygon polygon = (Polygon) geometry;


### PR DESCRIPTION
This Pull Request contains a new interface `org.deegree.sqldialect.oracle.sdo.SDOInspector` that can be used to interfere before a geometry is written to or after the geometry has been read from the database.
With this `org.deegree.sqldialect.oracle.sdo.SDOInspector`, which works similar as `org.deegree.feature.persistence.FeatureInspector`, it is possible to handle custom geometries and or specialized simplification with an extended dialect.

This PR is logically related to PR #1285 