### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
           <configuration>
             <!-- Travis build workaround -->
             <argLine>-Djava.awt.headless=true -Xms1024m -Xmx2048m</argLine>
-            <forkCount>1</forkCount>
+            <forkCount>1.5C</forkCount>
             <reuseForks>true</reuseForks>
             <skip>${skip.unit.tests}</skip>
             <trimStackTrace>true</trimStackTrace>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
