### PR TITLE
Fix background color issues with no-data sections in gdal tiles [3.4]

### DIFF
--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalDataset.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalDataset.java
@@ -360,7 +360,14 @@ public class GdalDataset implements KeyedResource {
             byte[] src = windowData[i];
             byte[] dst = bands[i];
             if ( i != 3 ) {
-                setWhite( dst );
+                // default to white / assume that white is -1
+                byte backgroundValue = -1;
+                Double[] noData = new Double[1];
+                dataset.GetRasterBand(i + 1).GetNoDataValue(noData);
+                if ( noData.length == 1 && noData[0] != null) {
+                    backgroundValue = noData[0].byteValue();
+                }
+                setDataToValue( dst, backgroundValue );
             }
             for ( int y = 0; y < windowSizeY; y++ ) {
                 for ( int x = 0; x < windowSizeX; x++ ) {
@@ -377,9 +384,9 @@ public class GdalDataset implements KeyedResource {
         return bands;
     }
 
-    private void setWhite( byte[] dst ) {
+    private void setDataToValue( byte[] dst, byte newValue ) {
         for ( int i = 0; i < dst.length; i++ ) {
-            dst[i] = -1;
+            dst[i] = newValue;
         }
     }
 


### PR DESCRIPTION
The current implementation uses a static value of -1, which is assumed to be white (as the function was named).
Furthermore, only bands 0-2 are overwritten with data, which I did not changed.

Before a customer had isses with small rasters images which showed black rectangles on the bottom and/or side of the image.
After applying the change the rectangles were gone and either transparency or background color was rendered.


* PR for 3.5 is #1381 
* GDAL Java API
  *  https://gdal.org/java/org/gdal/gdal/Band.html#GetNoDataValue(java.lang.Double%5B%5D)
* GDAL C++ API
  *  https://gdal.org/api/gdalrasterband_cpp.html#_CPPv4N14GDALRasterBand14GetNoDataValueEPi