### PR TITLE
Fix conversation of foot within unit of measure handling

### DIFF
--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/UomCalculator.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/UomCalculator.java
@@ -65,8 +65,9 @@ public class UomCalculator {
         case Pixel:
             return in * 0.28 / pixelSize;
         case Foot:
-            // TODO properly convert the res to foot
-            return in / resolution;
+            // Note: Use 1 foot as 12 inches => 30,48 cm
+            // @see http://en.wikipedia.org/wiki/Foot_%28unit%29
+            return in * 0.3048d / resolution;
         case Metre:
             return in / resolution;
         case mm:


### PR DESCRIPTION
Values given in foot where previously handled incorrectly like meter.
Now uses the conversation factor of 0.3048 meter per foot as defined at the [International Yard and Pound Agreement](https://en.wikipedia.org/wiki/International_Yard_and_Pound_Agreement) in 1959.

Source: http://en.wikipedia.org/wiki/Foot_%28unit%29