### PR TITLE
Fix GmlGetFeatureHandler not excluding features that are already exported

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -584,8 +584,10 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
                             featuresAdded++;
                         }
                     } else {
-                        allFeatures.add( feature );
-                        fids.add( feature.getId() );
+                        if ( !fids.contains( feature.getId() ) ) {
+                            allFeatures.add( feature );
+                            fids.add( feature.getId() );
+                        }
                     }
                 }
             } finally {


### PR DESCRIPTION
This pull request fixes the GmlGetFeatureHandler not excluding features that are already exported.

The bug was introduced through https://github.com/deegree/deegree3/pull/1128; this fix is necessary to pass the OGC compliance renewal for this year (also see #1283).