### PR TITLE
Enforce UTF-8 as platform encoding in unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
           <version>3.0.0-M7</version>
           <configuration>
             <!-- Travis build workaround -->
-            <argLine>-Djava.awt.headless=true -Xms1024m -Xmx2048m --illegal-access=permit
+            <argLine>-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xms1024m -Xmx2048m --illegal-access=permit
               --add-opens java.base/java.lang=ALL-UNNAMED
               --add-opens java.base/java.net=ALL-UNNAMED
               --add-opens java.base/java.util=ALL-UNNAMED


### PR DESCRIPTION
Without setting the encoding explicitly some unittest fail on systems that do not use UTF-8 as platform encoding.