### PR TITLE
Make report file configurable in the loader tool

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
@@ -170,6 +170,7 @@ arguments:
  -sqlFeatureStoreId=<feature_store_identifier>, the ID of the SQLFeatureStore in the given workspace
 
 options:
+ -reportWriteStatistics=true, create a summary of all written feature types, disabled by default
  -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default
 
 Example:

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
@@ -171,6 +171,7 @@ arguments:
 
 options:
  -reportWriteStatistics=true, create a summary of all written feature types, disabled by default
+ -reportFile=GmlLoader.log, the name and optionally path to the report file, defaults to GmlLoader.log
  -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default
 
 Example:

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/FeatureStatistics.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/FeatureStatistics.java
@@ -1,0 +1,74 @@
+/*-
+ * #%L
+ * deegree-cli-utility
+ * %%
+ * Copyright (C) 2022 grit graphische Informationstechnik Beratungsgesellschaft mbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.tools.featurestoresql.loader;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import javax.xml.namespace.QName;
+
+import org.deegree.feature.Feature;
+import org.springframework.batch.core.ItemWriteListener;
+
+/**
+ * Collects statistics for each type loaded
+ *
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
+ */
+public class FeatureStatistics {
+    private Map<QName, AtomicLong> counter = new TreeMap<>( Comparator.comparing( QName::getNamespaceURI ).thenComparing( QName::getLocalPart ) );
+
+    public void reset() {
+        counter.clear();
+    }
+
+    /**
+     * @param name
+     *            type name to increment
+     */
+    public long increment( QName name ) {
+        AtomicLong cnt = counter.get( name );
+        if ( cnt == null ) {
+            cnt = new AtomicLong();
+            counter.put( name, cnt );
+        }
+        return cnt.incrementAndGet();
+    }
+
+    /**
+     * @param out
+     *            Consumer function that receives the output
+     */
+    public void summary( Consumer<String> out ) {
+        final long max = counter.values().stream() //
+                                .map( AtomicLong::get ) //
+                                .max( Long::compareTo )//
+                                .orElse( 1L );
+        final int len = String.valueOf( max ).length();
+        final String format = "%" + len + "d %s";
+        counter.forEach( ( k, v ) -> out.accept( String.format( format, v.get(), k.toString() ) ) );
+    }
+}

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/FeatureStoreWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/FeatureStoreWriter.java
@@ -3,6 +3,7 @@
  * deegree-cli-utility
  * %%
  * Copyright (C) 2016 - 2021 lat/lon GmbH
+ * Copyright (C) 2022 grit graphische Informationstechnik Beratungsgesellschaft mbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -63,20 +64,20 @@ public class FeatureStoreWriter implements ItemWriter<Feature> {
     }
 
     @Override
-    public void write( List features )
+    public void write( List<? extends Feature> features )
                             throws Exception {
 
         FeatureCollection featureCollection = new GenericFeatureCollection();
-        for ( Object feature : features ) {
-            Feature featureToAdd = (Feature) feature;
-            LOG.info( "Adding feature with GML ID '"+featureToAdd.getId()+"' of type '"+featureToAdd.getType().getName()+"' to chunk" );
+        for ( Feature featureToAdd : features ) {
+            LOG.debug( "Adding feature with GML ID '{}' of type '{}' to chunk", featureToAdd.getId(),
+                       featureToAdd.getType().getName() );
             featureCollection.add( featureToAdd );
+            summary.increaseNumberOfFeatures( featureToAdd.getType().getName() );
         }
-        LOG.info( "Trying to write " + featureCollection.size() + " features" );
+        LOG.info( "Trying to write {} features", featureCollection.size() );
         SQLFeatureStoreTransaction transaction = (SQLFeatureStoreTransaction) sqlFeatureStore.getTransaction();
         transaction.performInsert( featureCollection, USE_EXISTING.withSkipResolveReferences( true ) );
         LOG.info( "Insert performed." );
-        summary.increaseNumberOfFeatures( featureCollection.size() );
     }
 
 }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
@@ -79,8 +79,9 @@ public class GmlLoaderConfiguration {
     }
 
     @Bean
