### PR TITLE
Upgrades axiom from 1.2.15 to 1.2.22 

### DIFF
--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -76,6 +76,10 @@
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.ws.commons.axiom</groupId>
+      <artifactId>axiom-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -80,12 +80,13 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamReader;
 
+import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
-import org.apache.axiom.soap.impl.llom.soap11.SOAP11Factory;
-import org.apache.axiom.soap.impl.llom.soap12.SOAP12Factory;
+import org.apache.axiom.soap.impl.common.SOAP11Factory;
+import org.apache.axiom.soap.impl.common.SOAP12Factory;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileUploadException;
@@ -919,9 +920,9 @@ public class OGCFrontController extends HttpServlet {
         SOAPFactory factory = null;
         String ns = root.getNamespace().getNamespaceURI();
         if ( "http://schemas.xmlsoap.org/soap/envelope/".equals( ns ) ) {
-            factory = new SOAP11Factory();
+            factory = OMAbstractFactory.getSOAP11Factory();
         } else {
-            factory = new SOAP12Factory();
+            factory = OMAbstractFactory.getSOAP12Factory();
         }
 
         StAXSOAPModelBuilder soap = new StAXSOAPModelBuilder( root.getXMLStreamReaderWithoutCaching(), factory,

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializerTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializerTest.java
@@ -40,8 +40,10 @@ import java.io.ByteArrayOutputStream;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamWriter;
 
-import org.apache.axiom.soap.impl.llom.soap11.SOAP11Factory;
-import org.apache.axiom.soap.impl.llom.soap12.SOAP12Factory;
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.soap.SOAPFactory;
+import org.apache.axiom.soap.impl.common.SOAP11Factory;
+import org.apache.axiom.soap.impl.common.SOAP12Factory;
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ows.Version;
 import org.deegree.commons.utils.kvp.InvalidParameterValueException;
@@ -60,7 +62,7 @@ public class SOAPExceptionSerializerTest {
     @Test
     public void testSerializeExceptionToXML_SOAP11()
                             throws Exception {
-        SOAP11Factory factory = new SOAP11Factory();
+        SOAPFactory factory = OMAbstractFactory.getSOAP11Factory();
         XMLExceptionSerializer detailSerializer = new OWS110ExceptionReportSerializer( new Version( 2, 0, 0 ) );
         SOAPExceptionSerializer soapExceptionSerializer = new SOAPExceptionSerializer( factory.getSOAPVersion(), null,
                                                                                        factory, detailSerializer );
@@ -77,7 +79,7 @@ public class SOAPExceptionSerializerTest {
     @Test
     public void testSerializeExceptionToXML_SOAP12()
                             throws Exception {
-        SOAP12Factory factory = new SOAP12Factory();
+        SOAPFactory factory = OMAbstractFactory.getSOAP12Factory();
         SOAPExceptionSerializer soapExceptionSerializer = createExceptionSerializer( factory );
         SOAPException soapException = createException();
 
@@ -94,7 +96,7 @@ public class SOAPExceptionSerializerTest {
         return new SOAPException( "reason", "code", owsException );
     }
 
-    private SOAPExceptionSerializer createExceptionSerializer( SOAP12Factory factory ) {
+    private SOAPExceptionSerializer createExceptionSerializer( SOAPFactory factory ) {
         XMLExceptionSerializer detailSerializer = new OWS110ExceptionReportSerializer( new Version( 2, 0, 0 ) );
         return new SOAPExceptionSerializer( factory.getSOAPVersion(), null, factory, detailSerializer );
     }

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializerTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/exception/serializer/SOAPExceptionSerializerTest.java
@@ -42,8 +42,6 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.soap.SOAPFactory;
-import org.apache.axiom.soap.impl.common.SOAP11Factory;
-import org.apache.axiom.soap.impl.common.SOAP12Factory;
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ows.Version;
 import org.deegree.commons.utils.kvp.InvalidParameterValueException;

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-impl</artifactId>
-        <version>1.2.15</version>
+        <version>${axoim.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.woodstox</groupId>
@@ -715,7 +715,7 @@
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-api</artifactId>
-        <version>1.2.15</version>
+        <version>${axoim.version}</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1245,6 +1245,7 @@
     <spring-batch.version>4.3.5</spring-batch.version>
     <spring-framework.version>5.3.18</spring-framework.version>
     <batik.version>1.14</batik.version>
+    <axoim.version>1.2.22</axoim.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This PR upgrades axiom from 1.2.15 to 1.2.22 and fixes wrong use of axoim's internal API.

The usage of the SOAPFactory implementations default constructors was not correct and the non-arg default constructors have been removed, "Note that they were not part of the public API, but considered internal implementation details. Application code should always use the OMAbstractFactory APIs to get references to factory instances, and never refer to implementation classes directly." (see https://ws.apache.org/axiom/release-notes/1.2.16.html)


