### PR TITLE
Unification of tunable parameter usage and their documentation

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/TunableParameter.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/TunableParameter.java
@@ -140,6 +140,12 @@ public class TunableParameter {
         return get( key, Byte.valueOf( defaultValue ) ).byteValue();
     }
 
+    public static void resetCache() {
+        CONFIG_BOOL.clear();
+        CONFIG_NUM.clear();
+        CONFIG_STR.clear();
+    }
+
     private static Number get( String key, Number defaultValue ) {
         boolean has = CONFIG_NUM.containsKey( key );
         Number val = CONFIG_NUM.get( key );

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.deegree.commons.utils.FileUtils;
 import org.deegree.commons.utils.StringUtils;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.coverage.raster.SimpleRaster;
 import org.deegree.coverage.raster.data.RasterDataFactory;
 import org.deegree.coverage.raster.data.nio.ByteBufferRasterData;
@@ -125,7 +126,7 @@ public class RasterCache {
      */
     private static void evaluateProperties() {
         synchronized ( MEM_LOCK ) {
-            String cacheSize = System.getProperty( DEF_RASTER_CACHE_MEM_SIZE );
+            String cacheSize = TunableParameter.get( DEF_RASTER_CACHE_MEM_SIZE, (String)null );
             long mm = StringUtils.parseByteSize( cacheSize );
             if ( mm == 0 ) {
                 if ( StringUtils.isSet( cacheSize ) ) {
@@ -143,11 +144,11 @@ public class RasterCache {
                           ( mm / ( 1024 * 1024 ) ) + "Mb", DEF_RASTER_CACHE_MEM_SIZE );
             }
             maxCacheMem = mm;
-            String t = System.getProperty( DEF_RASTER_CACHE_DISK_SIZE );
+            String t = TunableParameter.get( DEF_RASTER_CACHE_DISK_SIZE, (String)null );
             mm = StringUtils.parseByteSize( t );
             if ( mm == 0 ) {
                 if ( StringUtils.isSet( t ) ) {
-                    LOG.warn( "Ignoring supplied property: {} because it could not be parsed. Using 20G of disk space for raster caching.",
+                    LOG.warn( "Ignoring supplied property: {} because it could not be parsed. Using 20GiB of disk space for raster caching.",
                               DEF_RASTER_CACHE_MEM_SIZE );
                 }
                 mm = 20 * ( 1024l * 1024 * 1024 );

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/IIORasterDataReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/IIORasterDataReader.java
@@ -54,6 +54,7 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.ImageInputStream;
 
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageReader;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.coverage.raster.cache.ByteBufferPool;
 import org.deegree.coverage.raster.cache.RasterCache;
 import org.deegree.coverage.raster.data.container.BufferResult;
@@ -83,7 +84,7 @@ public class IIORasterDataReader implements RasterDataReader {
     private static final boolean CACHE_DISABLED;
 
     static {
-        CACHE_DISABLED = "false".equalsIgnoreCase( System.getProperty( "deegree.raster.cache.iioreader", "true" ));
+        CACHE_DISABLED = !TunableParameter.get( "deegree.raster.cache.iioreader", true );
         if ( !CACHE_DISABLED ) {
             LoggerFactory.getLogger( IIORasterDataReader.class ).info( "IIORaster cache is disabled for file based resources via system property!" );
         }

--- a/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/cache/TestRasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/cache/TestRasterCache.java
@@ -49,6 +49,7 @@ import java.util.UUID;
 import junit.framework.Assert;
 
 import org.deegree.commons.utils.FileUtils;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.coverage.raster.AbstractRaster;
 import org.deegree.coverage.raster.TiledRaster;
 import org.deegree.coverage.raster.container.MemoryTileContainer;
@@ -127,14 +128,15 @@ public class TestRasterCache {
     }
 
     private static void setRasterCache() {
+        TunableParameter.resetCache();
         System.setProperty( RasterCache.DEF_RASTER_CACHE_MEM_SIZE, "4m" );
         System.setProperty( RasterCache.DEF_RASTER_CACHE_DISK_SIZE, "5m" );
         RasterCache.reset( true );
-
     }
 
     private static void resetCache() {
         System.out.println( "class is going down" );
+        TunableParameter.resetCache();
         System.setProperty( RasterCache.DEF_RASTER_CACHE_MEM_SIZE, "" );
         System.setProperty( RasterCache.DEF_RASTER_CACHE_DISK_SIZE, "" );
         RasterCache.reset( true );

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
@@ -33,6 +33,14 @@ like https://tomcat.apache.org/tomcat-9.0-doc/config/context.html#Environment_En
 |===
 |Option |Type |Default Value |Description
 
+|deegree.raster.cache.memsize |java.lang.String | |Size of memory that can be used to cache raster data in memory. By default, half of the memory available for the Java Process running deegree is used. 
+
+|deegree.raster.cache.disksize |java.lang.String |20GiB |Defines the maximum amount of disk space that can be used for caching raster data on disk.
+f
+|deegree.raster.cache.iioreader |java.lang.Boolean |true |Enable caching of raster data at the reader level, enabled by default.
+
+|deegree.protocol.wms.client.fallback |java.lang.Boolean |false |Fall back to the previously used `URLConnection` for requests to remote WMS servers, disabled by default.
+
 |deegree.rendering.stroke.miterlimit |java.lang.Float |10 |When the configured factor is exceeded portrayal changes from JOIN_MITER to JOIN_BEVEL (see https://docs.oracle.com/javase/tutorial/2d/geometry/strokeandfill.html).
 
 |deegree.sqldialect.oracle.optimized_point_storage |java.lang.Boolean |true |Use optimized point storage for 2D points in oracle database.


### PR DESCRIPTION
This PR changed the code so that for all `deegree.*` parameters `TunableParameter` is used.
Also, documentation of previously not mentioned parameters has been added.