-    public ReportWriter reportWriter( Summary summary ) {
-        Path outputFile = Paths.get( "GmlLoader.log" );
+    public ReportWriter reportWriter( Summary summary,
+                                      @Value("#{jobParameters['reportFile'] ?: 'GmlLoader.log'}") String fileName ) {
+        Path outputFile = Paths.get( fileName );
         return new ReportWriter( summary, outputFile );
     }
 

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
@@ -3,6 +3,7 @@
  * deegree-cli-utility
  * %%
  * Copyright (C) 2016 - 2021 lat/lon GmbH
+ * Copyright (C) 2022 grit graphische Informationstechnik Beratungsgesellschaft mbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -38,6 +39,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
@@ -64,9 +66,16 @@ public class GmlLoaderConfiguration {
     @Autowired
     private StepBuilderFactory stepBuilderFactory;
 
+    @JobScope
     @Bean
-    public Summary summary() {
-        return new Summary();
+    public Summary summary( @Value("#{jobParameters[reportWriteStatistics] ?: false}") boolean reportWriteStatistics ) {
+        Summary summary = new Summary();
+
+        if ( reportWriteStatistics ) {
+            summary.setStatistics( new FeatureStatistics() );
+        }
+
+        return summary;
     }
 
     @Bean

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
@@ -41,6 +41,7 @@ public class GmlLoaderHelpUsage {
         System.out.println();
         System.out.println( "options:" );
         System.out.println( " -reportWriteStatistics=true, create a summary of all written feature types, disabled by default");
+        System.out.println( " -reportFile=GmlLoader.log, the name and optionally path to the report file, defaults to GmlLoader.log");
         System.out.println( " -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default" );
         System.out.println();
         System.out.println( "Example:" );

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
@@ -25,6 +25,7 @@ package org.deegree.tools.featurestoresql.loader;
  * GmlLoader CLI usage info.
  *
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public class GmlLoaderHelpUsage {
 
@@ -38,6 +39,7 @@ public class GmlLoaderHelpUsage {
         System.out.println( " -sqlFeatureStoreId=<feature_store_identifier>, the ID of the SQLFeatureStore in the given workspace" );
         System.out.println();
         System.out.println( "options:" );
+        System.out.println( " -reportWriteStatistics=true, enable per feature statistics for all written features");
         System.out.println( " -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default" );
         System.out.println();
         System.out.println( "Example:" );

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
@@ -30,6 +30,7 @@ package org.deegree.tools.featurestoresql.loader;
 public class GmlLoaderHelpUsage {
 
     public static void printUsage() {
+        // see also the webservices-handbook chapter for the CLI 
         System.out.println( "Usage: java -jar deegree-tools-gml.jar GmlLoader -pathToFile=<path/to/gmlfile> -workspaceName=<workspace_identifier> -sqlFeatureStoreId=<feature_store_identifier> [options]" );
         System.out.println( "Description: Imports a GML file directly into a given deegree SQLFeatureStore" );
         System.out.println();
@@ -39,7 +40,7 @@ public class GmlLoaderHelpUsage {
         System.out.println( " -sqlFeatureStoreId=<feature_store_identifier>, the ID of the SQLFeatureStore in the given workspace" );
         System.out.println();
         System.out.println( "options:" );
-        System.out.println( " -reportWriteStatistics=true, enable per feature statistics for all written features");
+        System.out.println( " -reportWriteStatistics=true, create a summary of all written feature types, disabled by default");
         System.out.println( " -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default" );
         System.out.println();
         System.out.println( "Example:" );

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/ReportWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/ReportWriter.java
@@ -3,6 +3,7 @@
  * deegree-cli-utility
  * %%
  * Copyright (C) 2016 - 2021 lat/lon GmbH
+ * Copyright (C) 2022 grit graphische Informationstechnik Beratungsgesellschaft mbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -43,6 +44,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * Job listener to write final report.
  *
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public class ReportWriter extends JobExecutionListenerSupport {
 
@@ -72,6 +74,7 @@ public class ReportWriter extends JobExecutionListenerSupport {
         ExitStatus exitStatus = stepExecution.getExitStatus();
         try ( PrintWriter writer = new PrintWriter( outFile.toFile() ) ) {
             writer.println( "Start: " + getStartTime( stepExecution ) );
+            writer.println( "End:   " + getEndTime( stepExecution ) );
             writer.println( "Time needed: " + getTimeNeeded( stepExecution ) );
 
             if ( ExitStatus.FAILED.getExitCode().equals( exitStatus.getExitCode() ) ) {
@@ -87,6 +90,12 @@ public class ReportWriter extends JobExecutionListenerSupport {
                 writer.println( "Status: FAILED" );
             } else if ( ExitStatus.COMPLETED.getExitCode().equals( exitStatus.getExitCode() ) ) {
                 writer.println( "Number of processed features: " + summary.getNumberOfFeatures() );
+                if ( summary.getStatistics() != null ) {
+                    writer.println( "Written feature statistics:" );
+                    writer.println( "===========================");
+                    summary.getStatistics().summary( writer::println );
+                    writer.println();
+                }
                 writer.println( "Status: SUCCESS" );
             } else {
                 writer.println( "Status: " + exitStatus );
@@ -128,5 +137,4 @@ public class ReportWriter extends JobExecutionListenerSupport {
             return DATE_FORMAT.format( stepExecution.getEndTime() );
         return "UNKNOWN";
     }
-
 }

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/Summary.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/Summary.java
@@ -3,6 +3,7 @@
  * deegree-cli-utility
  * %%
  * Copyright (C) 2016 - 2021 lat/lon GmbH
+ * Copyright (C) 2022 grit graphische Informationstechnik Beratungsgesellschaft mbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -24,12 +25,13 @@ package org.deegree.tools.featurestoresql.loader;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.springframework.batch.core.StepExecution;
+import javax.xml.namespace.QName;
 
 /**
  * Report summary.
  *
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public class Summary {
 
@@ -39,7 +41,7 @@ public class Summary {
 
     private Set<String> unresolvableReferences = new HashSet<>();
 
-    private StepExecution stepExecution;
+    private FeatureStatistics statistics = null;
 
     /**
      * @param increaseBy
@@ -47,6 +49,17 @@ public class Summary {
      */
     public void increaseNumberOfFeatures( int increaseBy ) {
         this.numberOfFeatures = this.numberOfFeatures + increaseBy;
+    }
+
+    /**
+     * @param increaseBy
+     *            integer to add (positive integer or null)
+     */
+    public void increaseNumberOfFeatures( QName typeName ) {
+        if ( this.statistics != null ) {
+            statistics.increment( typeName );
+        }
+        this.numberOfFeatures++;
     }
 
     /**
@@ -100,4 +113,18 @@ public class Summary {
         return this.commitFailed;
     }
 
+    /**
+     * @return the statistics, may be <code>null</code>
+     */
+    public FeatureStatistics getStatistics() {
+        return statistics;
+    }
+
+    /**
+     * @param statistics
+     *            the statistics to use inside this summary
+     */
+    public void setStatistics( FeatureStatistics statistics ) {
+        this.statistics = statistics;
+    }
 }


### PR DESCRIPTION
This PR builds on top of #1293 

A new command line option has been added to specify the report file name (can include the path)