### PR TITLE
Prevent improper rendering of SVG graphics

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/SvgRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/SvgRenderer.java
@@ -1,4 +1,3 @@
-//$HeadURL$
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
  Copyright (C) 2001-2010 by:
@@ -64,6 +63,7 @@ import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.batik.transcoder.image.PNGTranscoder;
 import org.deegree.commons.utils.ComparablePair;
+import org.deegree.commons.utils.TunableParameter;
 import org.deegree.style.styling.components.Graphic;
 import org.slf4j.Logger;
 
@@ -73,34 +73,36 @@ import com.sun.media.jai.codec.MemoryCacheSeekableStream;
  * Renders svg images onto buffered images.
  * 
  * @author <a href="mailto:schmitz@occamlabs.de">Andreas Schmitz</a>
- * @author last edited by: $Author: mschneider $
- * 
- * @version $Revision: 31882 $, $Date: 2011-09-15 02:05:04 +0200 (Thu, 15 Sep 2011) $
  */
 class SvgRenderer {
 
     private static final Logger LOG = getLogger( SvgRenderer.class );
 
-    final LinkedHashMap<ComparablePair<String, Integer>, BufferedImage> svgCache = new LinkedHashMap<ComparablePair<String, Integer>, BufferedImage>(
-                                                                                                                                                      256 ) {
+    private final int cacheSize = TunableParameter.get( "deegree.cache.svgrenderer", 256 );
+
+    final LinkedHashMap<String, BufferedImage> svgCache = new LinkedHashMap<>( cacheSize ) {
         private static final long serialVersionUID = -6847956873232942891L;
 
         @Override
-        protected boolean removeEldestEntry( Map.Entry<ComparablePair<String, Integer>, BufferedImage> eldest ) {
-            return size() > 256; // yeah, hardcoded max size... TODO
+        protected boolean removeEldestEntry( Map.Entry<String, BufferedImage> eldest ) {
+            return size() > cacheSize;
         }
     };
 
     BufferedImage prepareSvg( Rectangle2D.Double rect, Graphic g ) {
         BufferedImage img = null;
-        ComparablePair<String, Integer> cp = new ComparablePair<String, Integer>( g.imageURL, round( g.size ) );
-        if ( svgCache.containsKey( cp ) ) {
-            img = svgCache.get( cp );
+        final String cacheKey = createCacheKey( g.imageURL, rect.width, rect.height );
+        if ( svgCache.containsKey( cacheKey ) ) {
+            img = svgCache.get( cacheKey );
         } else {
             PNGTranscoder t = new PNGTranscoder();
 
-            t.addTranscodingHint( KEY_WIDTH, new Float( rect.width ) );
-            t.addTranscodingHint( KEY_HEIGHT, new Float( rect.height ) );
+            if ( rect.width > 0.0d ) {
+                t.addTranscodingHint( KEY_WIDTH, new Float( rect.width ) );
+            }
+            if ( rect.height > 0.0d ) {
+                t.addTranscodingHint( KEY_HEIGHT, new Float( rect.height ) );
+            }
 
             TranscoderInput input = new TranscoderInput( g.imageURL );
 
@@ -110,7 +112,6 @@ class SvgRenderer {
             TranscoderOutput output = new TranscoderOutput( out );
             InputStream in = null;
 
-            // TODO cache images
             try {
                 t.transcode( input, output );
                 out.flush();
@@ -118,7 +119,7 @@ class SvgRenderer {
                 MemoryCacheSeekableStream mcss = new MemoryCacheSeekableStream( in );
                 RenderedOp rop = create( "stream", mcss );
                 img = rop.getAsBufferedImage();
-                svgCache.put( cp, img );
+                svgCache.put( cacheKey, img );
             } catch ( TranscoderException e ) {
                 LOG.warn( "Could not rasterize svg '{}': {}", g.imageURL, e.getLocalizedMessage() );
             } catch ( IOException e ) {
@@ -131,4 +132,7 @@ class SvgRenderer {
         return img;
     }
 
+    String createCacheKey( String url, double width, double height ) {
+        return String.format( "%s_%d_%d", url, round( width ), round( height ) );
+    }
 }

--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/SvgRendererTests.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/SvgRendererTests.java
@@ -1,0 +1,81 @@
+package org.deegree.rendering.r2d;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.deegree.style.styling.components.Graphic;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class SvgRendererTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger( SvgRendererTests.class );
+
+    @Parameters(name = "{index}: {4} {2}x{3} => {0}x{1}")
+    public static Collection<Object[]> data() {
+        // target width, height, rectWidth, rectHeight, file
+        return Arrays.asList( new Object[][] {
+                                               //
+                                               { 183, 100, 0, 100, "svg_w200_h100_border10.svg" },
+                                               { 100, 55, 100, 0, "svg_w200_h100_border10.svg" },
+                                               { 100, 100, 100, 100, "svg_w200_h100_border10.svg" },
+                                               { 220, 120, 0, 0, "svg_w200_h100_border10.svg" },
+                                               { 200, 100, 0, 100, "svg_w200_h100_no_border.svg" },
+                                               { 100, 50, 100, 0, "svg_w200_h100_no_border.svg" },
+                                               { 100, 100, 100, 100, "svg_w200_h100_no_border.svg" },
+                                               { 200, 100, 0, 0, "svg_w200_h100_no_border.svg" },
+                                               //
+                                               { 100, 183, 100, 0, "svg_w100_h200_border10.svg" },
+                                               { 55, 100, 0, 100, "svg_w100_h200_border10.svg" },
+                                               { 100, 100, 100, 100, "svg_w100_h200_border10.svg" },
+                                               { 120, 220, 0, 0, "svg_w100_h200_border10.svg" },
+                                               { 100, 200, 100, 0, "svg_w100_h200_no_border.svg" },
+                                               { 50, 100, 0, 100, "svg_w100_h200_no_border.svg" },
+                                               { 100, 100, 100, 100, "svg_w100_h200_no_border.svg" },
+                                               { 100, 200, 0, 0, "svg_w100_h200_no_border.svg" }, } );
+    }
+
+    @Parameter(0)
+    public int requiredWidth;
+
+    @Parameter(1)
+    public int requiredHeight;
+
+    @Parameter(2)
+    public int requestedWidth;
+
+    @Parameter(3)
+    public int requestedHeight;
+
+    @Parameter(4)
+    public String fileName;
+
+    @Test
+    public void testGeneratedImage()
+                            throws IOException {
+        Rectangle2D.Double rect = new Rectangle2D.Double( 0, 0, requestedWidth, requestedHeight );
+        Graphic g = new Graphic();
+        //
+        g.size = requestedHeight > 0 ? requestedHeight : -requestedWidth;
+        g.imageURL = getClass().getResource( "svgtests/" + fileName ).toExternalForm();
+
+        BufferedImage img = ( new SvgRenderer() ).prepareSvg( rect, g );
+
+        assertNotNull( img );
+        LOG.info( "generated image w: {} h: {} from: {}", img.getWidth(), img.getHeight(), fileName );
+        assertEquals( requiredWidth, img.getWidth() );
+        assertEquals( requiredHeight, img.getHeight() );
+    }
+}

--- a/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w100_h200_border10.svg
+++ b/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w100_h200_border10.svg
@@ -1,0 +1,6 @@
+<svg height="220" version="1.1" width="120" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative; top: -0.875px;">
+  <rect x="10" y="10" width="100" height="200" rx="0" ry="0" fill="#00ffff" stroke="#000000" stroke-width="5">
+  </rect>
+  <path fill="none" stroke="#000000" d="M110,10L10,210" stroke-width="5">
+  </path>
+</svg>

--- a/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w100_h200_no_border.svg
+++ b/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w100_h200_no_border.svg
@@ -1,0 +1,6 @@
+<svg height="200" version="1.1" width="100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative; top: -0.875px;">
+  <rect x="0" y="0" width="100" height="200" rx="0" ry="0" fill="#00ffff" stroke="#000000" stroke-width="5">
+  </rect>
+  <path fill="none" stroke="#000000" d="M100,0L0,200" stroke-width="5">
+  </path>
+</svg>

--- a/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w200_h100_border10.svg
+++ b/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w200_h100_border10.svg
@@ -1,0 +1,6 @@
+<svg height="120" version="1.1" width="220" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative; top: -0.8125px;">
+  <rect x="10" y="10" width="200" height="100" rx="0" ry="0" fill="#00ffff" stroke="#000000" stroke-width="5">
+  </rect>
+  <path fill="none" stroke="#000000" d="M10,110L210,10" stroke-width="5">
+  </path>
+</svg>

--- a/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w200_h100_no_border.svg
+++ b/deegree-core/deegree-core-rendering-2d/src/test/resources/org/deegree/rendering/r2d/svgtests/svg_w200_h100_no_border.svg
@@ -1,0 +1,6 @@
+<svg height="100" version="1.1" width="200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative; top: -0.8125px;">
+  <rect x="0" y="0" width="200" height="100" rx="0" ry="0" fill="#00ffff" stroke="#000000" stroke-width="5">
+  </rect>
+  <path fill="none" stroke="#000000" d="M0,100L200,0" stroke-width="5">
+  </path>
+</svg>

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/ShapeHelper.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/ShapeHelper.java
@@ -1,4 +1,3 @@
-//$HeadURL: svn+ssh://aschmitz@deegree.wald.intevation.de/deegree/deegree3/trunk/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/RenderHelper.java $
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
  Copyright (C) 2001-2009 by:
@@ -65,6 +64,7 @@ import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.gvt.GVTTreeWalker;
 import org.apache.batik.gvt.GraphicsNode;
 import org.apache.batik.gvt.RootGraphicsNode;
+import org.apache.xerces.parsers.SAXParser;
 import org.deegree.style.styling.components.Mark;
 import org.slf4j.Logger;
 import org.w3c.dom.svg.SVGDocument;
@@ -263,7 +263,7 @@ public class ShapeHelper {
      */
     public static Shape getShapeFromSvg( InputStream in, String url ) {
         try {
-            SAXSVGDocumentFactory fac = new SAXSVGDocumentFactory( "org.apache.xerces.parsers.SAXParser" );
+            SAXSVGDocumentFactory fac = new SAXSVGDocumentFactory( SAXParser.class.getName() );
             SVGDocument doc = fac.createSVGDocument( url, in );
             GVTBuilder builder = new GVTBuilder();
             UserAgent userAgent = new UserAgentAdapter();

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
@@ -45,4 +45,6 @@ f
 
 |deegree.sqldialect.oracle.optimized_point_storage |java.lang.Boolean |true |Use optimized point storage for 2D points in oracle database.
 
+|deegree.cache.svgrenderer |java.lang.Integer |256 |Maximum number of rendered SVG images to be cached for speed
+
 |===


### PR DESCRIPTION
This PR is a part of the larger PR #1207

It contains corrections that avoid misrepresentation when height or width are undefined. 

The modification in the ShapeHelper does not change the current behavior of the class.
It only converts the soft reference to a compile-time reference, so that if Xerces may be removed in future the dependence becomes recognizable.