### PR TITLE
bump dbcp2 to 2.9.0 and commons-pool2 to 2.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -553,12 +553,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
-        <version>2.7.0</version>
+        <version>2.11.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.7.0</version>
+        <version>2.9.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
PR upgrades Apache DBCP 2.7.0->2.9.0 and Commons Pool 2.7.0->2.11.1