### PR TITLE
Fix table name in generated create index statement

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/PostGISDDLCreator.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/PostGISDDLCreator.java
@@ -134,7 +134,7 @@ public class PostGISDDLCreator extends DDLCreator {
         StringBuffer indexSql = new StringBuffer( "CREATE INDEX " );
         String idxName = createIdxName( table.getTable(), column );
         indexSql.append( idxName );
-        indexSql.append( " ON " ).append( currentFtTable );
+        indexSql.append( " ON " ).append( table.getTable().toLowerCase() );
         indexSql.append( " USING GIST (" ). append( column ).append( " ); " );
         ddls.add( indexSql );
         return ddls;


### PR DESCRIPTION
This PR fixes a bug in SqlFeatureStoreConfigCreator (part of GmlLoader) when generating the create index statement.