### PR TITLE
Remove duplicate JCL dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -788,6 +788,12 @@
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-bridge</artifactId>
         <version>${batik.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
This PR removes a duplicate dependency to Java Commons Logging (JCL) detected by maven enforcer ban duplicates classes plugin