### PR TITLE
Enhance FeatureInspector with the context of the transaction, if available

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/FeatureInspector.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/FeatureInspector.java
@@ -1,10 +1,11 @@
-//$HeadURL$
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
- Copyright (C) 2001-2011 by:
+ Copyright (C) 2001-2022 by:
  Department of Geography, University of Bonn
  and
  lat/lon GmbH
+ and
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
 
  This library is free software; you can redistribute it and/or modify it under
  the terms of the GNU Lesser General Public License as published by the Free
@@ -31,6 +32,11 @@
  Germany
  http://www.geographie.uni-bonn.de/deegree/
 
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
 package org.deegree.feature.persistence;
@@ -46,9 +52,7 @@ import org.deegree.geometry.GeometryInspectionException;
  * </p>
  * 
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
- * @author last edited by: $Author$
- * 
- * @version $Revision$, $Date$
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public interface FeatureInspector {
 
@@ -62,4 +66,21 @@ public interface FeatureInspector {
      *             if the inspector rejects the {@link Geometry}
      */
     public Feature inspect( Feature f );
+
+    /**
+     * Invokes the inspection of the given {@link Feature}.
+     * 
+     * @param f
+     *            feature to be inspected, never <code>null</code>
+     * @param transaction
+     *            transaction if feature is inspected in context of a {@link FeatureStoreTransaction}, may be
+     *            <code>null</null>
+     * @return inspected feature, may be a different or modified instance
+     * @throws GeometryInspectionException
+     *             if the inspector rejects the {@link Geometry}
+     */
+    default public Feature inspect( Feature f, FeatureStoreTransaction transaction ) {
+        // default implementation to be compatible to previous inspectors
+        return inspect( f );
+    }
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTransaction.java
@@ -1,10 +1,12 @@
 //$HeadURL$
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
- Copyright (C) 2001-2012 by:
+ Copyright (C) 2001-2022 by:
  - Department of Geography, University of Bonn -
  and
  - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
 
  This library is free software; you can redistribute it and/or modify it under
  the terms of the GNU Lesser General Public License as published by the Free
@@ -30,6 +32,11 @@
  Postfach 1147, 53001 Bonn
  Germany
  http://www.geographie.uni-bonn.de/deegree/
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
 
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
@@ -120,9 +127,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
- * @author last edited by: $Author$
- *
- * @version $Revision$, $Date$
  */
 public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
 
@@ -556,7 +560,7 @@ public class SQLFeatureStoreTransaction implements FeatureStoreTransaction {
         for ( FeatureInspector inspector : inspectors ) {
             for ( Feature f : features ) {
                 // TODO cope with inspectors that return a different instance
-                inspector.inspect( f );
+                inspector.inspect( f, this );
             }
         }
 


### PR DESCRIPTION
This PR extends the FeatureInspector in a backwards compatible way (default interface) to give the feature inspection, if available, more context information.