### PR TITLE
Enhanced configuration to hide version reference in header

### DIFF
--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -194,6 +194,8 @@ public class OGCFrontController extends HttpServlet {
 
     private transient String version;
 
+    private boolean isReportDeegreeVersion = false;
+
     /**
      * Returns the only instance of this class.
      * 
@@ -295,11 +297,13 @@ public class OGCFrontController extends HttpServlet {
         return getInstance().modulesInfo;
     }
 
-    private static void addHeaders( HttpServletResponse response ) {
+    private void addHeaders( HttpServletResponse response ) {
         // add cache control headers
         response.addHeader( "Cache-Control", "no-cache, no-store" );
         // add deegree header
-        response.addHeader( "deegree-version", getInstance().version );
+        if ( isReportDeegreeVersion ) {
+            response.addHeader( "deegree-version", getInstance().version );
+        }
     }
 
     /**
@@ -1110,6 +1114,9 @@ public class OGCFrontController extends HttpServlet {
         serviceConfiguration = workspace.getNewWorkspace().getResourceManager( OwsManager.class );
         OwsGlobalConfigLoader loader = workspace.getNewWorkspace().getInitializable( OwsGlobalConfigLoader.class );
         mainConfig = loader.getMainConfig();
+        if ( mainConfig != null && mainConfig.isReportDeegreeVersion() != null ) {
+            this.isReportDeegreeVersion = mainConfig.isReportDeegreeVersion();
+        }
         if ( mainConfig != null ) {
             initHardcodedUrls( mainConfig );
         }

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -85,8 +85,6 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axiom.soap.impl.builder.StAXSOAPModelBuilder;
-import org.apache.axiom.soap.impl.common.SOAP11Factory;
-import org.apache.axiom.soap.impl.common.SOAP12Factory;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileUploadException;
@@ -194,7 +192,7 @@ public class OGCFrontController extends HttpServlet {
 
     private transient String version;
 
-    private boolean isReportDeegreeVersion = false;
+    private boolean addDeegreeVersionToHeader = false;
 
     /**
      * Returns the only instance of this class.
@@ -301,7 +299,7 @@ public class OGCFrontController extends HttpServlet {
         // add cache control headers
         response.addHeader( "Cache-Control", "no-cache, no-store" );
         // add deegree header
-        if ( isReportDeegreeVersion ) {
+        if ( addDeegreeVersionToHeader ) {
             response.addHeader( "deegree-version", getInstance().version );
         }
     }
@@ -1114,8 +1112,8 @@ public class OGCFrontController extends HttpServlet {
         serviceConfiguration = workspace.getNewWorkspace().getResourceManager( OwsManager.class );
         OwsGlobalConfigLoader loader = workspace.getNewWorkspace().getInitializable( OwsGlobalConfigLoader.class );
         mainConfig = loader.getMainConfig();
-        if ( mainConfig != null && mainConfig.isReportDeegreeVersion() != null ) {
-            this.isReportDeegreeVersion = mainConfig.isReportDeegreeVersion();
+        if ( mainConfig != null && mainConfig.isAddDeegreeVersionToHeader() != null ) {
+            this.addDeegreeVersionToHeader = mainConfig.isAddDeegreeVersionToHeader();
         }
         if ( mainConfig != null ) {
             initHardcodedUrls( mainConfig );

--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/controller/controller.xsd
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/controller/controller.xsd
@@ -16,6 +16,7 @@
         <xs:element name="ReportedUrls" type="controller:ReportedUrlsType" minOccurs="0" />
         <xs:element name="DCP" type="controller:DCPType" minOccurs="0" />
       </xs:choice>
+      <xs:element name="ReportDeegreeVersion" type="xs:boolean" minOccurs="0" default="false" />
       <xs:element name="PreventClassloaderLeaks" type="xs:boolean" minOccurs="0" default="true" />
       <xs:element name="RequestLogging" minOccurs="0">
         <xs:complexType>

--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/controller/controller.xsd
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/controller/controller.xsd
@@ -16,7 +16,7 @@
         <xs:element name="ReportedUrls" type="controller:ReportedUrlsType" minOccurs="0" />
         <xs:element name="DCP" type="controller:DCPType" minOccurs="0" />
       </xs:choice>
-      <xs:element name="ReportDeegreeVersion" type="xs:boolean" minOccurs="0" default="false" />
+      <xs:element name="AddDeegreeVersionToHeader" type="xs:boolean" minOccurs="0" default="false" />
       <xs:element name="PreventClassloaderLeaks" type="xs:boolean" minOccurs="0" default="true" />
       <xs:element name="RequestLogging" minOccurs="0">
         <xs:complexType>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -2696,6 +2696,8 @@ specifiying them, their order must be respected.
 |ReportedUrls |0..1 |Complex |Hardcode reported URLs in service
 responses
 
+|AddDeegreeVersionToHeader |0..1 |Boolean |Add header "deegree-version" to each response, default: false
+
 |PreventClassloaderLeaks |0..1 |Boolean |TODO
 
 |RequestLogging |0..1 |Complex |TODO


### PR DESCRIPTION
Fixes #1102.

This PR adds a new element `AddDeegreeVersionToHeader` to the service controller  configuration with default `false` which disables the HTTP header `deegree-version` send in responses.