### PR TITLE
Speed up transcoding SVG to Image

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/SvgImageTranscoder.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/SvgImageTranscoder.java
@@ -1,0 +1,90 @@
+/*----------------------------------------------------------------------------
+ This file is part of deegree, http://deegree.org/
+ Copyright (C) 2001-2010 by:
+ - Department of Geography, University of Bonn -
+ and
+ - lat/lon GmbH -
+ and
+ - grit graphische Informationstechnik Beratungsgesellschaft mbH -
+
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation; either version 2.1 of the License, or (at your option)
+ any later version.
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ details.
+ You should have received a copy of the GNU Lesser General Public License
+ along with this library; if not, write to the Free Software Foundation, Inc.,
+ 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+ Contact information:
+
+ grit graphische Informationstechnik Beratungsgesellschaft mbH
+ Landwehrstr. 143, 59368 Werne
+ Germany
+ http://www.grit.de/
+
+ lat/lon GmbH
+ Aennchenstr. 19, 53177 Bonn
+ Germany
+ http://lat-lon.de/
+
+ Department of Geography, University of Bonn
+ Prof. Dr. Klaus Greve
+ Postfach 1147, 53001 Bonn
+ Germany
+ http://www.geographie.uni-bonn.de/deegree/
+
+ e-mail: info@deegree.org
+ ----------------------------------------------------------------------------*/
+package org.deegree.rendering.r2d;
+
+import java.awt.image.BufferedImage;
+
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.ImageTranscoder;
+
+public class SvgImageTranscoder extends ImageTranscoder {
+
+    public class SvgImageOutput extends TranscoderOutput {
+
+        private BufferedImage image;
+
+        public SvgImageOutput() {
+        }
+
+        public BufferedImage getBufferedImage() {
+            return this.image;
+        }
+
+        public void setImage( BufferedImage image ) {
+            this.image = image;
+        }
+    }
+
+    public SvgImageTranscoder() {
+        super();
+    }
+
+    @Override
+    public BufferedImage createImage( int w, int h ) {
+        return new BufferedImage( w, h, BufferedImage.TYPE_INT_ARGB );
+    }
+
+    @Override
+    public void writeImage( BufferedImage image, TranscoderOutput output )
+                            throws TranscoderException {
+        if ( !( output instanceof SvgImageOutput ) ) {
+            throw new TranscoderException( "TranscoderOutput has to be of type SvgImageOutput" );
+        }
+
+        ( (SvgImageOutput) output ).setImage( image );
+    }
+
+    public SvgImageOutput createOutput() {
+        return new SvgImageOutput();
+    }
+}


### PR DESCRIPTION
This PR was part of #1202 and the SvgImageTranscoder get reworked, as it was used there i a different way.

It replaces the the current way of transcoding (SVG -> PNG-Stream -> BufferedImage) by implementing `org.apache.batik.transcoder.image.ImageTranscoder` which gives direct access to the BufferedImage instead of  using `org.apache.batik.transcoder.image.PNGTranscoder `.

A simple performance comparison was done on my local system by executing the following class five times with 100 iterations each. 
```java
package org.deegree.rendering.r2d;

import java.awt.geom.Rectangle2D;
import java.awt.image.BufferedImage;
import org.deegree.style.styling.components.Graphic;

public class SvgRenderPerformanceTest {

    public static void main( String[] args ) {
        new SvgRenderPerformanceTest().run();
    }

    public void run(){
        Rectangle2D.Double rect = new Rectangle2D.Double( 0, 0, 50, 50 );
        Graphic g = new Graphic();
        g.size = 50;
        g.imageURL = getClass().getResource( "similaritytests/gym.svg"  ).toExternalForm();
        BufferedImage img;

        long  tend, tstart = System.currentTimeMillis();
        for ( int i = 0; i < 100; i++ ) {
            // recreate renderer to prevent cacheing
            img = ( new SvgRenderer() ).prepareSvg( rect, g );
        }
        tend = System.currentTimeMillis();
        System.out.println("100 iteration took " + (tend-tstart)+" ms");

    }
}
```

**This results into roughly 25% less time used to render a single SVG image 100 times.** (Win10, Temurin 11, CPU 6x3.0Ghz)

* Before (ms):
  - 2464
  - 2379
  - 2461
  - 2396
  - 2441
* After/With SvgImageTranscoder (ms):
  - 1813
  - 1812
  - 1798
  - 1834
  - 1855
