### PR TITLE
Bump Mockito from 2.28.2 to 3.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,8 @@
             <!-- Travis build workaround -->
             <argLine>-Djava.awt.headless=true -Xms1024m -Xmx2048m --illegal-access=permit
               --add-opens java.base/java.lang=ALL-UNNAMED
+              --add-opens java.base/java.net=ALL-UNNAMED
+              --add-opens java.base/java.util=ALL-UNNAMED
               --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED</argLine>
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>
@@ -446,7 +448,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.28.2</version>
+        <version>3.12.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Upgrades Mockito from 2.28.2 to 3.12.4 and adds "add-open for java.base" modules to surefire maven plugin (supports compile with JDK 17+) 