### PR TITLE
Extend the serialization of SQL/MM (curved) geometries to WKT 

### DIFF
--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKTWriter.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKTWriter.java
@@ -1,4 +1,3 @@
-//$HeadURL$
 /*----------------------------------------------------------------------------
  This file is part of deegree, http://deegree.org/
  Copyright (C) 2001-2009 by:
@@ -47,6 +46,7 @@ import java.util.Set;
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometry;
+import org.deegree.geometry.GeometryException;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.composite.CompositeCurve;
 import org.deegree.geometry.composite.CompositeGeometry;
@@ -64,14 +64,17 @@ import org.deegree.geometry.multi.MultiSurface;
 import org.deegree.geometry.points.Points;
 import org.deegree.geometry.precision.PrecisionModel;
 import org.deegree.geometry.primitive.Curve;
+import org.deegree.geometry.primitive.Curve.CurveType;
 import org.deegree.geometry.primitive.GeometricPrimitive;
 import org.deegree.geometry.primitive.LineString;
 import org.deegree.geometry.primitive.LinearRing;
 import org.deegree.geometry.primitive.Point;
 import org.deegree.geometry.primitive.Polygon;
 import org.deegree.geometry.primitive.Ring;
+import org.deegree.geometry.primitive.Ring.RingType;
 import org.deegree.geometry.primitive.Solid;
 import org.deegree.geometry.primitive.Surface;
+import org.deegree.geometry.primitive.Surface.SurfaceType;
 import org.deegree.geometry.primitive.Tin;
 import org.deegree.geometry.primitive.patches.GriddedSurfacePatch;
 import org.deegree.geometry.primitive.patches.PolygonPatch;
@@ -89,6 +92,7 @@ import org.deegree.geometry.primitive.segments.CircleByCenterPoint;
 import org.deegree.geometry.primitive.segments.Clothoid;
 import org.deegree.geometry.primitive.segments.CubicSpline;
 import org.deegree.geometry.primitive.segments.CurveSegment;
+import org.deegree.geometry.primitive.segments.CurveSegment.CurveSegmentType;
 import org.deegree.geometry.primitive.segments.Geodesic;
 import org.deegree.geometry.primitive.segments.GeodesicString;
 import org.deegree.geometry.primitive.segments.LineStringSegment;
@@ -103,9 +107,7 @@ import org.slf4j.Logger;
  * 
  * @author <a href="mailto:thomas@lat-lon.de">Steffen Thomas</a>
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
- * @author last edited by: $Author$
- * 
- * @version $Revision$, $Date$
+ * @author <a href="mailto:reichhelm@grit.de">Stephan Reichhelm</a>
  */
 public class WKTWriter {
 
@@ -123,9 +125,6 @@ public class WKTWriter {
      * The flag is used to specify which geometric operations the database is capable of
      * 
      * @author <a href="mailto:thomas@lat-lon.de">Steffen Thomas</a>
-     * @author last edited by: $Author$
-     * 
-     * @version $Revision$, $Date$
      */
     public enum WKTFlag {
         /** Export can use ENVELOPE */
@@ -210,6 +209,7 @@ public class WKTWriter {
      *            that is used
      * @throws IOException
      */
+    @SuppressWarnings("unchecked")
     public void writeGeometry( Geometry geometry, Writer writer )
                             throws IOException {
 
@@ -465,12 +465,39 @@ public class WKTWriter {
      */
     public void writePolygon( Polygon geometry, Writer writer )
                             throws IOException {
-
-        writer.append( "POLYGON " );
+        if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
+            if ( isCompoundPolyogn( geometry ) ) {
+                writeCurvePolygon( geometry, writer );
+                return;
+            } else {
+                writer.append( "POLYGON " );
+            }
+        } else {
+            writer.append( "POLYGON " );
+        }
         if ( flags.contains( WKTFlag.USE_DKT ) ) {
             appendObjectProps( writer, geometry );
         }
         writePolygonWithoutPrefix( geometry, writer );
+    }
+
+    private void writeCurvePolygon( Polygon geometry, Writer writer )
+                            throws IOException {
+        writer.append( "CURVEPOLYGON " );
+        writer.append( "(" );
+        writeCurvePolygonWithoutPrefix( geometry, writer );
+        writer.append( ')' );
+    }
+
+    private void writeCurvePolygonWithoutPrefix( Polygon geometry, Writer writer )
+                            throws IOException {
+        writeCurveGeometry( geometry.getExteriorRing(), writer );
+
+        for ( Ring ring : geometry.getInteriorRings() ) {
+            writer.append( ',' );
+            writeCurveGeometry( ring, writer );
+
+        }
     }
 
     /**
@@ -573,8 +600,20 @@ public class WKTWriter {
         } else if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
             writer.append( "COMPOUNDCURVE " );
             writer.append( '(' );
-            // TODO implementation here; no values commited
-
+            int counter = 0;
+            for ( Curve c : geometry ) {
+                counter++;
+                if ( c.getCurveType() == CurveType.LineString ) {
+                    writer.append( '(' );
+                    writeLineStringWithoutPrefix( (LineString) c, writer );
+                    writer.append( ')' );
+                } else {
+                    writeCurve( c, writer );
+                }
+                if ( counter != geometry.size() ) {
+                    writer.append( ',' );
+                }
+            }
         } else {
 
             List<Curve> l = geometry.subList( 0, geometry.size() );
@@ -608,12 +647,16 @@ public class WKTWriter {
             writeCurveSegments( geometry, writer );
             writer.append( ')' );
         } else if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
-
-            // s.append( "COMPOUNDCURVE(" );
-            throw new UnsupportedOperationException( "Handling curves within 'SQL-MM Part 3' is not implemented yet." );
-
+            int segments = geometry.getCurveSegments().size();
+            if ( segments > 1 ) {
+                writer.write( "COMPOUNDCURVE (" );
+            }
+            writeCurveSegments( geometry, writer );
+            if ( segments > 1 ) {
+                writer.write( ')' );
+            }
         } else {
-            CurveLinearizer cl = new CurveLinearizer( new GeometryFactory() );
+            CurveLinearizer cl = linearizer != null ? linearizer : new CurveLinearizer( new GeometryFactory() );
             LinearizationCriterion crit = new NumPointsCriterion( linearizedControlPoints );
             Curve c = cl.linearize( geometry, crit );
 
@@ -635,7 +678,15 @@ public class WKTWriter {
                             throws IOException {
 
         if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
-            throw new UnsupportedOperationException( "Handling curves within 'SQL-MM Part 3' is not implemented yet." );
+            int segments = geometry.getCurveSegments().size();
+            if ( segments > 1 ) {
+                writer.write( "COMPOUNDCURVE (" );
+            }
+            writeCurveSegments( geometry, writer );
+            if ( segments > 1 ) {
+                writer.write( ')' );
+            }
+            return;
         }
         CurveLinearizer cl = new CurveLinearizer( new GeometryFactory() );
         LinearizationCriterion crit = new NumPointsCriterion( linearizedControlPoints );
@@ -852,7 +903,11 @@ public class WKTWriter {
      */
     private void writeArcString( ArcString curve, Writer writer )
                             throws IOException {
-        writer.append( "ARCSTRING " );
+        if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
+            writer.append( "CIRCULARSTRING " );
+        } else {
+            writer.append( "ARCSTRING " );
+        }
         // if(flags.contains( WKTFlag.USE_DKT )){
         // appendObjectProps( writer, (Geometry) arcString );
         // }
@@ -897,7 +952,11 @@ public class WKTWriter {
      */
     private void writeLineStringSegment( LineStringSegment curve, Writer writer )
                             throws IOException {
-        writer.append( "LINESTRINGSEGMENT " );
+        if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
+            // write nothing
+        } else {
+            writer.append( "LINESTRINGSEGMENT " );
+        }
         // if(flags.contains( WKTFlag.USE_DKT )){
         // appendObjectProps( writer, (Geometry) createLineStringSegment );
         // }
@@ -922,7 +981,12 @@ public class WKTWriter {
      */
     private void writeArc( Arc curve, Writer writer )
                             throws IOException {
-        writer.append( "ARC " );
+        if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
+            writer.append( "CIRCULARSTRING " );
+        } else {
+            writer.append( "ARC " );
+        }
+
         // if(flags.contains( WKTFlag.USE_DKT )){
         // appendObjectProps( writer, (Geometry) createArc );
         // }
@@ -1046,6 +1110,7 @@ public class WKTWriter {
      * @param writer
      * @throws IOException
      */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void writeMultiGeometry( MultiGeometry<? extends Geometry> geometry, Writer writer )
                             throws IOException {
 
@@ -1096,7 +1161,31 @@ public class WKTWriter {
      */
     public void writeMultiSurface( MultiSurface<Surface> geometry, Writer writer )
                             throws IOException {
-        writer.append( "MULTIPOLYGON " );
+        if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
+            writer.append( "MULTISURFACE " );
+            writer.write( '(' );
+            int counter = 0;
+            for ( Surface surface : geometry ) {
+                counter++;
+                if ( surface.getSurfaceType() == SurfaceType.Polygon ) {
+                    if ( isCompoundPolyogn( (Polygon) surface ) ) {
+                        writeCurvePolygon( (Polygon) surface, writer );
+                    } else {
+                        writer.write( '(' );
+                        writeCurvePolygonWithoutPrefix( (Polygon) surface, writer );
+                        writer.write( ')' );
+                    }
+                } else {
+                    writeSurface( surface, writer );
+                }
+                if ( counter < geometry.size() )
+                    writer.write( ',' );
+            }
+            writer.write( ')' );
+            return;
+        } else {
+            writer.append( "MULTIPOLYGON " );
+        }
         if ( flags.contains( WKTFlag.USE_DKT ) ) {
             appendObjectProps( writer, geometry );
         }
@@ -1121,7 +1210,11 @@ public class WKTWriter {
     public void writeMultiCurve( MultiCurve<Curve> geometry, Writer writer )
                             throws IOException {
 
-        writer.append( "MULTILINESTRING " );
+        if ( flags.contains( WKTFlag.USE_SQL_MM ) ) {
+            writer.append( "MULTICURVE " );
+        } else {
+            writer.append( "MULTILINESTRING " );
+        }
         if ( flags.contains( WKTFlag.USE_DKT ) ) {
             appendObjectProps( writer, geometry );
         }
@@ -1315,6 +1408,7 @@ public class WKTWriter {
      * @return a wkt String representation of the given geometry, of the emtpy string if the geometry is
      *         <code>null</code>
      */
+    @SuppressWarnings("unchecked")
     public static String write( Geometry geom ) {
         if ( geom == null ) {
             return "";
@@ -1353,11 +1447,15 @@ public class WKTWriter {
             throw new NullPointerException( "The writer may not be null." );
         }
         Set<WKTFlag> flags = new HashSet<WKTFlag>();
-        int dim =geom.getCoordinateDimension();
-        if (dim == 3){
-            flags.add( WKTWriter.WKTFlag.USE_3D );
-        }
-        else{
+        try {
+            int dim = geom.getCoordinateDimension();
+            if ( dim == 3 ) {
+                flags.add( WKTWriter.WKTFlag.USE_3D );
+            } else {
+                flags = null;
+            }
+        } catch ( GeometryException gex ) {
+            // ignore dimension on empty geometries
             flags = null;
         }
         WKTWriter wktW = new WKTWriter( flags, null );
@@ -1386,5 +1484,68 @@ public class WKTWriter {
             writer.append( "" );
         writer.append( '\'' );
         writer.append( ']' );
+    }
+
+    /**
+     * Test if Polygon is made from compound rings
+     * 
+     * @return true if the polygon is constructed from non-linear rings, rings which are non-linear or rings with
+     *         contains more than one segment
+     */
+    private boolean isCompoundPolyogn( Polygon geometry ) {
+        if ( isCompoundRing( geometry.getExteriorRing() ) ) {
+            return true;
+        }
+        for ( Ring ring : geometry.getInteriorRings() ) {
+            if ( isCompoundRing( ring ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Test if Ring is compound (non-linear or made from more than one segment)
+     * 
+     * @return true if the ring is non-linear or the ring is made from more than one segment
+     */
+    private boolean isCompoundRing( Ring geometry ) {
+        if ( geometry.getRingType() == RingType.LinearRing ) {
+            return false;
+        } else {
+            if ( geometry.getMembers().size() > 1 )
+                return true;
+
+            for ( Curve c : geometry.getMembers() ) {
+                if ( isCompoundCurve( c ) ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Test if Curve is compound (non-linear or made from more than one segment)
+     * 
+     * @return true if the curve is non-linear or the curve is made from more than one segment
+     */
+    private boolean isCompoundCurve( Curve geometry ) {
+        if ( geometry.getCurveType() == CurveType.LineString ) {
+            return false;
+        } else if ( geometry.getCurveType() == CurveType.Ring ) {
+            return isCompoundRing( (Ring) geometry );
+        } else if ( geometry.getCurveType() == CurveType.Curve ) {
+            List<CurveSegment> segments = geometry.getCurveSegments();
+            if ( segments.size() > 1 )
+                return true;
+
+            for ( CurveSegment seg : segments ) {
+                if ( seg.getSegmentType() != CurveSegmentType.LINE_STRING_SEGMENT ) {
+                    return true;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiCurve.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/standard/multi/DefaultMultiCurve.java
@@ -35,13 +35,13 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.geometry.standard.multi;
 
+import java.util.ArrayList;
 import java.util.List;
-
 import org.deegree.cs.coordinatesystems.ICRS;
 import org.deegree.geometry.multi.MultiCurve;
 import org.deegree.geometry.precision.PrecisionModel;
 import org.deegree.geometry.primitive.Curve;
-
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
 
@@ -82,11 +82,18 @@ public class DefaultMultiCurve extends DefaultMultiGeometry<Curve> implements Mu
 
     @Override
     protected MultiLineString buildJTSGeometry() {
-        LineString[] jtsMembers = new LineString[size()];
-        int i = 0;
+        List<LineString> jtsMembers = new ArrayList<>( size() );
+
         for ( Curve geometry : members ) {
-            jtsMembers[i++] = (LineString) getAsDefaultGeometry( geometry ).getJTSGeometry();
+            Geometry jtsGeom = getAsDefaultGeometry( geometry ).getJTSGeometry();
+            if ( jtsGeom instanceof MultiLineString ) {
+                for ( int i = 0; i < jtsGeom.getNumGeometries(); i++ ) {
+                    jtsMembers.add( (LineString) jtsGeom.getGeometryN( i ) );
+                }
+            } else {
+                jtsMembers.add( (LineString) jtsGeom );
+            }
         }
-        return jtsFactory.createMultiLineString( jtsMembers );
+        return jtsFactory.createMultiLineString( jtsMembers.toArray( new LineString[0] ) );
     }
 }

--- a/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/io/WKTWriterSqlMMTests.java
+++ b/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/io/WKTWriterSqlMMTests.java
@@ -1,0 +1,105 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2022 by:
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.geometry.io;
+
+import static org.deegree.geometry.io.WKTWriter.WKTFlag.USE_SQL_MM;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Set;
+import org.deegree.geometry.Geometry;
+import org.deegree.geometry.GeometryFactory;
+import org.deegree.geometry.primitive.Curve;
+import org.deegree.geometry.primitive.Point;
+import org.deegree.geometry.primitive.Ring;
+import org.deegree.geometry.primitive.segments.ArcString;
+import org.deegree.geometry.primitive.segments.LineStringSegment;
+import org.junit.Test;
+
+public class WKTWriterSqlMMTests {
+    private static GeometryFactory fac = new GeometryFactory();
+
+    private static WKTWriter wkt = new WKTWriter( Set.of( USE_SQL_MM ), new DecimalCoordinateFormatter( 0 ) );
+
+    @Test
+    public void testPolygonFromArcString()
+                            throws IOException {
+        List<Point> points = List.of( fac.createPoint( null, 0, 0, null ), //
+                                      fac.createPoint( null, 10, 0, null ), //
+                                      fac.createPoint( null, 0, 0, null ) );
+        ArcString circle = fac.createArcString( fac.createPoints( points ) );
+        Ring ring = fac.createRing( null, null, List.of( fac.createCurve( null, null, circle ) ) );
+        Geometry geom = fac.createPolygon( null, null, ring, null );
+
+        StringWriter out = new StringWriter();
+        wkt.writeGeometry( geom, out );
+        assertThat( out.toString(), is( "CURVEPOLYGON (CIRCULARSTRING (0 0,10 0,0 0))" ) );
+    }
+
+    @Test
+    public void testCurveArcString()
+                            throws IOException {
+        List<Point> points = List.of( fac.createPoint( null, 0, 0, null ), //
+                                      fac.createPoint( null, 10, 0, null ), //
+                                      fac.createPoint( null, 0, 0, null ) );
+        ArcString circle = fac.createArcString( fac.createPoints( points ) );
+        Curve curve = fac.createCurve( null, null, circle );
+
+        StringWriter out = new StringWriter();
+        wkt.writeCurveGeometry( curve, out );
+        assertThat( out.toString(), is( "CIRCULARSTRING (0 0,10 0,0 0)" ) );
+    }
+
+    @Test
+    public void testCompoundCurve()
+                            throws IOException {
+        List<Point> points = List.of( fac.createPoint( null, 0, 0, null ), //
+                                      fac.createPoint( null, 10, 0, null ), //
+                                      fac.createPoint( null, 0, 0, null ) );
+        ArcString circle = fac.createArcString( fac.createPoints( points ) );
+        LineStringSegment line = fac.createLineStringSegment( fac.createPoints( points ) );
+        Curve curve = fac.createCurve( null, null, circle, line );
+
+        StringWriter out = new StringWriter();
+        wkt.writeCurveGeometry( curve, out );
+        assertThat( out.toString(), is( "COMPOUNDCURVE (CIRCULARSTRING (0 0,10 0,0 0),(0 0,10 0,0 0))" ) );
+    }
+}


### PR DESCRIPTION
This PR is a, reworked, part of the larger PR #1204

This changes optimize the serialization for common geometry types in SQL/MM (like CURVEPOLYGON, CIRCULARSTRING, etc.).
It also extends the linearization code to allow SQL/MM like circles which are defined through the points of the diameter.
This change extends the current code which implements the GML 3.x way of circles, which would be incompatible, to also allow circles like in SQL/MM.

Quote from the GML 3.2 specification
> A Circle is an arc whose ends coincide to form a simple closed loop. The three control points shall be distinct non-co-linear points for the circle to be unambiguously defined. The arc is simply extended past the third control point until the first control point is encountered.

Quote from the PostGIS documentation (SQL/MM Part 3)
> CircularString is the basic curve type, similar to a LineString in the linear world. A single arc segment is specified by three points: the start and end points (first and third) and some other point on the arc. To specify a closed circle the start and end points are the same and the middle point is the opposite point on the circle diameter (which is the center of the arc). In a sequence of arcs the end point of the previous arc is the start point of the next arc, just like the segments of a LineString. This means that a CircularString must have an odd number of points greater than 1.