### PR TITLE
Upgrade JSF Primefaces to v12.0

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -337,12 +337,12 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>11.0.0</version>
+      <version>12.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>11.0.3</version>
+      <version>12.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR updates the JSF Primefaces libraries to version 12.0
See https://www.primefaces.org/primefaces-12-0-2-released/ and change log for more information: https://github.com/primefaces/primefaces/issues?q=is%3Aissue+label%3A12.0.2+is%3Aclosed