### PR TITLE
Allow disabling trimming of simple property values in GML reader

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -85,6 +85,7 @@ import org.deegree.commons.tom.ows.StringOrRef;
 import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.uom.Measure;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.commons.xml.CommonNamespaces;
 import org.deegree.commons.xml.XMLAdapter;
 import org.deegree.commons.xml.XMLParsingException;
@@ -139,6 +140,8 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractGMLObjectReader extends XMLAdapter {
 
     private static final Logger LOG = LoggerFactory.getLogger( AbstractGMLObjectReader.class );
+
+    private static final boolean PROPERTY_SIMPLE_TRIM = TunableParameter.get("deegree.gml.property.simple.trim", true);
 
     protected final String gmlNs;
 
@@ -275,7 +278,8 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
             // TODO need to check that element is indeed empty?
             XMLStreamUtils.nextElement( xmlStream );
         } else {
-            property = createSimpleProperty( xmlStream, propDecl, xmlStream.getElementText().trim() );
+            String value = PROPERTY_SIMPLE_TRIM ? xmlStream.getElementText().trim() : xmlStream.getElementText();
+            property = createSimpleProperty( xmlStream, propDecl, value );
         }
         return property;
     }

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
@@ -50,4 +50,7 @@ f
 |deegree.rendering.svg-to-shape.previous |java.lang.Boolean |false |Enables the behavior of previously used versions when scaling SVG graphics for the rendering of strokes
 
 |deegree.rendering.graphicstroke.svg-as-mark |java.lang.Boolean |false |Enables the previous behavior of rendering SVG graphics in `GraphicStroke`/`OnlineResource` like a Mark with the color of the `Stroke` instead of a rendered graphic.
+
+|deegree.gml.property.simple.trim |java.lang.Boolean |true |When deegree reads GML data, by default (`true`) simple property values get their leading and trailing whitespace characters removed.
+
 |===


### PR DESCRIPTION
This PR introduces the new option `deegree.gml.property.simple.trim` which allows disabling of the trimming of white-space characters while reading GML simple property values.

This option was implemented, as a specific data source needed to be imported as is, without the common trimming of white spaces like newlines etc..