### PR TITLE
Bump h2 from 1.3.171 to 2.1.210 and fix issue in creation of table LOCKS

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/DefaultLockManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/DefaultLockManager.java
@@ -40,6 +40,7 @@ import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;
 import static org.deegree.commons.tom.datetime.ISO8601Converter.formatDateTime;
 import static org.deegree.commons.utils.JDBCUtils.close;
 import static org.deegree.feature.i18n.Messages.getMessage;
+import static org.h2.engine.Constants.SCHEMA_MAIN;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -119,7 +120,7 @@ public class DefaultLockManager implements LockManager {
         try {
             conn = connection.getConnection();
             DatabaseMetaData dbMetaData = conn.getMetaData();
-            rs = dbMetaData.getTables( null, null, "LOCKS", new String[] { "TABLE" } );
+            rs = dbMetaData.getTables( null, SCHEMA_MAIN, "LOCKS", new String[] { "TABLE" } );
             if ( !rs.next() ) {
                 LOG.debug( "Creating table 'LOCKS'." );
                 stmt = conn.createStatement();
@@ -134,7 +135,7 @@ public class DefaultLockManager implements LockManager {
             }
             rs.close();
 
-            rs = dbMetaData.getTables( null, null, "LOCKED_FIDS", new String[] { "TABLE" } );
+            rs = dbMetaData.getTables( null, SCHEMA_MAIN, "LOCKED_FIDS", new String[] { "TABLE" } );
             if ( !rs.next() ) {
                 LOG.debug( "Creating table 'LOCKED_FIDS'." );
                 if ( stmt == null ) {
@@ -150,7 +151,7 @@ public class DefaultLockManager implements LockManager {
             }
             rs.close();
 
-            rs = dbMetaData.getTables( null, null, "LOCK_FAILED_FIDS", new String[] { "TABLE" } );
+            rs = dbMetaData.getTables( null, SCHEMA_MAIN, "LOCK_FAILED_FIDS", new String[] { "TABLE" } );
             if ( !rs.next() ) {
                 LOG.debug( "Creating table 'LOCK_FAILED_FIDS'." );
                 if ( stmt == null ) {

--- a/pom.xml
+++ b/pom.xml
@@ -957,7 +957,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>1.3.171</version>
+        <version>2.1.210</version>
       </dependency>
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>


### PR DESCRIPTION
The current code does not detect, that H2 now includes an `INFORMATION_SCHEMA` which also included an internal `LOCKS` table.

This PR is a replacement for https://github.com/deegree/deegree3/pull/1270

References:
  * http://h2database.com/html/migration-to-v2.html#information_schema
  * http://h2database.com/html/systemtables.html#information_schema_locks