### PR TITLE
Add option to skip reference check in GmlLoader tool

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/cli-utility.adoc
@@ -9,7 +9,7 @@ You can download the latest release from https://repo.deegree.org/repository/pub
 Java is installed and the _JAVA_HOME_ system environment variable points to the correct installation directory of a compatible JDK.
 Supported JDK versions are listed in <<system-requirements>>.
 
-=== Usage
+=== General Usage
 
 The executable JAR file contains help information. The following command line option shows the usage:
 
@@ -26,7 +26,7 @@ Use the keywords 'SqlFeatureStoreConfigCreator' or 'GmlLoader' to choose between
    GmlLoader -h (Prints the usage for this tool)
 ----
 
-Using the SqlFeatureStoreConfigCreator CLI:
+=== Using the SqlFeatureStoreConfigCreator CLI
 
 ----
 java -jar deegree-tools-gml.jar SqlFeatureStoreConfigCreator -h
@@ -161,7 +161,7 @@ The option useRefDataProps must be used with the option referenceData and result
  * Mapping of optional properties not in the referenceData is omitted.
  * Mapping of properties with xsi:nil="true" in the referenceData is reduced to the mapping of @xsi:nil and @nilReason.
 
-Using the GmlLoader CLI:
+=== Using the GmlLoader CLI GmlLoader
 
 ----
 java -jar deegree-tools-gml.jar GmlLoader -h
@@ -183,6 +183,7 @@ options:
  -reportFile=GmlLoader.log, the name and optionally path to the report file, defaults to GmlLoader.log
  -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default
  -chunkSize=<features_per_chunk>, number of features processed per chunk
+ -skipReferenceCheck=true, skip integrity check for feature references
  -dryRun=true, enable dry run where writing is skipped (checks only if all data can be read), disabled by default
 
 Example:
@@ -190,6 +191,14 @@ Example:
 
 ----
 
+==== Usage of option skipReferenceCheck
+
+In normal operation, the GmlLoader checks if all referenced features were included in the operation.
+The order in which the objects appear and how they are distributed among files is not relevant.
+However, there are use cases where the check has to be omitted, which can be done by specifying the
+parameter `-skipReferenceCheck=true`.
+This may be the case if the entire dataset is too large to be loaded in a single operation or
+the check can only be performed after the loading operation has finished.
 
 === Examples
 

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderHelpUsage.java
@@ -45,6 +45,7 @@ public class GmlLoaderHelpUsage {
         System.out.println( " -reportFile=GmlLoader.log, the name and optionally path to the report file, defaults to GmlLoader.log");
         System.out.println( " -disabledResources=<urlpatterns>, a comma separated list url patterns which should not be resolved, not set by default" );
         System.out.println( " -chunkSize=<features_per_chunk>, number of features processed per chunk");
+        System.out.println( " -skipReferenceCheck=true, skip integrity check for feature references");
         System.out.println( " -dryRun=true, enable dry run where writing is skipped (checks only if all data can be read), disabled by default");
         System.out.println();
         System.out.println( "Example:" );

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/TransactionHandler.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/TransactionHandler.java
@@ -21,6 +21,7 @@
  */
 package org.deegree.tools.featurestoresql.loader;
 
+import static java.util.Collections.emptySet;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.batch.core.ExitStatus.COMPLETED;
 import static org.springframework.batch.core.ExitStatus.FAILED;
@@ -97,6 +98,10 @@ public class TransactionHandler implements StepExecutionListener {
     private FeatureReferenceCheckResult checkReferences( StepExecution stepExecution ) {
         List<String> featureIds = (List<String>) stepExecution.getExecutionContext().get( FeatureReferencesParser.FEATURE_IDS );
         List<String> referenceIds = (List<String>) stepExecution.getExecutionContext().get( FeatureReferencesParser.REFERENCE_IDS );
+        if (featureIds == null || referenceIds == null) {
+            LOG.warn( "The reference check is skipped during this operation" );
+            return new FeatureReferenceCheckResult( emptySet() );
+        }
         FeatureReferenceChecker featureReferenceChecker = new FeatureReferenceChecker();
         return featureReferenceChecker.checkReferences( featureIds, referenceIds );
     }


### PR DESCRIPTION
With this change, the object ID and references are not stored in the ExecutionContext and the check is skipped.
Additionally, the list of files, if used, is checked before starting the loading operation.

This extension can be used, if the integrity check can be skipped or done later, to work around issue #1451.

References:
 - #1451