### PR TITLE
Fixes packaging of log4j2.properties file in WAR file

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -13,13 +13,22 @@
     <version>3.4.29-SNAPSHOT</version>
   </parent>
   <build>
+    <resources>
+      <resource>
+          <directory>src/main/resources</directory>
+          <excludes>
+              <exclude>log4j2.properties</exclude>
+          </excludes>
+          <filtering>false</filtering>
+      </resource>
+  </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.1</version>
         <configuration>
           <archiveClasses>true</archiveClasses>
+          <attachClasses>true</attachClasses>
           <archive>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -34,61 +43,32 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptors>
-            <descriptor>assembly.xml</descriptor>
-          </descriptors>
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <id>assemble-tomcat</id>
-            <phase>package</phase>
+            <id>copy-resources</id>
+            <phase>install</phase>
             <goals>
-              <goal>single</goal>
+              <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <appendAssemblyId>false</appendAssemblyId>
-              <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
+              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/WEB-INF/classes</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <includes>
+                    <include>**/log4j2.properties</include>
+                  </includes>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-  <!-- Workaround for dependency plugin issue (http://jira.codehaus.org/browse/MDEP-259) -->
   <profiles>
-    <profile>
-      <id>activate-dependency-plugin</id>
-      <activation>
-        <property>
-          <name>!deactivateDependencyPlugin</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>tomcat</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>unpack-dependencies</goal>
-                </goals>
-                <configuration>
-                  <type>zip</type>
-                  <includeGroupIds>org.deegree</includeGroupIds>
-                  <includeArtifactIds>deegree-tomcat</includeArtifactIds>
-                  <outputDirectory>target/deegree-tomcat</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>jersey-provided</id>
       <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.3</version>
+          <version>3.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #1306 packaging of log4j2.properties file in WAR file in WEB-INF/classes and not in JAR file. (cherry picked from commit a4a4b92584d4c5b25d5f8d871cf45d0fef651fee)

Replaces PR  #1307.