### PR TITLE
Optimize logging of SQLFeaturestore in initialization phase

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -304,7 +304,7 @@ public class SQLFeatureStore implements FeatureStore {
     @SuppressWarnings("unchecked")
     private CustomParticleConverter<TypedObjectNode> instantiateConverter( CustomConverterJAXB config ) {
         String className = config.getClazz();
-        LOG.info( "Instantiating configured custom particle converter (class=" + className + ")" );
+        LOG.debug( "Instantiating configured custom particle converter (class={})", className );
         try {
             return (CustomParticleConverter<TypedObjectNode>) workspace.getModuleClassLoader().loadClass( className ).newInstance();
         } catch ( Throwable t ) {


### PR DESCRIPTION
Simple change to reduce the amount of logging if an excessive amount of custom converter are used (for ex. in large import jobs).
Also use SLF4J parameter style for easier filtering, as the static log message with placeholder are easier filtered.