### PR TITLE
Remove jettison from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,11 +767,6 @@
         <version>1.2</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.jettison</groupId>
-        <artifactId>jettison</artifactId>
-        <version>1.5.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.jboss.netty</groupId>
         <artifactId>netty</artifactId>
         <version>3.2.10.Final</version>


### PR DESCRIPTION
Was previously used by deegree-featurestore-geocouch which is uncoupled/oprhanded since 2013.

https://github.com/deegree/deegree3/blob/bdb3e36c2239499ab37eabd39fd1bfde7aa7ca55/uncoupled/orphaned-after-3.2/deegree-featurestore-couchbase/pom.xml#L51-L54