### PR TITLE
Dependency updates for deegree 3.4 (backport from 3.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1089,7 +1089,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.2.4</version>
+        <version>2.8.9</version>
       </dependency>
       <dependency>
         <groupId>org.deegree</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1017,7 +1017,7 @@
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
-        <version>10.9.1.0</version>
+        <version>10.14.2.0</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -729,7 +729,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.3</version>
+        <version>42.4.1</version>
       </dependency>
       <!-- Oracle (Offical provided driver from repo1.maven.org) -->
       <dependency>


### PR DESCRIPTION
Cherry-picked dependabot PRs we also want to merge into 3.4.

fixes #1370