### PR TITLE
Upgrade to Apache Commons DBCP 2 (and Commons Pool 2)

### DIFF
--- a/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceConnectionProvider.java
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceConnectionProvider.java
@@ -57,9 +57,9 @@ import org.slf4j.Logger;
 
 /**
  * {@link ConnectionProvider} based on <code>javax.sql.DataSource</code>.
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.4
  */
 class DataSourceConnectionProvider implements ConnectionProvider {
@@ -76,7 +76,7 @@ class DataSourceConnectionProvider implements ConnectionProvider {
 
     /**
      * Creates a new {@link DataSourceConnectionProvider} instance.
-     * 
+     *
      * @param resourceMetadata
      *            metadata, must not be <code>null</code>
      * @param ds
@@ -118,16 +118,15 @@ class DataSourceConnectionProvider implements ConnectionProvider {
     @Override
     public void destroy() {
         if ( destroyMethod != null ) {
-            LOG.info("Closing connection pool " + resourceMetadata.getIdentifier());
+            LOG.info("Closing connection pool {}", resourceMetadata.getIdentifier());
             try {
                 destroyMethod.invoke( ds );
             } catch ( Exception e ) {
-                String msg = "Error destroying DataSource instance: " + e.getLocalizedMessage();
-                LOG.error( msg );
+                LOG.error( "Error destroying DataSource instance: {}", e.getLocalizedMessage() );
             }
         } else {
-            LOG.warn("Unable to close connection pool " + resourceMetadata.getIdentifier()
-                    + ". Check the DataSource configuration if the attribute 'destroyMethod' is configured." );
+            LOG.warn( "Unable to close connection pool {}. Check the DataSource configuration if the attribute "
+                      + "'destroyMethod' is configured.", resourceMetadata.getIdentifier() );
         }
     }
 

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceConnectionProvider.java
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceConnectionProvider.java
@@ -118,12 +118,16 @@ class DataSourceConnectionProvider implements ConnectionProvider {
     @Override
     public void destroy() {
         if ( destroyMethod != null ) {
+            LOG.info("Closing connection pool " + resourceMetadata.getIdentifier());
             try {
                 destroyMethod.invoke( ds );
             } catch ( Exception e ) {
                 String msg = "Error destroying DataSource instance: " + e.getLocalizedMessage();
                 LOG.error( msg );
             }
+        } else {
+            LOG.warn("Unable to close connection pool " + resourceMetadata.getIdentifier()
+                    + ". Check the DataSource configuration if the attribute 'destroyMethod' is configured." );
         }
     }
 

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_mssql.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_mssql.xml
@@ -1,9 +1,9 @@
 <DataSourceConnectionProvider configVersion="3.4.0"
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
+  xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/jdbc/datasource/3.4.0/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="com.mysql.jdbc.Driver" />

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_oracle.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_oracle.xml
@@ -1,9 +1,9 @@
 <DataSourceConnectionProvider configVersion="3.4.0"
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
+  xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/jdbc/datasource/3.4.0/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="oracle.jdbc.OracleDriver" />

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_postgres.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_postgres.xml
@@ -1,9 +1,9 @@
 <DataSourceConnectionProvider configVersion="3.4.0"
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
+  xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/jdbc/datasource/3.4.0/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -71,16 +71,16 @@
       <artifactId>Saxon-HE</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-pool</groupId>
-      <artifactId>commons-pool</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
     </dependency>
     <dependency>
       <groupId>jogl</groupId>

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/ConnectionPool.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/ConnectionPool.java
@@ -52,10 +52,9 @@ import org.slf4j.Logger;
 
 /**
  * Simple implementation of a JDBC connection pool based on the Apache Commons Pool and DBCP projects.
- * 
+ *
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author: schneider $
- * 
  * @version $Revision: $, $Date: $
  */
 @LoggingNotes(debug = "logs information about pool usage")
@@ -71,7 +70,7 @@ public class ConnectionPool {
 
     /**
      * Creates a new {@link ConnectionPool} instance.
-     * 
+     *
      * @param id
      * @param connectURI
      * @param user
@@ -86,12 +85,12 @@ public class ConnectionPool {
         this.id = id;
         ConnectionFactory connectionFactory = new DriverManagerConnectionFactory( connectURI, user, password );
         PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory( connectionFactory, null );
-        pool = new GenericObjectPool<>(poolableConnectionFactory);
+        pool = new GenericObjectPool<>( poolableConnectionFactory );
         pool.setMinIdle( minIdle );
         pool.setMaxTotal( maxActive );
-        pool.setTestOnBorrow(true);
+        pool.setTestOnBorrow( true );
 
-        poolableConnectionFactory.setPool(pool);
+        poolableConnectionFactory.setPool( pool );
         ds = new PoolingDataSource( pool );
 
         // needed, so users can retrieve the underlying connection from pooled
@@ -102,7 +101,7 @@ public class ConnectionPool {
 
     /**
      * Returns a {@link Connection} from the pool.
-     * 
+     *
      * @return a connection from the pool
      * @throws SQLException
      */

--- a/deegree-core/deegree-core-db/src/main/java/org/deegree/db/legacy/LegacyConnectionProvider.java
+++ b/deegree-core/deegree-core-db/src/main/java/org/deegree/db/legacy/LegacyConnectionProvider.java
@@ -44,7 +44,8 @@ package org.deegree.db.legacy;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.apache.commons.dbcp.DelegatingConnection;
+import org.apache.commons.dbcp2.DelegatingConnection;
+import org.apache.commons.dbcp2.PoolableConnection;
 import org.deegree.commons.jdbc.ConnectionPool;
 import org.deegree.db.ConnectionProvider;
 import org.deegree.sqldialect.SQLDialect;
@@ -128,7 +129,7 @@ public class LegacyConnectionProvider implements ConnectionProvider {
     @Override
     public void invalidate( Connection conn ) {
         try {
-            pool.invalidate( (DelegatingConnection) conn );
+            pool.invalidate( (PoolableConnection) conn );
         } catch ( Exception e ) {
             throw new RuntimeException( e );
         }

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTIFFTile.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTIFFTile.java
@@ -51,7 +51,7 @@ import java.util.Hashtable;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 
-import org.apache.commons.pool.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.deegree.feature.FeatureCollection;
 import org.deegree.geometry.Envelope;
 import org.deegree.tile.Tile;

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTIFFTileDataLevel.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTIFFTileDataLevel.java
@@ -43,7 +43,7 @@ package org.deegree.tile.persistence.geotiff;
 import java.io.File;
 import java.util.List;
 
-import org.apache.commons.pool.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.tile.TileDataLevel;

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/ImageReaderFactory.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/ImageReaderFactory.java
@@ -50,42 +50,52 @@ import java.util.Iterator;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
-import org.apache.commons.pool.PoolableObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
 
 /**
- * <code>ImageReaderFactory</code>: an object factory for commons-pool. It should really be replaced with a better
- * solution, not using generics here (and throwing Exception) is not the way to go...
+ * <code>ImageReaderFactory</code>: an object factory for Apache commons-pool providing
+ * file-based image reader.
  * 
  * @author <a href="mailto:schmitz@occamlabs.de">Andreas Schmitz</a>
- * @author last edited by: $Author: mschneider $
- * 
- * @version $Revision: 31882 $, $Date: 2011-09-15 02:05:04 +0200 (Thu, 15 Sep 2011) $
+ * @author <a href="mailto:friebe@lat-lon.de">Torsten Friebe</a>
+ *
  */
+public class ImageReaderFactory implements PooledObjectFactory<ImageReader> {
 
-public class ImageReaderFactory implements PoolableObjectFactory {
-
-    private File file;
+    private final File file;
 
     public ImageReaderFactory( File file ) {
         this.file = file;
     }
 
     @Override
-    public void activateObject( Object o )
-                            throws Exception {
-        // nothing to do
-    }
-
-    @Override
-    public void destroyObject( Object o )
-                            throws Exception {
-        ImageReader reader = (ImageReader) o;
+    public void destroyObject(PooledObject pooledObject) throws Exception {
+        ImageReader reader = (ImageReader) pooledObject;
         reader.dispose();
     }
 
     @Override
-    public Object makeObject()
-                            throws Exception {
+    public boolean validateObject(PooledObject pooledObject) {
+        // ImageReader reader = (ImageReader) o;
+        // ImageInputStream iis = (ImageInputStream) reader.getInput();
+        // unknown if we need something here, so far no readers have become invalid
+        return true;
+    }
+
+    @Override
+    public void activateObject(PooledObject pooledObject) throws Exception {
+        // nothing to do
+    }
+
+    @Override
+    public void passivateObject(PooledObject pooledObject) throws Exception {
+        // nothing to do
+    }
+
+    @Override
+    public PooledObject<ImageReader> makeObject() throws Exception {
         ImageInputStream iis = null;
         ImageReader reader = null;
         Iterator<ImageReader> readers = getImageReadersBySuffix( "tiff" );
@@ -95,21 +105,6 @@ public class ImageReaderFactory implements PoolableObjectFactory {
         iis = createImageInputStream( file );
         // already checked in provider
         reader.setInput( iis );
-        return reader;
+        return new DefaultPooledObject(reader);
     }
-
-    @Override
-    public void passivateObject( Object o )
-                            throws Exception {
-        // nothing to do
-    }
-
-    @Override
-    public boolean validateObject( Object o ) {
-        // ImageReader reader = (ImageReader) o;
-        // ImageInputStream iis = (ImageInputStream) reader.getInput();
-        // unknown if we need something here, so far no readers have become invalid
-        return true;
-    }
-
 }

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -273,7 +273,7 @@ allows for the following options:
 (instead of constructor)
 
 |destroyMethod |0..1 |String |Method to be invoked on the javax.sql.DataSource
-object to close the underlying connection pool
+object to close the underlying connection pool. Which method to be called depends on the implementation of the javax.sql.DataSource. Check the API documentation for more information.
 
 |Argument |0..1 |Complex |Argument to use for instantiation/method call
 |===

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -54,15 +54,15 @@ database:
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
-  <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
+  <!-- Creation of javax.sql.DataSource instance -->
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />
   <Property name="url" value="jdbc:postgresql://localhost/deegree-db" />
   <Property name="username" value="kelvin" />
   <Property name="password" value="s3cr3t" />
-  <Property name="maxActive" value="10" />
+  <Property name="maxTotal" value="10" />
 
 </DataSourceConnectionProvider>
 ----
@@ -101,8 +101,8 @@ This example defines a connection pool for an Oracle database:
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
-  <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
+  <!-- Creation of javax.sql.DataSource instance -->
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="oracle.jdbc.OracleDriver" />
@@ -110,7 +110,7 @@ This example defines a connection pool for an Oracle database:
   <Property name="username" value="kelvin" />
   <Property name="password" value="s3cr3t" />
   <Property name="poolPreparedStatements" value="true" />
-  <Property name="maxActive" value="10" />
+  <Property name="maxTotal" value="10" />
   <Property name="maxIdle" value="10" />
 
 </DataSourceConnectionProvider>
@@ -146,8 +146,8 @@ This example defines a connection pool for a Microsoft SQL Server:
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
-  <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
+  <!-- Creation of javax.sql.DataSource instance -->
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />
@@ -155,7 +155,7 @@ This example defines a connection pool for a Microsoft SQL Server:
   <Property name="username" value="kelvin" />
   <Property name="password" value="s3cr3t" />
   <Property name="poolPreparedStatements" value="true" />
-  <Property name="maxActive" value="10" />
+  <Property name="maxTotal" value="10" />
   <Property name="maxIdle" value="10" />
 
 </DataSourceConnectionProvider>
@@ -187,7 +187,7 @@ servlet container that runs deegree webservices (e.g. Apache Tomcat):
   xmlns="http://www.deegree.org/connectionprovider/datasource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
-  <!-- Creation / lookup of javax.sql.DataSource instance -->
+  <!-- Lookup of javax.sql.DataSource instance via JNDI -->
   <DataSource javaClass="org.deegree.db.datasource.JndiLookup" factoryMethod="lookup">
     <Argument value="java:comp/env/jdbc/DatabaseName" javaClass="java.lang.String" />
   </DataSource>
@@ -272,8 +272,8 @@ allows for the following options:
 |factoryMethod |0..1 |String |If present, this static method is used
 (instead of constructor)
 
-|destroyMethod |0..1 |String |Configuration of javax.sql.DataSource
-object
+|destroyMethod |0..1 |String |Method to be invoked on the javax.sql.DataSource
+object to close the underlying connection pool
 
 |Argument |0..1 |Complex |Argument to use for instantiation/method call
 |===
@@ -300,6 +300,7 @@ arguments passed to the constructor.
 [source,xml]
 ----
 ... 
+<!-- Lookup of javax.sql.DataSource instance via JNDI -->
 <DataSource javaClass="org.deegree.db.datasource.JndiLookup" factoryMethod="lookup">
   <Argument value="java:comp/env/jdbc/DatabaseName" javaClass="java.lang.String" />
 </DataSource>
@@ -337,7 +338,7 @@ _javax.sql.DataSource_ instance:
 <Property name="username" value="kelvin" />
 <Property name="password" value="s3cr3t" />
 <Property name="poolPreparedStatements" value="true" />
-<Property name="maxActive" value="10" />
+<Property name="maxTotal" value="10" />
 <Property name="maxIdle" value="10" />
 ...
 ----

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -55,7 +55,7 @@ database:
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />
@@ -68,7 +68,7 @@ database:
 ----
 
 * The DataSource object uses Java class
-_org.apache.commons.dbcp.BasicDataSource_ (a connection pool class
+_org.apache.commons.dbcp2.BasicDataSource_ (a connection pool class
 provided by
 http://commons.apache.org/proper/commons-dbcp/index.html[Apache Commons
 DBCP].). If you don't know what this means, then this is most likely
@@ -102,7 +102,7 @@ This example defines a connection pool for an Oracle database:
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="oracle.jdbc.OracleDriver" />
@@ -119,7 +119,7 @@ This example defines a connection pool for an Oracle database:
 This defines a database connection with the following properties:
 
 * The DataSource object uses the Java class
-_org.apache.commons.dbcp.BasicDataSource_ (a connection pool class
+_org.apache.commons.dbcp2.BasicDataSource_ (a connection pool class
 provided by Apache DBCP). If you are not familiar with J2EE containers,
 this is most likely what you want to use.
 * The JDBC driver class is _oracle.jdbc.OracleDriver_. This is the
@@ -147,7 +147,7 @@ This example defines a connection pool for a Microsoft SQL Server:
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />
@@ -164,7 +164,7 @@ This example defines a connection pool for a Microsoft SQL Server:
 This defines a database connection with the following properties:
 
 * The DataSource object uses the Java class
-_org.apache.commons.dbcp.BasicDataSource_ (a connection pool class
+_org.apache.commons.dbcp2.BasicDataSource_ (a connection pool class
 provided by Apache DBCP). If you are not familiar with J2EE containers,
 this is most likely what you want to use.
 * The JDBC driver class is _org.postgresql.Driver_. This is the Java
@@ -286,13 +286,13 @@ snippets for clarification:
 [source,xml]
 ----
 ... 
-<DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" />
+<DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
 ...
 ----
 
 In this snippet, no _factoryMethod_ attribute is present. Therefore,
 the constructor of Java class
-_org.apache.commons.dbcp.BasicDataSource_ is invoked. The returned
+_org.apache.commons.dbcp2.BasicDataSource_ is invoked. The returned
 instance must be an implementation of _javax.sql.DataSource_, and this
 is guaranteed, because the class implements this interface. There are no
 arguments passed to the constructor.
@@ -346,7 +346,7 @@ The properties available for configuration depend on the implementation
 of _javax.sql.DataSource_:
 
 * Apache Commons DBCP: See
-http://commons.apache.org/proper/commons-dbcp/api-1.4/org/apache/commons/dbcp/BasicDataSource.html
+http://commons.apache.org/proper/commons-dbcp/api-2.7.0/org/apache/commons/dbcp2/BasicDataSource.html
 * Oracle UCP:
 http://docs.oracle.com/cd/E11882_01/java.112/e12826/oracle/ucp/jdbc/PoolDataSource.html
 

--- a/pom.xml
+++ b/pom.xml
@@ -534,14 +534,14 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>commons-pool</groupId>
-        <artifactId>commons-pool</artifactId>
-        <version>1.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-pool2</artifactId>
+        <version>2.7.0</version>
       </dependency>
       <dependency>
-        <groupId>commons-dbcp</groupId>
-        <artifactId>commons-dbcp</artifactId>
-        <version>1.4</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-dbcp2</artifactId>
+        <version>2.7.0</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>


### PR DESCRIPTION
This is the rebased version of PR #1022 

Original text:

Apache Commons DBCP and Commons Pool dependencies were upgraded to version 2.7.0.

Reason: Currently used version is outdated and not maintained by the community any more.

Also, the documentation was updated and improved in some points (e.g. for destroyMethod).

Closes https://github.com/deegree/deegree3/issues/1017.