### PR TITLE
Fix default values of maxFeatures and featureInfoRadius

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
@@ -36,7 +36,7 @@
 package org.deegree.rendering.r2d.context;
 
 /**
- * 
+ *
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
@@ -170,10 +170,10 @@ public class MapOptions {
 
     /**
      * <code>Quality</code>
-     * 
+     *
      * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
      * @author last edited by: $Author: aschmitz $
-     * 
+     *
      * @version $Revision: 32136 $, $Date: 2011-10-12 15:21:52 +0200 (Wed, 12 Oct 2011) $
      */
     public static enum Quality {
@@ -187,10 +187,10 @@ public class MapOptions {
 
     /**
      * <code>Interpolation</code>
-     * 
+     *
      * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
      * @author last edited by: $Author: aschmitz $
-     * 
+     *
      * @version $Revision: 32136 $, $Date: 2011-10-12 15:21:52 +0200 (Wed, 12 Oct 2011) $
      */
     public static enum Interpolation {
@@ -206,10 +206,10 @@ public class MapOptions {
 
     /**
      * <code>Antialias</code>
-     * 
+     *
      * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
      * @author last edited by: $Author: aschmitz $
-     * 
+     *
      * @version $Revision: 32136 $, $Date: 2011-10-12 15:21:52 +0200 (Wed, 12 Oct 2011) $
      */
     public static enum Antialias {
@@ -293,9 +293,9 @@ public class MapOptions {
 
         private Antialias antialias;
 
-        private int maxFeatures;
+        private int maxFeatures = -1;
 
-        private int featureInfoRadius;
+        private int featureInfoRadius = -1;
 
         /**
          * @param quality


### PR DESCRIPTION
This pull request fixes the default values of maxFeatures and featureInfoRadius.
Previously, when requesting a WFS without maxFeatures, no features were returned as 0 was set for this parameter.
This PR fixes that by setting -1 default values.