### PR TITLE
Make decimal places of numeric values in GetFeatureInfo for cover configurable

### DIFF
--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -261,7 +261,7 @@ public final class ConfigUtils {
                                antialias( alias ).
                                maxFeatures( maxFeats ).
                                featureInfoRadius( rad ).
-                               featureInfoDecimalsPlaces( decimalPlaces ).
+                               featureInfoDecimalPlaces( decimalPlaces ).
                                build();
     }
 

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/ConfigUtils.java
@@ -38,11 +38,13 @@ package org.deegree.layer.config;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
+import java.math.BigInteger;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.deegree.commons.utils.Pair;
 import org.deegree.layer.dims.Dimension;
@@ -219,6 +221,7 @@ public final class ConfigUtils {
         int maxFeats = -1;
         int rad = -1;
         boolean opaque = false;
+        Integer decimalPlaces = null;
         try {
             alias = Antialias.valueOf( cfg.getAntiAliasing() );
         } catch ( Throwable e ) {
@@ -240,6 +243,9 @@ public final class ConfigUtils {
         if ( cfg.getFeatureInfo() != null ) {
             if ( cfg.getFeatureInfo().isEnabled() ) {
                 rad = Math.max( 0, cfg.getFeatureInfo().getPixelRadius().intValue() );
+                decimalPlaces = Optional.ofNullable(cfg.getFeatureInfo().getDecimalPlaces())
+                        .map(BigInteger::intValue)
+                        .orElse(null);
             } else {
                 rad = 0;
             }
@@ -254,7 +260,9 @@ public final class ConfigUtils {
                                interpolation( interpol ).
                                antialias( alias ).
                                maxFeatures( maxFeats ).
-                               featureInfoRadius( rad ).build();
+                               featureInfoRadius( rad ).
+                               featureInfoDecimalsPlaces( decimalPlaces ).
+                               build();
     }
 
     public static Map<String, Dimension<?>> parseDimensions( String layerName, List<DimensionType> dimensions ) {

--- a/deegree-core/deegree-core-layer/src/main/resources/META-INF/schemas/layers/base/base.xsd
+++ b/deegree-core/deegree-core-layer/src/main/resources/META-INF/schemas/layers/base/base.xsd
@@ -101,6 +101,7 @@
           <complexType>
             <attribute name="enabled" type="boolean" default="true"/>
             <attribute name="pixelRadius" type="positiveInteger" default="1"/>
+            <attribute name="decimalPlaces" type="nonNegativeInteger"/>
           </complexType>
         </element>
         <element name="FeatureInfoRadius" type="int" />

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/MapOptions.java
@@ -54,28 +54,47 @@ public class MapOptions {
 
     private boolean opaque;
 
+    private Integer featureInfoDecimalPlaces;
+
     /**
      * Instantiates {@link MapOptions} with default values (quality = null, interpol = null, antialias = null,
-     * maxFeatures = -1, featureInfoRadius = -1)
+     * maxFeatures = -1, featureInfoRadius = -1, opaque = false, featureInfoDecimalPlaces = null)
      *
+     * @deprecated Use {@link MapOptions.Builder} instead.
      */
     public MapOptions() {
-        this( null, null, null, -1, -1 );
+        this( null, null, null, -1, -1, false, null );
     }
 
+    /**
+     * Instantiates {@link MapOptions}
+     *
+     * @deprecated Use {@link MapOptions.Builder} instead.
+     */
     public MapOptions( Quality quality, Interpolation interpol, Antialias antialias, int maxFeatures,
                        int featureInfoRadius ) {
-        this( quality, interpol, antialias, maxFeatures, featureInfoRadius, false );
+        this( quality, interpol, antialias, maxFeatures, featureInfoRadius, false, null );
     }
 
+    /**
+     * Instantiates {@link MapOptions}
+     *
+     * @deprecated Use {@link MapOptions.Builder} instead.
+     */
     public MapOptions( Quality quality, Interpolation interpol, Antialias antialias, int maxFeatures,
                        int featureInfoRadius, boolean opaque ) {
+        this( quality, interpol, antialias, maxFeatures, featureInfoRadius, opaque, null );
+    }
+
+    private MapOptions( Quality quality, Interpolation interpol, Antialias antialias, int maxFeatures,
+                        int featureInfoRadius, boolean opaque, Integer featureInfoDecimalPlaces ) {
         this.quality = quality;
         this.interpol = interpol;
         this.antialias = antialias;
         this.maxFeatures = maxFeatures;
         this.featureInfoRadius = featureInfoRadius;
         this.opaque = opaque;
+        this.featureInfoDecimalPlaces = featureInfoDecimalPlaces;
     }
 
     /**
@@ -166,6 +185,23 @@ public class MapOptions {
      */
     public void setOpaque( boolean opaque ) {
         this.opaque = opaque;
+    }
+
+    /**
+     * @return featureInfoDecimalPlaces, a non <code>null</code> positive value defines the requested number of
+     *         digits after the decimal point to be used for numeric values, if this feature is available
+     */
+    public Integer getFeatureInfoDecimalPlaces() {
+        return featureInfoDecimalPlaces;
+    }
+
+    /**
+     * @param featureInfoDecimalPlaces
+     *            the featureInfoDecimalPlaces to set, a non <code>null</code> positive value defines the requested
+     *            number of digits after the decimal point to be used for numeric values, if this feature is available
+     */
+    public void setFeatureInfoDecimalPlaces( Integer featureInfoDecimalPlaces ) {
+        this.featureInfoDecimalPlaces = featureInfoDecimalPlaces;
     }
 
     /**
@@ -297,6 +333,10 @@ public class MapOptions {
 
         private int featureInfoRadius = -1;
 
+        private boolean opaque;
+
+        private Integer featureInfoDecimalPlaces;
+
         /**
          * @param quality
          *            the quality to set
@@ -342,8 +382,30 @@ public class MapOptions {
             return this;
         }
 
+        /**
+         * @param opaque
+         *            set if layer is opaque
+         */
+        public Builder opaque( boolean opaque ) {
+            this.opaque = opaque;
+            return this;
+        }
+
+        /**
+         * @param featureInfoDecimalPlaces
+         *            the featureInfoDecimalPlaces to set, a non <code>null</code> positive value defines the requested
+         *            number of digits after the decimal point to be used for numeric values, if this feature is
+         *            available
+         */
+        public Builder featureInfoDecimalPlaces( Integer featureInfoDecimalPlaces ) {
+            this.featureInfoDecimalPlaces = featureInfoDecimalPlaces;
+            return this;
+        }
+
+
         public MapOptions build() {
-            return new MapOptions( quality, interpolation, antialias, maxFeatures, featureInfoRadius );
+            return new MapOptions( quality, interpolation, antialias, maxFeatures, featureInfoRadius, opaque,
+                                   featureInfoDecimalPlaces );
         }
 
     }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayer.java
@@ -40,6 +40,7 @@ import static org.deegree.coverage.raster.interpolation.InterpolationType.NEARES
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.coverage.rangeset.RangeSet;
@@ -50,6 +51,7 @@ import org.deegree.geometry.Envelope;
 import org.deegree.layer.AbstractLayer;
 import org.deegree.layer.LayerQuery;
 import org.deegree.layer.metadata.LayerMetadata;
+import org.deegree.rendering.r2d.context.MapOptions;
 import org.deegree.rendering.r2d.context.MapOptions.Interpolation;
 import org.deegree.style.StyleRef;
 import org.deegree.style.se.unevaluated.Style;
@@ -161,7 +163,7 @@ public class CoverageLayer extends AbstractLayer {
             return new CoverageLayerData( raster, bbox, query.getWidth(), query.getHeight(),
                                           InterpolationType.NEAREST_NEIGHBOR, filter, style,
                                           getMetadata().getFeatureTypes().get( 0 ), dimensionHandler, featureInfoMode,
-                                          query.getX(), query.getY() );
+                                          query.getX(), query.getY(), getFeatureInfoDecimalPlaces() );
 
         } catch ( OWSException e ) {
             throw e;
@@ -172,4 +174,10 @@ public class CoverageLayer extends AbstractLayer {
         return null;
     }
 
+    private Integer getFeatureInfoDecimalPlaces() {
+        return Optional.of( getMetadata() ) //
+                .map( LayerMetadata::getMapOptions ) //
+                .map( MapOptions::getFeatureInfoDecimalPlaces ) //
+                .orElse( null );
+    }
 }

--- a/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayerData.java
+++ b/deegree-layers/deegree-layers-coverage/src/main/java/org/deegree/layer/persistence/coverage/CoverageLayerData.java
@@ -97,16 +97,18 @@ public class CoverageLayerData implements LayerData {
 
     private final int infoPosY;
 
+    private final Integer featureInfoDecimalPlaces;
+
     public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
                               RangeSet filter, Style style, FeatureType featureType,
                               CoverageFeatureInfoMode featureInfoMode ) {
-        this( raster, bbox, width, height, interpol, filter, style, featureType, null, featureInfoMode, -1, -1 );
+        this( raster, bbox, width, height, interpol, filter, style, featureType, null, featureInfoMode, -1, -1, null );
     }
 
     public CoverageLayerData( AbstractRaster raster, Envelope bbox, int width, int height, InterpolationType interpol,
                               RangeSet filter, Style style, FeatureType featureType,
                               CoverageDimensionHandler dimensionHandler, CoverageFeatureInfoMode featureInfoMode,
-                              int infoPosX, int infoPosY ) {
+                              int infoPosX, int infoPosY, Integer featureInfoDecimalPlaces ) {
         this.raster = raster;
         this.bbox = bbox;
         this.width = width;
@@ -119,6 +121,7 @@ public class CoverageLayerData implements LayerData {
         this.featureInfoMode = featureInfoMode;
         this.infoPosX = infoPosX;
         this.infoPosY = infoPosY;
+        this.featureInfoDecimalPlaces = featureInfoDecimalPlaces;
     }
 
     @Override
@@ -176,7 +179,7 @@ public class CoverageLayerData implements LayerData {
     @Override
     public FeatureCollection info() {
         CoverageFeatureInfoHandler handler = new CoverageFeatureInfoHandler( raster, bbox, featureType, interpol,
-                                                                             dimensionHandler );
+                                                                             dimensionHandler, featureInfoDecimalPlaces );
         if ( featureInfoMode == CoverageFeatureInfoMode.POINT ) {
             return handler.handleFeatureInfoPoint( infoPosX, infoPosY, width, height );
         } else {

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataMerger.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataMerger.java
@@ -156,7 +156,7 @@ class LayerMetadataMerger {
 
     private void adjustMapOptions( LayerMetadata themeMetadata, int queryable, boolean opaque, int cascaded ) {
         if ( themeMetadata.getMapOptions() == null ) {
-            themeMetadata.setMapOptions( new MapOptions() );
+            themeMetadata.setMapOptions( new MapOptions.Builder().build() );
         }
         if ( queryable == QUERYABLE_DISABLED_MASK ) {
             themeMetadata.getMapOptions().setFeatureInfoRadius( 0 );

--- a/deegree-services/deegree-services-wms/src/test/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataMergerTest.java
+++ b/deegree-services/deegree-services-wms/src/test/java/org/deegree/services/wms/controller/capabilities/theme/LayerMetadataMergerTest.java
@@ -165,13 +165,13 @@ public class LayerMetadataMergerTest {
 
     @Test
     public void mergeThemeWithTwoSubthemesWithTwoLayersWithOpaqueAndWithoutOpaque() {
-        final MapOptions mapOptionsWithOpaque = new MapOptions( null, null, null, -1, -1, true );
+        final MapOptions mapOptionsWithOpaque = new MapOptions.Builder().opaque( true ).build();
         final Layer layerWithOpaque = createLayer( "LayerWithOpaque", -180.0, -90.0, 180.0, 90, mapOptionsWithOpaque );
         final List<Layer> layersWithOpaque = Collections.singletonList( layerWithOpaque );
         final Theme subThemeWithOpaque = createTheme( "SubthemeWithOpaque", -180.0, -90.0, 180.0, 90, layersWithOpaque,
                                                       null, null );
 
-        final MapOptions mapOptionsWithoutOpaque = new MapOptions( null, null, null, -1, -1, false );
+        final MapOptions mapOptionsWithoutOpaque = new MapOptions.Builder().opaque( false ).build();
         final Layer layerWithoutOpaque = createLayer( "LayerWithoutOpaque", -180.0, -90.0, 180.0, 90,
                                                       mapOptionsWithoutOpaque );
         final List<Layer> layersWithoutOpaque = Collections.singletonList( layerWithoutOpaque );

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/layers.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/layers.adoc
@@ -307,6 +307,11 @@ disabled (default is true)
 
 |FeatureInfo |0..1 |None |attribute _pixelRadius_: Number of pixels to
 consider when doing GetFeatureInfo, default is 1
+
+|FeatureInfo |0..1 |None |attribute _decimalPlaces_: Desired number of
+digits after the decimal point when returning numeric values in
+GetFeatureInfo, default is unbounded. Currently limited to 
+GetFeatureInfo for coverage (raster) data.
 |===
 
 Here is an example snippet:


### PR DESCRIPTION
This PR extends the GetFeatureInfo configuration and adds the new attribute `decimalPlaces`.
The intended use-case is to request a fixed number of decimal digits on numerical data extracted from coverage data.

On coverage (raster) data, feature info gets sampled or aggregated, so that it is not unusual to have many decimal digits, which can lead to a false interpretation of accuracy.

**Note on MapOptions:** During the integration of the changes into the current `main` the remaining uses of MapOptions constructors was cleaned up to use the previously introduced `MapOptions.Builder`.