### PR TITLE
Fix export of returnFeatureTypes without namespace in StoredQueryDefinitionEncoder

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/storedquery/xml/StoredQueryDefinition200Encoder.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/storedquery/xml/StoredQueryDefinition200Encoder.java
@@ -160,14 +160,20 @@ public class StoredQueryDefinition200Encoder {
         for ( QName returnFeatureType : queryExpressionText.getReturnFeatureTypes() ) {
             if ( !isFirst )
                 returnFeatureTypes.append( ' ' );
-            boolean prefixBound = ( writer.getPrefix( returnFeatureType.getNamespaceURI() ) != null ) ? true : false;
-            if ( prefixBound ) {
-                returnFeatureTypes.append( writer.getPrefix( returnFeatureType.getNamespaceURI() ) );
+            if( returnFeatureType.getNamespaceURI()  != null && !returnFeatureType.getNamespaceURI().isBlank() ) {
+                boolean prefixBound = ( writer.getPrefix( returnFeatureType.getNamespaceURI() ) != null ) ?
+                                      true :
+                                      false;
+                if ( prefixBound ) {
+                    returnFeatureTypes.append( writer.getPrefix( returnFeatureType.getNamespaceURI() ) );
+                } else {
+                    writer.writeNamespace( returnFeatureType.getPrefix(), returnFeatureType.getNamespaceURI() );
+                    returnFeatureTypes.append( returnFeatureType.getPrefix() );
+                }
+                returnFeatureTypes.append( ':' ).append( returnFeatureType.getLocalPart() );
             } else {
-                writer.writeNamespace( returnFeatureType.getPrefix(), returnFeatureType.getNamespaceURI() );
-                returnFeatureTypes.append( returnFeatureType.getPrefix() );
+                returnFeatureTypes.append( returnFeatureType.getLocalPart() );
             }
-            returnFeatureTypes.append( ':' ).append( returnFeatureType.getLocalPart() );
             isFirst = false;
         }
         writer.writeAttribute( "returnFeatureTypes", returnFeatureTypes.toString() );

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/storedquery/xml/StoredQueryDefinition200EncoderTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/storedquery/xml/StoredQueryDefinition200EncoderTest.java
@@ -37,10 +37,12 @@ package org.deegree.protocol.wfs.storedquery.xml;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.deegree.protocol.wfs.storedquery.QueryExpressionText;
 import org.deegree.protocol.wfs.storedquery.StoredQueryDefinition;
 import org.junit.Test;
 import org.xmlunit.matchers.CompareMatcher;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
@@ -81,6 +83,26 @@ public class StoredQueryDefinition200EncoderTest {
         assertThat( actual, CompareMatcher.isSimilarTo(
                         IOUtils.toString( getClass().getResourceAsStream( storedQueryResource ),
                                           UTF_8 ) ).ignoreWhitespace() );
+    }
+
+    @Test
+    public void testExport_ServedFeatureTypes()
+                    throws Exception {
+        String storedQueryResource = "storedQuery.xml";
+        StoredQueryDefinition queryDefinition = parseStoredQueryDefinition( storedQueryResource );
+        QueryExpressionText queryExpressionText = queryDefinition.getQueryExpressionTextEls().get( 0 );
+        queryExpressionText.getReturnFeatureTypes().clear();
+        queryExpressionText.getReturnFeatureTypes().add( new QName( "${deegreewfs:ServedFeatureTypes}" ) );
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        XMLStreamWriter writer = XMLOutputFactory.newInstance().createXMLStreamWriter( stream );
+        StoredQueryDefinition200Encoder.export( queryDefinition, writer );
+        writer.close();
+
+        String actual = stream.toString( UTF_8 );
+        assertThat( actual,
+                    hasXPath(
+                                    "/wfs:StoredQueryDefinition/wfs:QueryExpressionText/@returnFeatureTypes",
+                                    is( "${deegreewfs:ServedFeatureTypes}" ) ).withNamespaceContext( nsContext() ) );
     }
 
     private StoredQueryDefinition parseStoredQueryDefinition( String resource )


### PR DESCRIPTION
Without this pull request deegree generates content like the following when no namespace is used:
```
returnFeatureTypes=":${deegreewfs:ServedFeatureTypes}" 
```

There is an `:` in the response which should not be there.

This pull request fixes that behavior (as confirmed by the unit test).