### PR TITLE
Use trimmed OGC schemas zip file (reducing size by approx. 32 MB)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1182,7 +1182,7 @@
       <dependency>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-ogcschemas</artifactId>
-        <version>20191108</version>
+        <version>20210817</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>


### PR DESCRIPTION
fixes #1105 using trimmed OGC schemas zip file (PR for 3.5)