### PR TITLE
Reworked profiles section for building deegree-webservices WAR file

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -103,72 +103,25 @@
       </plugin>
     </plugins>
   </build>
-  <!-- Workaround for dependency plugin issue (http://jira.codehaus.org/browse/MDEP-259) -->
   <profiles>
     <profile>
-      <id>activate-dependency-plugin</id>
-      <activation>
-        <property>
-          <name>!deactivateDependencyPlugin</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>tomcat</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>unpack-dependencies</goal>
-                </goals>
-                <configuration>
-                  <type>zip</type>
-                  <includeGroupIds>org.deegree</includeGroupIds>
-                  <includeArtifactIds>deegree-tomcat</includeArtifactIds>
-                  <outputDirectory>target/deegree-tomcat</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jersey-provided</id>
+      <id>mssql</id>
       <dependencies>
         <dependency>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-server</artifactId>
+          <groupId>org.deegree</groupId>
+          <artifactId>deegree-sqldialect-mssql</artifactId>
+          <version>${project.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>com.microsoft.sqlserver</groupId>
+              <artifactId>mssql-jdbc</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
     <profile>
-      <id>jsf-provided</id>
-      <dependencies>
-        <dependency>
-          <groupId>javax.faces</groupId>
-          <artifactId>javax.faces-api</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.faces</groupId>
-          <artifactId>jsf-impl</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>jstl-provided</id>
-      <dependencies>
-        <dependency>
-          <groupId>javax.servlet</groupId>
-          <artifactId>jstl</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>ojdbc6-provided</id>
+      <id>oracle</id>
       <dependencies>
         <dependency>
           <groupId>org.deegree</groupId>
@@ -176,7 +129,7 @@
           <version>${project.version}</version>
           <exclusions>
             <exclusion>
-              <groupId>com.oracle</groupId>
+              <groupId>com.oracle.database.jdbc</groupId>
               <artifactId>ojdbc8</artifactId>
             </exclusion>
           </exclusions>


### PR DESCRIPTION
This PR removes unused and outdated profiles, adapts existing profile for oracle to use same dependencies as root pom, and adds a profile for mssql to add the  sqldialect JAR  to WAR file if enabled.

For Oracle and MS SQL Server the JDBC drivers are NOT added to the WEB-INF/lib directory on purpose. Please note the explanations in https://download.deegree.org/documentation/current/html/#anchor-configuration-javamodules. The documentation may contain the following explanation:

The considerations to put JDBC driver JAR files into $CATALINA_HOME/lib directory are that JDBC drivers register themselves in the JVM-wide singleton [DriverManager](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/DriverManager.html) which is shared by all web apps inside of a Tomcat/JVM instance. The class DriverManager gets loaded by the bootstrap classloader and thereby "lives" globally in the JVM, while Tomcat loads all web apps in their own classloaders. So if a JDBC driver from a web app's WEB-INF/lib folder registers itself in DriverManager, it pins that web app's classloader in memory (and thereby all the classes of that web app), preventing its garbage collection when stopped and undeployed.