### PR TITLE
Refactored deegree-dialect-mssql module and upgraded JDBC driver for SQL Server

### DIFF
--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>net.postgis</groupId>
       <artifactId>postgis-geometry</artifactId>
-      <version>2.5.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -43,8 +43,9 @@
       <artifactId>postgis-jdbc</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>net.postgis</groupId>
+      <artifactId>postgis-geometry</artifactId>
+      <version>2.5.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
           <groupId>com.microsoft.sqlserver</groupId>
           <artifactId>mssql-jdbc</artifactId>
-          <version>7.2.2.jre8</version>
+          <version>10.2.2.jre11</version>
         </dependency>
       </dependencies>
     </profile>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>deegree-core-db</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
@@ -61,14 +61,12 @@ import org.deegree.sqldialect.SortCriterion;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
 import org.deegree.sqldialect.filter.PropertyNameMapper;
 import org.deegree.sqldialect.filter.UnmappableException;
-import org.deegree.sqldialect.filter.mssql.MSSQLGeometryConverter;
-import org.deegree.sqldialect.filter.mssql.MSSQLWhereBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.deegree.sqldialect.AbstractSQLDialect;
 
 /**
- * {@link SQLDialect} for Microsoft SQL databases.
+ * {@link SQLDialect} for Microsoft SQL Server databases.
  * 
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialectProvider.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialectProvider.java
@@ -44,7 +44,7 @@ import org.deegree.sqldialect.SQLDialect;
 import org.slf4j.Logger;
 
 /**
- * {@link SqlDialectProvider} for Microsoft SQL databases.
+ * {@link SqlDialectProvider} for Microsoft SQL Server databases.
  * 
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
  * @author last edited by: $Author: schneider $

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLGeometryConverter.java
@@ -33,7 +33,7 @@
 
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
-package org.deegree.sqldialect.filter.mssql;
+package org.deegree.sqldialect.mssql;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -52,7 +52,7 @@ import org.deegree.geometry.utils.GeometryParticleConverter;
 import org.slf4j.Logger;
 
 /**
- * {@link GeometryParticleConverter} for PostGIS databases.
+ * {@link GeometryParticleConverter} for Microsoft SQL Server databases.
  * 
  * @author <a href="mailto:schneider@lat-lon.de">Markus Schneider</a>
  * @author last edited by: $Author: mschneider $

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilder.java
@@ -33,7 +33,7 @@
 
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
-package org.deegree.sqldialect.filter.mssql;
+package org.deegree.sqldialect.mssql;
 
 import static java.sql.Types.BOOLEAN;
 import static org.deegree.commons.tom.primitive.BaseType.DECIMAL;

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/test/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilderTest.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/test/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilderTest.java
@@ -33,7 +33,7 @@
 
  e-mail: info@deegree.org
  ----------------------------------------------------------------------------*/
-package org.deegree.sqldialect.filter.mssql;
+package org.deegree.sqldialect.mssql;
 
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.xml.CommonNamespaces;

--- a/pom.xml
+++ b/pom.xml
@@ -810,6 +810,11 @@
         <version>2.5.1</version>
       </dependency>
       <dependency>
+        <groupId>net.postgis</groupId>
+        <artifactId>postgis-geometry</artifactId>
+        <version>2.5.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>42.4.3</version>


### PR DESCRIPTION
Fixes #1322. PR includes refactoring of  classes from the commons moved to mssql dialect module, fixed usage of profiles in deegree-webservices module and upgraded jdbc driver to v10.2. for support of MS SQL Server 2019.

Todo
- [ ] Change of [matrix](https://github.com/deegree/deegree3/wiki/End-of-Life-and-Support-Matrix)  to support MS SQL Server v2012-2019
- [x] #1447 To add the mssql dialect module to the webapp