### PR TITLE
Update Oracle driver to 19.9.0.0

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -31,7 +31,7 @@ PostgreSQL/PostGIS, Oracle Spatial or Microsoft SQL Server.
 deegree currently supports the following backends:
 
 * PostgreSQL 9.4, 9.5, 9.6 with PostGIS extension 2.3, 2.4, 2.5
-* Oracle Spatial 12c
+* Oracle Spatial 19
 * Microsoft SQL Server 2012
 
 TIP: If you want to use Oracle Spatial or Microsoft SQL Server, you will need

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,6 @@
                     <ignoreClass>com.sun.media.jai.*</ignoreClass>
                     <ignoreClass>com.sun.xml.*</ignoreClass>
                     <ignoreClass>org.w3c.dom.*</ignoreClass>
-                    <ignoreClass>oracle.xml.*</ignoreClass>
                   </ignoreClasses>
                   <scopes>
                     <scope>compile</scope>
@@ -819,66 +818,27 @@
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc8</artifactId>
         <version>${oracle.version}</version>
-        <exclusions>
-          <!-- exclude Java Connection Pool (UCP) -->
-          <exclusion>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ucp</artifactId>
-          </exclusion>
-          <!-- exclude Oracle Wallets and/or the Notification System-->
-          <exclusion>
-            <groupId>com.oracle.database.security</groupId>
-            <artifactId>oraclepki</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.oracle.database.security</groupId>
-            <artifactId>osdt_cert</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.oracle.database.security</groupId>
-            <artifactId>osdt_core</artifactId>
-          </exclusion>
-          <!-- exclude FAN events with UCP and/or the JDBC driver -->
-          <exclusion>
-            <groupId>com.oracle.database.ha</groupId>
-            <artifactId>simplefan</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.oracle.database.ha</groupId>
-            <artifactId>ons</artifactId>
-          </exclusion>
-          <!-- exclude Internationalization -->
-          <exclusion>
-            <groupId>com.oracle.database.nls</groupId>
-            <artifactId>orai18n</artifactId>
-          </exclusion>
-          <!-- exclude XMLType (xmlparserv2) -->
-          <exclusion>
-            <groupId>com.oracle.database.xml</groupId>
-            <artifactId>xmlparserv2</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!-- Oracle GeoRaster -->
       <dependency>
         <groupId>com.oracle</groupId>
         <artifactId>sdoapi</artifactId>
-        <version>12.2.0.1</version>
+        <version>${oracle.version}</version>
       </dependency>
       <dependency>
         <groupId>com.oracle</groupId>
         <artifactId>sdotype</artifactId>
-        <version>12.2.0.1</version>
+        <version>${oracle.version}</version>
       </dependency>
       <dependency>
         <groupId>com.oracle</groupId>
         <artifactId>sdogr</artifactId>
-        <version>12.2.0.1</version>
+        <version>${oracle.version}</version>
       </dependency>
       <dependency>
         <groupId>com.oracle</groupId>
         <artifactId>sdoutl</artifactId>
-        <version>12.2.0.1</version>
+        <version>${oracle.version}</version>
       </dependency>
       <dependency>
         <groupId>com.oracle</groupId>
@@ -1238,7 +1198,7 @@
     <site.dir>${user.home}/Sites</site.dir>
     <java.version>11</java.version>
     <antlr.version>3.5.2</antlr.version>
-    <oracle.version>19.3.0.0</oracle.version>
+    <oracle.version>19.9.0.0</oracle.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
     <spring-boot.version>2.5.12</spring-boot.version>


### PR DESCRIPTION
This PR updates the Oracle dependencies to version 19.9.0.0.
It also removes the duplicate/different dependency, which had previously be manually excluded from the enforcer plugin with `<ignoreClass>oracle.xml.*</ignoreClass>`.

See also Issue #1430