### PR TITLE
Add GZIP compression support and an extension point for custom FeatureInputStreams to the loader tool

### DIFF
--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -22,6 +22,10 @@
       <name>Lyn Goltz</name>
       <email>goltz@lat-lon.de</email>
     </developer>
+    <developer>
+      <name>Stephan Reichhelm</name>
+      <email>reichhelm@grit.de</email>
+    </developer>
   </developers>
 
   <build>

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/FeatureStreamFactory.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/FeatureStreamFactory.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * deegree-cli-utility
+ * %%
+ * Copyright (C) 2022 grit graphische Informationstechnik Beratungsgesellschaft mbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.tools.featurestoresql.loader;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamReader;
+
+import org.deegree.feature.stream.FeatureInputStream;
+import org.deegree.gml.GMLStreamReader;
+
+/**
+ * Extension point that allows to use custom FeatureInputStreams
+ * 
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ */
+public interface FeatureStreamFactory {
+
+    /**
+     * Check if the root element of the XML stream is applicable
+     * 
+     * @param rootElement
+     *            root element from the document or stream
+     * @return true if this factory can supply a capable FeatureInputStream
+     */
+    public boolean isApplicableToDocumentRoot( QName rootElement );
+
+    public FeatureInputStream createStream( XMLStreamReader xmlStream, GMLStreamReader gmlStream );
+}


### PR DESCRIPTION
This pull request adds support for `gz` files and also adds an extension point that allows custom implementations of `org.deegree.feature.stream.FeatureInputStream` to be used.

With this approach it is now possible to load gml/xml files where several elements (metadata) have to be skipped before the actual data can be processed. 