### PR TITLE
Upgrades log4j2 to v2.17.2 and slf4j to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1123,8 +1123,8 @@
     <spring-boot.version>2.4.13</spring-boot.version>
     <spring-batch.version>4.3.3</spring-batch.version>
     <spring-framework.version>5.3.12</spring-framework.version>
-    <log4j.version>2.17.1</log4j.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <log4j.version>2.17.2</log4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <batik.version>1.14</batik.version>
   </properties>
 


### PR DESCRIPTION
This PR upgrades Apache log4j2 to v2.17.2 and slf4j to latest bugfix version v1.7.36