### PR TITLE
Fix rendering of symbolizer with external SVG graphics

### DIFF
--- a/deegree-core/deegree-core-style/pom.xml
+++ b/deegree-core/deegree-core-style/pom.xml
@@ -85,6 +85,10 @@
       <artifactId>batik-xml</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis-ext</artifactId>
     </dependency>


### PR DESCRIPTION
Fixes #1383 by adding batik-codec as described in https://bz.apache.org/bugzilla/show_bug.cgi?id=44682