### PR TITLE
Implement PointsList#copy() and JTSPoints#copy()

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/Reference.java
@@ -79,6 +79,15 @@ public class Reference<T extends Object> implements Object {
     }
 
     /**
+     * Returns the resolver.
+     *
+     * @return the resolver, never <code>null</code>
+     */
+    public ReferenceResolver getResolver() {
+        return resolver;
+    }
+
+    /**
      * Returns the URI of the object.
      *
      * @return the URI of the object, never <code>null</code>

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/primitive/Point.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/primitive/Point.java
@@ -35,10 +35,6 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.geometry.primitive;
 
-import java.util.List;
-
-import org.deegree.commons.tom.gml.property.Property;
-
 /**
  * 0-dimensional primitive.
  * 
@@ -52,35 +48,35 @@ public interface Point extends GeometricPrimitive {
 
     /**
      * Must always return {@link GeometricPrimitive.PrimitiveType#Point}.
-     * 
+     *
      * @return {@link GeometricPrimitive.PrimitiveType#Point}
      */
     public PrimitiveType getPrimitiveType();
 
     /**
      * Returns the value of the first ordinate.
-     * 
+     *
      * @return value of the first ordinate
      */
     public double get0();
 
     /**
      * Returns the value of the second ordinate.
-     * 
+     *
      * @return value of the second ordinate, or <code>Double.NAN</code> if the point only has one dimension
      */
     public double get1();
 
     /**
      * Returns the value of the third ordinate.
-     * 
+     *
      * @return value of the third ordinate, or <code>Double.NAN</code> if the point only has one or two dimensions
      */
     public double get2();
 
     /**
      * Returns the value of the specified ordinate.
-     * 
+     *
      * @param dimension
      *            ordinate to be returned (first dimension=0)
      * @return ordinate value of the passed dimension, or <code>Double.NAN</code> if <code>dimension</code> is greater
@@ -90,8 +86,13 @@ public interface Point extends GeometricPrimitive {
 
     /**
      * Returns all ordinates.
-     * 
+     *
      * @return all ordinates, the length of the array is equal to the number of dimensions
      */
     public double[] getAsArray();
+
+    /**
+     * @return a copy of the point
+     */
+    Point copy();
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/refs/PointReference.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/refs/PointReference.java
@@ -38,6 +38,9 @@ package org.deegree.geometry.refs;
 
 import org.deegree.commons.tom.gml.GMLReferenceResolver;
 import org.deegree.geometry.primitive.Point;
+import org.deegree.geometry.standard.primitive.DefaultPoint;
+
+import java.util.Arrays;
 
 /**
  * The <code></code> class TODO add class documentation here.
@@ -92,4 +95,10 @@ public class PointReference extends GeometricPrimitiveReference<Point> implement
     public double get2() {
         return getReferencedObject().get2();
     }
+
+    @Override
+    public Point copy() {
+        return new PointReference( (GMLReferenceResolver) getResolver(), getURI(), getBaseURL() );
+    }
+
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/JTSPoints.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/JTSPoints.java
@@ -216,6 +216,6 @@ public class JTSPoints implements Points {
 
     @Override
     public CoordinateSequence copy() {
-        throw new UnsupportedOperationException();
+        return new JTSPoints( crs, seq.copy() );
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/JTSPoints.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/JTSPoints.java
@@ -211,7 +211,7 @@ public class JTSPoints implements Points {
 
     @Override
     public Object clone() {
-        throw new UnsupportedOperationException();
+        return copy();
     }
 
     @Override

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsList.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsList.java
@@ -36,8 +36,11 @@
 package org.deegree.geometry.standard.points;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.deegree.commons.tom.Reference;
 import org.deegree.geometry.points.Points;
@@ -208,7 +211,8 @@ public class PointsList implements Points {
 
     @Override
     public CoordinateSequence copy() {
-        throw new UnsupportedOperationException();
+        List<Point> copiedPoints = points.stream().map( point -> point.copy() ).collect( Collectors.toList() );
+        return new PointsList( copiedPoints );
     }
 
     @Override

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsList.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/points/PointsList.java
@@ -206,7 +206,7 @@ public class PointsList implements Points {
 
     @Override
     public Object clone() {
-        return new PointsList( new ArrayList<Point>( points ) );
+        return copy();
     }
 
     @Override

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultPoint.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/primitive/DefaultPoint.java
@@ -45,6 +45,8 @@ import org.deegree.geometry.standard.DefaultEnvelope;
 
 import org.locationtech.jts.geom.Coordinate;
 
+import java.util.Arrays;
+
 /**
  * Default implementation of {@link Point}.
  * 
@@ -113,6 +115,11 @@ public class DefaultPoint extends AbstractDefaultGeometry implements Point {
             return coordinates[2];
         }
         return Double.NaN;
+    }
+
+    @Override
+    public Point copy() {
+        return new DefaultPoint( id, crs, pm,  Arrays.copyOf( coordinates, coordinates.length ) );
     }
 
     @Override


### PR DESCRIPTION
Interface org.deegree.geometry.primitive.Point was enhanced by copy() method.

Afterwards, PointReference and DefaultPoint were enhanced by implementations of this new method.

Finally, PointsList#copy() could be implemented.
JTSPoints#copy() was also implemented.