### PR TITLE
Enable support for 4-band raster data with GdalLayer

### DIFF
--- a/deegree-layers/deegree-layers-gdal/src/main/java/org/deegree/layer/persistence/gdal/GdalLayerData.java
+++ b/deegree-layers/deegree-layers-gdal/src/main/java/org/deegree/layer/persistence/gdal/GdalLayerData.java
@@ -29,6 +29,7 @@ package org.deegree.layer.persistence.gdal;
 
 import static java.awt.color.ColorSpace.CS_sRGB;
 import static java.awt.image.DataBuffer.TYPE_BYTE;
+import static org.deegree.commons.utils.TunableParameter.get;
 import static org.deegree.cs.components.Axis.AO_EAST;
 import static org.deegree.cs.components.Axis.AO_WEST;
 import static org.gdal.gdalconst.gdalconstConstants.CE_None;
@@ -81,6 +82,8 @@ class GdalLayerData implements LayerData {
 
     private static final Logger LOG = getLogger( GdalLayerData.class );
 
+    private static final boolean DEFAULT_LIMIT_BANDS = get( "deegree.gdal.layer.limit_bands", false );
+
     private final List<File> datasets;
 
     private final Envelope bbox;
@@ -119,7 +122,7 @@ class GdalLayerData implements LayerData {
             return null;
         }
         byte[][] bytes = compose( regions );
-        return toImage( bytes, width, height, true );
+        return toImage( bytes, width, height, DEFAULT_LIMIT_BANDS );
     }
 
     private BufferedImage extractAndReprojectRegion( ICRS nativeCrs ) {
@@ -135,7 +138,7 @@ class GdalLayerData implements LayerData {
         byte[][] rawImage = readBands( reprojectedRegion );
         nativeRegion.delete();
         reprojectedRegion.delete();
-        return toImage( rawImage, width, height, true );
+        return toImage( rawImage, width, height, DEFAULT_LIMIT_BANDS );
     }
 
     private Dataset reproject( Dataset src, String dstCrsWkt ) {

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
@@ -45,6 +45,8 @@ f
 
 |deegree.sqldialect.oracle.optimized_point_storage |java.lang.Boolean |true |Use optimized point storage for 2D points in oracle database.
 
+|deegree.gdal.layer.limit_bands |java.lang.Boolean |false |If problems occur with data using four bands (e.g. including transparency or infrared), this option can be used to limit data access to the first three bands.
+
 |deegree.cache.svgrenderer |java.lang.Integer |256 |Maximum number of rendered SVG images to be cached for speed
 
 |deegree.rendering.svg-to-shape.previous |java.lang.Boolean |false |Enables the behavior of previously used versions when scaling SVG graphics for the rendering of strokes


### PR DESCRIPTION
This pull requests changes the default configuration for GdalLayer to not delete band four by default.
It is a replacement for #1067 and introduces a configuration option to get back the old behavior.

Detailed description of problem: #1065

Closes #1067 
Closes #1065