### PR TITLE
Prevent serialization of exceptions with "null" message

### DIFF
--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CswExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CswExceptionReportSerializer.java
@@ -101,7 +101,7 @@ public class CswExceptionReportSerializer extends XMLExceptionSerializer {
             writer.writeAttribute( "locator", ex.getLocator() );
         }
         writer.writeStartElement( OWS_NS, "ExceptionText" );
-        writer.writeCharacters( ex.getMessage() );
+        writer.writeCharacters( ex.getMessage() != null ? ex.getMessage() : "not available" );
         writer.writeEndElement();
         writer.writeEndElement(); // Exception
         writer.writeEndElement(); // ExceptionReport

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/WCS100ServiceExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/WCS100ServiceExceptionReportSerializer.java
@@ -73,7 +73,7 @@ public class WCS100ServiceExceptionReportSerializer extends XMLExceptionSerializ
         if ( ex.getLocator().length() > 0 ) {
             writer.writeAttribute( "locator", ex.getLocator() );
         }
-        writer.writeCharacters( ex.getMessage() );
+        writer.writeCharacters( ex.getMessage() != null ? ex.getMessage() : "not available" );
         writer.writeEndElement(); // ServiceException
         writer.writeEndElement(); // ServiceExceptionReport
     }

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMS111ExceptionReportSerializer.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMS111ExceptionReportSerializer.java
@@ -63,7 +63,7 @@ public class WMS111ExceptionReportSerializer extends XMLExceptionSerializer {
         if ( ex.getLocator() != null && !"".equals( ex.getLocator().trim() ) ) {
             writer.writeAttribute( "locator", ex.getLocator() );
         }
-        writer.writeCharacters( ex.getMessage() );
+        writer.writeCharacters( ex.getMessage() != null ? ex.getMessage() : "not available" );
         writer.writeEndElement(); // ServiceException
         writer.writeEndElement(); // ServiceExceptionReport
     }


### PR DESCRIPTION
Currently serialized NullPointerExceptions are written with a message of `null`, which should be avoided.