### PR TITLE
JAXB v3

### DIFF
--- a/deegree-core/deegree-connectionprovider-datasource/pom.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/datasource.xsd
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/datasource.xsd
@@ -1,5 +1,5 @@
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jdbc="http://www.deegree.org/jdbc" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  targetNamespace="http://www.deegree.org/connectionprovider/datasource" elementFormDefault="qualified" jaxb:version="2.1">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jdbc="http://www.deegree.org/jdbc" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  targetNamespace="http://www.deegree.org/connectionprovider/datasource" elementFormDefault="qualified" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-3d/pom.xml
+++ b/deegree-core/deegree-core-3d/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-3d/src/main/resources/META-INF/schemas/datasource/3d/batchedmt/file.xsd
+++ b/deegree-core/deegree-core-3d/src/main/resources/META-INF/schemas/datasource/3d/batchedmt/file.xsd
@@ -4,7 +4,7 @@
   -->
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/3d/batchedmt/file" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-3d/src/main/resources/META-INF/schemas/datasource/3d/renderable/file.xsd
+++ b/deegree-core/deegree-core-3d/src/main/resources/META-INF/schemas/datasource/3d/renderable/file.xsd
@@ -4,7 +4,7 @@
   -->
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:file="http://www.deegree.org/datasource/renderable/file"
   xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/3d/renderable/file"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-3d/src/main/resources/META-INF/schemas/datasource/3d/renderable/sql.xsd
+++ b/deegree-core/deegree-core-3d/src/main/resources/META-INF/schemas/datasource/3d/renderable/sql.xsd
@@ -4,7 +4,7 @@
   -->
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/3d/renderable/sql" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -30,8 +30,8 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.deegree</groupId>
@@ -55,8 +55,8 @@
       <artifactId>FastInfoset</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/mail/MailHelper.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/mail/MailHelper.java
@@ -42,14 +42,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
-import javax.mail.Message;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
+import jakarta.mail.Message;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +62,8 @@ import org.slf4j.LoggerFactory;
  * 
  * @version $Revision$,$Date$
  * 
- * @see javax.mail.Message
- * @see javax.mail.internet.MimeMessage
+ * @see jakarta.mail.Message
+ * @see jakarta.mail.internet.MimeMessage
  */
 
 public final class MailHelper {
@@ -146,7 +146,7 @@ public final class MailHelper {
      * @throws SendMailException
      *             an exception if the message is undeliverable
      * 
-     * @see javax.mail.Transport
+     * @see jakarta.mail.Transport
      * @see <a href="http://java.sun.com/j2ee/tutorial/1_3-fcs/doc/Resources4.html#63060">J2EE Mail Session connection
      *      </a>
      */

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/datetime/DateTime.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/datetime/DateTime.java
@@ -36,7 +36,7 @@
 package org.deegree.commons.tom.datetime;
 
 import static java.util.Calendar.getInstance;
-import static javax.xml.bind.DatatypeConverter.printDateTime;
+import static jakarta.xml.bind.DatatypeConverter.printDateTime;
 
 import java.util.Calendar;
 import java.util.TimeZone;

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/datetime/ISO8601Converter.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/datetime/ISO8601Converter.java
@@ -45,7 +45,7 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 /**
  * Converts between <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601:2004</a> encodings and deegree's temporal

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/jaxb/JAXBUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/jaxb/JAXBUtils.java
@@ -42,9 +42,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;

--- a/deegree-core/deegree-core-commons/src/main/resources/META-INF/schemas/commons/description/description.xsd
+++ b/deegree-core/deegree-core-commons/src/main/resources/META-INF/schemas/commons/description/description.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license. -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:d="http://www.deegree.org/metadata/description"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" targetNamespace="http://www.deegree.org/metadata/description"
-  elementFormDefault="qualified" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" targetNamespace="http://www.deegree.org/metadata/description"
+  elementFormDefault="qualified" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-core/deegree-core-commons/src/main/resources/META-INF/schemas/proxy/proxy.xsd
+++ b/deegree-core/deegree-core-commons/src/main/resources/META-INF/schemas/proxy/proxy.xsd
@@ -2,8 +2,8 @@
   <!--
     This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license.
   -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jdbc="http://www.deegree.org/proxy" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  targetNamespace="http://www.deegree.org/proxy" elementFormDefault="qualified" jaxb:version="2.1">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jdbc="http://www.deegree.org/proxy" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  targetNamespace="http://www.deegree.org/proxy" elementFormDefault="qualified" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-coverage/pom.xml
+++ b/deegree-core/deegree-core-coverage/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageMetadata.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageMetadata.java
@@ -43,7 +43,7 @@ package org.deegree.coverage.persistence.pyramid;
 
 import static org.deegree.commons.xml.jaxb.JAXBUtils.unmarshall;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.coverage.Coverage;
 import org.deegree.coverage.persistence.pyramid.jaxb.Pyramid;

--- a/deegree-core/deegree-core-coverage/src/main/resources/META-INF/schemas/datasource/coverage/raster/pyramid.xsd
+++ b/deegree-core/deegree-core-coverage/src/main/resources/META-INF/schemas/datasource/coverage/raster/pyramid.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:raster="http://www.deegree.org/datasource/coverage/pyramid" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/coverage/pyramid" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-coverage/src/main/resources/META-INF/schemas/datasource/coverage/raster/raster.xsd
+++ b/deegree-core/deegree-core-coverage/src/main/resources/META-INF/schemas/datasource/coverage/raster/raster.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:raster="http://www.deegree.org/datasource/coverage/raster" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/coverage/raster" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-cs/pom.xml
+++ b/deegree-core/deegree-core-cs/pom.xml
@@ -36,6 +36,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.media</groupId>
       <artifactId>jai-core</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-cs/pom.xml
+++ b/deegree-core/deegree-core-cs/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/DeegreeCRSStoreProvider.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/DeegreeCRSStoreProvider.java
@@ -43,7 +43,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.commons.utils.net.DURL;
 import org.deegree.commons.xml.XMLAdapter;

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLCRSStoreProvider.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLCRSStoreProvider.java
@@ -44,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.commons.utils.net.DURL;
 import org.deegree.commons.xml.XMLAdapter;

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/PROJ4CRSStoreProvider.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/PROJ4CRSStoreProvider.java
@@ -41,7 +41,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.File;
 import java.net.URL;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.commons.utils.net.DURL;
 import org.deegree.commons.xml.XMLAdapter;

--- a/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/deegree/deegree.xsd
+++ b/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/deegree/deegree.xsd
@@ -2,8 +2,8 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:crs="http://www.deegree.org/crs/stores/deegree" xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:str="http://www.deegree.org/crs/store" targetNamespace="http://www.deegree.org/crs/stores/deegree"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<import namespace="http://www.deegree.org/crs/store"
 		schemaLocation="../store.xsd" />
 	<annotation>

--- a/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/deegree2/deegree2.xsd
+++ b/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/deegree2/deegree2.xsd
@@ -2,8 +2,8 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:crs="http://www.deegree.org/crs/stores/deegree2" xmlns:str="http://www.deegree.org/crs/store"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/crs/stores/deegree2"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<import namespace="http://www.deegree.org/crs/store"
 		schemaLocation="../store.xsd" />
 	<annotation>

--- a/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/gml/gml.xsd
+++ b/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/gml/gml.xsd
@@ -2,8 +2,8 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:crs="http://www.deegree.org/crs/stores/gml" xmlns="http://www.w3.org/2001/XMLSchema"
 	xmlns:str="http://www.deegree.org/crs/store" targetNamespace="http://www.deegree.org/crs/stores/gml"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<import namespace="http://www.deegree.org/crs/store"
 		schemaLocation="../store.xsd" />
 	<annotation>

--- a/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/proj4/proj4.xsd
+++ b/deegree-core/deegree-core-cs/src/main/resources/META-INF/schemas/crs/stores/proj4/proj4.xsd
@@ -2,8 +2,8 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:crs="http://www.deegree.org/crs/proj4" xmlns:str="http://www.deegree.org/crs/store"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/crs/stores/proj4"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<import namespace="http://www.deegree.org/crs/store"
 		schemaLocation="../store.xsd" />
 	<annotation>

--- a/deegree-core/deegree-core-db/pom.xml
+++ b/deegree-core/deegree-core-db/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-db/src/main/resources/META-INF/schemas/jdbc/jdbc.xsd
+++ b/deegree-core/deegree-core-db/src/main/resources/META-INF/schemas/jdbc/jdbc.xsd
@@ -2,8 +2,8 @@
   <!--
     This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license.
   -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jdbc="http://www.deegree.org/jdbc" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  targetNamespace="http://www.deegree.org/jdbc" elementFormDefault="qualified" jaxb:version="2.1">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jdbc="http://www.deegree.org/jdbc" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  targetNamespace="http://www.deegree.org/jdbc" elementFormDefault="qualified" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-gdal/pom.xml
+++ b/deegree-core/deegree-core-gdal/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalSettings.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalSettings.java
@@ -38,7 +38,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.apache.commons.io.IOUtils;
 import org.deegree.commons.gdal.jaxb.GDALSettings;

--- a/deegree-core/deegree-core-gdal/src/main/resources/META-INF/schemas/commons/gdal/gdal.xsd
+++ b/deegree-core/deegree-core-gdal/src/main/resources/META-INF/schemas/commons/gdal/gdal.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/gdal" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1" xmlns:gdal="http://www.deegree.org/gdal">
+  targetNamespace="http://www.deegree.org/gdal" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0" xmlns:gdal="http://www.deegree.org/gdal">
 
   <annotation>
     <appinfo>

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-geometry/src/main/resources/META-INF/schemas/commons/spatialmetadata/spatialmetadata.xsd
+++ b/deegree-core/deegree-core-geometry/src/main/resources/META-INF/schemas/commons/spatialmetadata/spatialmetadata.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license. -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:s="http://www.deegree.org/metadata/spatial" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  targetNamespace="http://www.deegree.org/metadata/spatial" elementFormDefault="qualified" jaxb:version="2.1">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:s="http://www.deegree.org/metadata/spatial" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  targetNamespace="http://www.deegree.org/metadata/spatial" elementFormDefault="qualified" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/metadata/SpatialMetadataConverterTest.java
+++ b/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/metadata/SpatialMetadataConverterTest.java
@@ -38,9 +38,9 @@ import org.deegree.geometry.Envelope;
 import org.deegree.geometry.metadata.jaxb.EnvelopeType;
 import org.junit.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 import java.io.InputStream;
 

--- a/deegree-core/deegree-core-layer/pom.xml
+++ b/deegree-core/deegree-core-layer/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-core/deegree-core-layer/src/main/resources/META-INF/schemas/layers/base/base.xsd
+++ b/deegree-core/deegree-core-layer/src/main/resources/META-INF/schemas/layers/base/base.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/layers/base" xmlns:l="http://www.deegree.org/layers/base" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1" xmlns:d="http://www.deegree.org/metadata/description"
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0" xmlns:d="http://www.deegree.org/metadata/description"
   xmlns:s="http://www.deegree.org/metadata/spatial">
 
   <annotation>

--- a/deegree-core/deegree-core-layer/src/test/java/org/deegree/layer/config/ConfigUtilsTest.java
+++ b/deegree-core/deegree-core-layer/src/test/java/org/deegree/layer/config/ConfigUtilsTest.java
@@ -49,9 +49,9 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
 
 import org.deegree.commons.utils.Pair;

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/src/main/resources/META-INF/schemas/datasource/remoteows/wfs/remotewfs.xsd
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/src/main/resources/META-INF/schemas/datasource/remoteows/wfs/remotewfs.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/remoteows/wfs"
-  xmlns:wfs="http://www.deegree.org/datasource/remoteows/wfs" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  xmlns:wfs="http://www.deegree.org/datasource/remoteows/wfs" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/src/main/resources/META-INF/schemas/datasource/remoteows/wms/remotewms.xsd
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/src/main/resources/META-INF/schemas/datasource/remoteows/wms/remotewms.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/remoteows/wms"
-  xmlns:wms="http://www.deegree.org/datasource/remoteows/wms" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  xmlns:wms="http://www.deegree.org/datasource/remoteows/wms" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/src/main/resources/META-INF/schemas/remoteows/wms/remotewms.xsd
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/src/main/resources/META-INF/schemas/remoteows/wms/remotewms.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/remoteows/wms"
-  xmlns:wms="http://www.deegree.org/remoteows/wms" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  xmlns:wms="http://www.deegree.org/remoteows/wms" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/src/main/java/org/deegree/remoteows/wmts/RemoteWmtsMetadata.java
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/src/main/java/org/deegree/remoteows/wmts/RemoteWmtsMetadata.java
@@ -29,7 +29,7 @@ package org.deegree.remoteows.wmts;
 
 import java.io.InputStream;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.commons.xml.jaxb.JAXBUtils;
 import org.deegree.remoteows.RemoteOWS;

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/src/main/resources/META-INF/schemas/remoteows/wmts/remotewmts.xsd
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/src/main/resources/META-INF/schemas/remoteows/wmts/remotewmts.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/remoteows/wmts"
-  xmlns:wmts="http://www.deegree.org/remoteows/wmts" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  xmlns:wmts="http://www.deegree.org/remoteows/wmts" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-core/deegree-core-theme/pom.xml
+++ b/deegree-core/deegree-core-theme/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-core/deegree-core-theme/src/main/resources/META-INF/schemas/themes/themes.xsd
+++ b/deegree-core/deegree-core-theme/src/main/resources/META-INF/schemas/themes/themes.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:t="http://www.deegree.org/themes/standard" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2001/XMLSchema"
- targetNamespace="http://www.deegree.org/themes/standard" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
- jaxb:version="2.1" xmlns:d="http://www.deegree.org/metadata/description" xmlns:g="http://www.deegree.org/metadata/spatial">
+ targetNamespace="http://www.deegree.org/themes/standard" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+ jaxb:version="3.0" xmlns:d="http://www.deegree.org/metadata/description" xmlns:g="http://www.deegree.org/metadata/spatial">
 
  <import namespace="http://www.deegree.org/metadata/description" schemaLocation="../commons/description/description.xsd" />
  <import namespace="http://www.deegree.org/metadata/spatial" schemaLocation="../commons/spatialmetadata/spatialmetadata.xsd" />

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/schemas/datasource/coverage/oraclegeoraster/oraclegeoraster.xsd
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/src/main/resources/META-INF/schemas/datasource/coverage/oraclegeoraster/oraclegeoraster.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:raster="http://www.deegree.org/datasource/coverage/oraclegeoraster" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/coverage/oraclegeoraster"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/resources/META-INF/schemas/datasource/feature/memory/memory.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/resources/META-INF/schemas/datasource/feature/memory/memory.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:memoryfs="http://www.deegree.org/datasource/feature/memory"
   xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/feature/memory"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/src/main/resources/META-INF/schemas/datasource/feature/remotewfs/remotewfs.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/src/main/resources/META-INF/schemas/datasource/feature/remotewfs/remotewfs.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:remotewfs="http://www.deegree.org/datasource/feature/remotewfs"
   xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/feature/remotewfs"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/resources/META-INF/schemas/datasource/feature/shape/shape.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/resources/META-INF/schemas/datasource/feature/shape/shape.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://www.deegree.org/commons" xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/datasource/feature/shape" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/datasource/feature/shape" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/src/main/resources/META-INF/schemas/datasource/feature/simplesql/simplesql.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/src/main/resources/META-INF/schemas/datasource/feature/simplesql/simplesql.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/feature/simplesql" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -29,8 +29,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
 import org.deegree.commons.jdbc.SQLIdentifier;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTableOld.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTableOld.java
@@ -55,7 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
 import org.deegree.commons.jdbc.SQLIdentifier;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/resources/META-INF/schemas/datasource/feature/sql/sql.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/resources/META-INF/schemas/datasource/feature/sql/sql.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:sqlfs="http://www.deegree.org/datasource/feature/sql"
   xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/feature/sql"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/resources/META-INF/schemas/datasource/metadata/ebrim/eo/ebrim-eo.xsd
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/resources/META-INF/schemas/datasource/metadata/ebrim/eo/ebrim-eo.xsd
@@ -2,7 +2,7 @@
 <!-- This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license. -->
 <schema xmlns:ds="http://www.deegree.org/datasource/metadata/ebrim/eo" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/metadata/ebrim/eo" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/src/main/resources/META-INF/schemas/datasource/metadata/iso19139/memory/memory.xsd
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/src/main/resources/META-INF/schemas/datasource/metadata/iso19139/memory/memory.xsd
@@ -2,7 +2,7 @@
 <!-- This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license. -->
 <schema xmlns:ds="http://www.deegree.org/datasource/metadata/iso19139/memory" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/metadata/iso19139/memory" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/resources/META-INF/schemas/datasource/metadata/iso19115/iso19115.xsd
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/resources/META-INF/schemas/datasource/metadata/iso19115/iso19115.xsd
@@ -2,7 +2,7 @@
 <!-- This file is part of deegree, for copyright/license information, please visit http://www.deegree.org/license. -->
 <schema xmlns:ds="http://www.deegree.org/datasource/metadata/iso19115" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/metadata/iso19115" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/sql/AnyTextHelperTest.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/sql/AnyTextHelperTest.java
@@ -38,9 +38,9 @@ package org.deegree.metadata.iso.persistence.sql;
 import java.net.URL;
 import java.util.TimeZone;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import org.deegree.commons.xml.XMLAdapter;
 import org.deegree.metadata.MetadataRecordFactory;

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/src/main/resources/META-INF/schemas/datasource/tile/cache/cache.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/src/main/resources/META-INF/schemas/datasource/tile/cache/cache.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/cache" xmlns:t="http://www.deegree.org/datasource/tile/cache"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/src/main/resources/META-INF/schemas/datasource/tile/tilematrixset/tilematrixset.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/src/main/resources/META-INF/schemas/datasource/tile/tilematrixset/tilematrixset.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:tms="http://www.deegree.org/datasource/tile/tilematrixset" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/tilematrixset" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <!-- workaround for a maven-jaxb2-plugin issue, project dependencies seem not to be added properly -->
           <dependency>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/src/main/resources/META-INF/schemas/datasource/tile/filesystem/filesystem.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/src/main/resources/META-INF/schemas/datasource/tile/filesystem/filesystem.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:md="http://www.deegree.org/metadata/spatial"
   targetNamespace="http://www.deegree.org/datasource/tile/filesystem" xmlns:t="http://www.deegree.org/datasource/tile/filesystem"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <import namespace="http://www.deegree.org/metadata/spatial" schemaLocation="../../../commons/spatialmetadata/spatialmetadata.xsd" />
 

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/pom.xml
@@ -14,8 +14,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/src/main/resources/META-INF/schemas/datasource/tile/gdal/gdal.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/src/main/resources/META-INF/schemas/datasource/tile/gdal/gdal.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/gdal" xmlns:t="http://www.deegree.org/datasource/tile/gdal"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/src/main/resources/META-INF/schemas/datasource/tile/tilematrixset/gdal/gdal.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/src/main/resources/META-INF/schemas/datasource/tile/tilematrixset/gdal/gdal.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:tms="http://www.deegree.org/datasource/tile/tilematrixset/gdal" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/tilematrixset/gdal" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/resources/META-INF/schemas/datasource/tile/geotiff/geotiff.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/resources/META-INF/schemas/datasource/tile/geotiff/geotiff.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/geotiff" xmlns:t="http://www.deegree.org/datasource/tile/geotiff"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/resources/META-INF/schemas/datasource/tile/tilematrixset/geotiff/geotiff.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/resources/META-INF/schemas/datasource/tile/tilematrixset/geotiff/geotiff.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:tms="http://www.deegree.org/datasource/tile/tilematrixset/geotiff" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/tilematrixset/geotiff" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/resources/META-INF/schemas/datasource/tile/merge/merge.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/resources/META-INF/schemas/datasource/tile/merge/merge.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/datasource/tile/merge" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/datasource/tile/merge" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/src/main/resources/META-INF/schemas/datasource/tile/remotewms/remotewms.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/src/main/resources/META-INF/schemas/datasource/tile/remotewms/remotewms.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/remotewms" elementFormDefault="qualified"
-  xmlns:r="http://www.deegree.org/datasource/tile/remotewms" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:r="http://www.deegree.org/datasource/tile/remotewms" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/pom.xml
@@ -17,8 +17,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/src/main/java/org/deegree/tile/persistence/remotewmts/RemoteWmtsTileStoreMetadata.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/src/main/java/org/deegree/tile/persistence/remotewmts/RemoteWmtsTileStoreMetadata.java
@@ -29,7 +29,7 @@ package org.deegree.tile.persistence.remotewmts;
 
 import static org.deegree.commons.xml.jaxb.JAXBUtils.unmarshall;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.remoteows.RemoteOWS;
 import org.deegree.remoteows.RemoteOWSProvider;

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/src/main/resources/META-INF/schemas/datasource/tile/remotewmts/remotewmts.xsd
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/src/main/resources/META-INF/schemas/datasource/tile/remotewmts/remotewmts.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/datasource/tile/remotewmts" elementFormDefault="qualified"
-  xmlns:r="http://www.deegree.org/datasource/tile/remotewmts" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:r="http://www.deegree.org/datasource/tile/remotewmts" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-layers/deegree-layers-coverage/pom.xml
+++ b/deegree-layers/deegree-layers-coverage/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-layers/deegree-layers-coverage/src/main/resources/META-INF/schemas/layers/coverage/coverage.xsd
+++ b/deegree-layers/deegree-layers-coverage/src/main/resources/META-INF/schemas/layers/coverage/coverage.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/layers/coverage" xmlns:f="http://www.deegree.org/layers/coverage"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1"
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0"
   xmlns:l="http://www.deegree.org/layers/base">
 
   <annotation>

--- a/deegree-layers/deegree-layers-feature/pom.xml
+++ b/deegree-layers/deegree-layers-feature/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-layers/deegree-layers-feature/src/main/resources/META-INF/schemas/layers/feature/feature.xsd
+++ b/deegree-layers/deegree-layers-feature/src/main/resources/META-INF/schemas/layers/feature/feature.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/layers/feature" xmlns:f="http://www.deegree.org/layers/feature"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1"
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0"
   xmlns:l="http://www.deegree.org/layers/base">
 
   <annotation>

--- a/deegree-layers/deegree-layers-gdal/pom.xml
+++ b/deegree-layers/deegree-layers-gdal/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-layers/deegree-layers-gdal/src/main/resources/META-INF/schemas/layers/gdal/gdal.xsd
+++ b/deegree-layers/deegree-layers-gdal/src/main/resources/META-INF/schemas/layers/gdal/gdal.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/layers/gdal" xmlns:g="http://www.deegree.org/layers/gdal"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1"
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0"
   xmlns:l="http://www.deegree.org/layers/base">
 
   <annotation>

--- a/deegree-layers/deegree-layers-remotewms/pom.xml
+++ b/deegree-layers/deegree-layers-remotewms/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-layers/deegree-layers-remotewms/src/main/resources/META-INF/schemas/layers/remotewms/remotewms.xsd
+++ b/deegree-layers/deegree-layers-remotewms/src/main/resources/META-INF/schemas/layers/remotewms/remotewms.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/layers/remotewms" xmlns:l="http://www.deegree.org/layers/remotewms" xmlns:d="http://www.deegree.org/metadata/description"
-  xmlns:s="http://www.deegree.org/metadata/spatial" xmlns:b="http://www.deegree.org/layers/base" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  xmlns:s="http://www.deegree.org/metadata/spatial" xmlns:b="http://www.deegree.org/layers/base" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-layers/deegree-layers-tile/pom.xml
+++ b/deegree-layers/deegree-layers-tile/pom.xml
@@ -19,8 +19,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-layers/deegree-layers-tile/src/main/resources/META-INF/schemas/layers/tile/tile.xsd
+++ b/deegree-layers/deegree-layers-tile/src/main/resources/META-INF/schemas/layers/tile/tile.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/layers/tile" xmlns:t="http://www.deegree.org/layers/tile" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1" xmlns:l="http://www.deegree.org/layers/base">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0" xmlns:l="http://www.deegree.org/layers/base">
 
   <annotation>
     <appinfo>

--- a/deegree-processproviders/deegree-processprovider-example/src/main/java/org/deegree/services/wps/provider/ExampleProcessProvider.java
+++ b/deegree-processproviders/deegree-processprovider-example/src/main/java/org/deegree/services/wps/provider/ExampleProcessProvider.java
@@ -39,7 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
 import org.deegree.commons.tom.ows.CodeType;

--- a/deegree-processproviders/deegree-processprovider-fme/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-fme/pom.xml
@@ -12,8 +12,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-processproviders/deegree-processprovider-fme/src/main/java/org/deegree/services/wps/provider/fme/FMEJobSubmitterInvocationStrategy.java
+++ b/deegree-processproviders/deegree-processprovider-fme/src/main/java/org/deegree/services/wps/provider/fme/FMEJobSubmitterInvocationStrategy.java
@@ -34,7 +34,7 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.services.wps.provider.fme;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
 import org.deegree.process.jaxb.java.ComplexFormatType;

--- a/deegree-processproviders/deegree-processprovider-fme/src/main/java/org/deegree/services/wps/provider/fme/FMEProcessProviderBuilder.java
+++ b/deegree-processproviders/deegree-processprovider-fme/src/main/java/org/deegree/services/wps/provider/fme/FMEProcessProviderBuilder.java
@@ -45,7 +45,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import org.apache.http.HttpResponse;
 import org.deegree.commons.json.JSONAdapter;

--- a/deegree-processproviders/deegree-processprovider-fme/src/main/resources/META-INF/schemas/processes/fme/fme.xsd
+++ b/deegree-processproviders/deegree-processprovider-fme/src/main/resources/META-INF/schemas/processes/fme/fme.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:st="http://www.deegree.org/processes/fme"
         targetNamespace="http://www.deegree.org/processes/fme"
-        elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-        jaxb:version="2.1">
+        elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+        jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-processproviders/deegree-processprovider-style/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-style/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-processproviders/deegree-processprovider-style/src/main/java/org/deegree/services/wps/provider/style/StyleProcessProvider.java
+++ b/deegree-processproviders/deegree-processprovider-style/src/main/java/org/deegree/services/wps/provider/style/StyleProcessProvider.java
@@ -40,7 +40,7 @@ import static java.math.BigInteger.ONE;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
 import org.deegree.commons.tom.ows.CodeType;

--- a/deegree-processproviders/deegree-processprovider-style/src/main/resources/META-INF/schemas/processes/style/styleProvider.xsd
+++ b/deegree-processproviders/deegree-processprovider-style/src/main/resources/META-INF/schemas/processes/style/styleProvider.xsd
@@ -1,7 +1,7 @@
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://www.deegree.org/processes/style"
 	targetNamespace="http://www.deegree.org/processes/style"
 	elementFormDefault="qualified" attributeFormDefault="unqualified"
-	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+	xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/OwsGlobalConfigLoader.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/OwsGlobalConfigLoader.java
@@ -34,7 +34,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.deegree.commons.utils.net.DURL;
 import org.deegree.commons.xml.jaxb.JAXBUtils;

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/security/SecurityConfiguration.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/security/SecurityConfiguration.java
@@ -47,9 +47,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.ServiceLoader;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOwsMetadataProviderBuilder.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOwsMetadataProviderBuilder.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOwsMetadataProviderMetadata.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOwsMetadataProviderMetadata.java
@@ -29,7 +29,7 @@ package org.deegree.services.metadata.provider;
 
 import static org.deegree.commons.xml.jaxb.JAXBUtils.unmarshall;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.deegree.services.jaxb.metadata.DeegreeServicesMetadataType;
 import org.deegree.services.metadata.OWSMetadataProvider;

--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/controller/controller.xsd
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/controller/controller.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:controller="http://www.deegree.org/services/controller" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/services/controller" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/controller" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <xs:annotation>
     <xs:appinfo>
       <jaxb:schemaBindings>

--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/metadata/metadata.xsd
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/metadata/metadata.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:md="http://www.deegree.org/services/metadata" xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/services/metadata" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/metadata" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/security/security.xsd
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/security/security.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:sec="http://www.deegree.org/services/security" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/services/security" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/security" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <xs:annotation>
     <xs:appinfo>

--- a/deegree-services/deegree-services-csw/pom.xml
+++ b/deegree-services/deegree-services-csw/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-services/deegree-services-csw/src/main/resources/META-INF/schemas/services/csw/csw_configuration.xsd
+++ b/deegree-services/deegree-services-csw/src/main/resources/META-INF/schemas/services/csw/csw_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:csw="http://www.deegree.org/services/csw" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/services/csw"
-  elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-services/deegree-services-wcs/pom.xml
+++ b/deegree-services/deegree-services-wcs/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/ServiceConfigurationXMLAdapter.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/ServiceConfigurationXMLAdapter.java
@@ -37,7 +37,7 @@ package org.deegree.services.wcs;
 
 import static org.deegree.commons.xml.jaxb.JAXBUtils.unmarshall;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.deegree.commons.xml.XMLAdapter;
 import org.deegree.commons.xml.XMLProcessingException;

--- a/deegree-services/deegree-services-wcs/src/main/resources/META-INF/schemas/services/wcs/wcs_configuration.xsd
+++ b/deegree-services/deegree-services-wcs/src/main/resources/META-INF/schemas/services/wcs/wcs_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:wcs="http://www.deegree.org/services/wcs" xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/services/wcs" elementFormDefault="qualified"
-  jaxb:version="2.1" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb">
+  jaxb:version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb">
 
   <xs:annotation>
     <xs:appinfo>

--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -155,7 +155,7 @@ import org.w3c.dom.Element;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 

--- a/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/wfs_configuration.xsd
+++ b/deegree-services/deegree-services-wfs/src/main/resources/META-INF/schemas/services/wfs/wfs_configuration.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.deegree.org/services/wfs" targetNamespace="http://www.deegree.org/services/wfs"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-services/deegree-services-wms/pom.xml
+++ b/deegree-services/deegree-services-wms/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/wms_configuration.xsd
+++ b/deegree-services/deegree-services-wms/src/main/resources/META-INF/schemas/services/wms/wms_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:wms="http://www.deegree.org/services/wms" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/services/wms" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/wms" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-services/deegree-services-wmts/pom.xml
+++ b/deegree-services/deegree-services-wmts/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-services/deegree-services-wmts/src/main/resources/META-INF/schemas/services/wmts/wmts.xsd
+++ b/deegree-services/deegree-services-wmts/src/main/resources/META-INF/schemas/services/wmts/wmts.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:wmts="http://www.deegree.org/services/wmts" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.deegree.org/services/wmts" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/wmts" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
 
   <annotation>
     <appinfo>

--- a/deegree-services/deegree-services-wps/pom.xml
+++ b/deegree-services/deegree-services-wps/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/deegree-services/deegree-services-wps/src/api/java/org/deegree/services/wps/ProcessletOutputs.java
+++ b/deegree-services/deegree-services-wps/src/api/java/org/deegree/services/wps/ProcessletOutputs.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.deegree.commons.tom.ows.CodeType;
 import org.deegree.process.jaxb.java.BoundingBoxOutputDefinition;

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/ExecutionManager.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/ExecutionManager.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/describeprocess/DescribeProcessResponseXMLAdapter.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/describeprocess/DescribeProcessResponseXMLAdapter.java
@@ -41,7 +41,7 @@ import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestKVPAdapter.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestKVPAdapter.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.tom.ows.CodeType;

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestXMLAdapter.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestXMLAdapter.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;

--- a/deegree-services/deegree-services-wps/src/main/resources/META-INF/schemas/processes/java/java.xsd
+++ b/deegree-services/deegree-services-wps/src/main/resources/META-INF/schemas/processes/java/java.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wps="http://www.deegree.org/processes/java" targetNamespace="http://www.deegree.org/processes/java"
-  elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-services/deegree-services-wps/src/main/resources/META-INF/schemas/services/wps/wps_configuration.xsd
+++ b/deegree-services/deegree-services-wps/src/main/resources/META-INF/schemas/services/wps/wps_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wps="http://www.deegree.org/services/wps" xmlns:xlink="http://www.w3.org/1999/xlink"
-  targetNamespace="http://www.deegree.org/services/wps" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/wps" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-services/deegree-services-wpvs/pom.xml
+++ b/deegree-services/deegree-services-wpvs/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deegree-services/deegree-services-wpvs/src/main/resources/META-INF/schemas/services/wpvs/wpvs_configuration.xsd
+++ b/deegree-services/deegree-services-wpvs/src/main/resources/META-INF/schemas/services/wpvs/wpvs_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wpvs="http://www.deegree.org/services/wpvs"
-  targetNamespace="http://www.deegree.org/services/wpvs" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/wpvs" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/deegree-services/deegree-services-wpvs/src/main/resources/META-INF/schemas/services/wpvs/wpvs_service_configuration.xsd
+++ b/deegree-services/deegree-services-wpvs/src/main/resources/META-INF/schemas/services/wpvs/wpvs_service_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wpvs="http://www.deegree.org/services/wpvs"
-  targetNamespace="http://www.deegree.org/services/wpvs" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/wpvs" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <element name="ServiceConfiguration">
     <annotation>
       <documentation>

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -323,12 +323,12 @@
       <artifactId>javax.servlet.jsp-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-themes/deegree-themes-remotewms/pom.xml
+++ b/deegree-themes/deegree-themes-remotewms/pom.xml
@@ -19,8 +19,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
         <dependencies>
           <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-themes/deegree-themes-remotewms/src/main/resources/META-INF/schemas/themes/remotewms/remotewms.xsd
+++ b/deegree-themes/deegree-themes-remotewms/src/main/resources/META-INF/schemas/themes/remotewms/remotewms.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/themes/remotewms" xmlns:l="http://www.deegree.org/themes/remotewms"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:md="http://www.deegree.org/metadata/description"
-  jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:md="http://www.deegree.org/metadata/description"
+  jaxb:version="3.0">
 
   <import namespace="http://www.deegree.org/metadata/spatial" schemaLocation="../../commons/spatialmetadata/spatialmetadata.xsd" />
 

--- a/deegree-tools/deegree-tools-3d/pom.xml
+++ b/deegree-tools/deegree-tools-3d/pom.xml
@@ -22,8 +22,8 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/InteractiveWPVS.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/InteractiveWPVS.java
@@ -62,7 +62,7 @@ import javax.media.opengl.glu.GLU;
 import javax.swing.JFrame;
 import javax.vecmath.Point3d;
 import javax.vecmath.Vector3d;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;

--- a/deegree-tools/deegree-tools-base/pom.xml
+++ b/deegree-tools/deegree-tools-base/pom.xml
@@ -22,8 +22,8 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.deegree</groupId>

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/feature/gml/ApplicationSchemaTool.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/feature/gml/ApplicationSchemaTool.java
@@ -57,7 +57,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.cli.Option;

--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -181,13 +181,10 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>2.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.3.5</version>
-      <scope>runtime</scope>
     </dependency>
     <!--  test -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
           <version>1.5.2</version>
         </plugin>
         <plugin>
-          <groupId>org.jvnet.jaxb2.maven2</groupId>
-          <artifactId>maven-jaxb2-plugin</artifactId>
-          <version>0.15.1</version>
+          <groupId>com.evolvedbinary.maven.jvnet</groupId>
+          <artifactId>jaxb30-maven-plugin</artifactId>
+          <version>0.15.0</version>
           <executions>
             <execution>
               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
           <version>3.0.0-M7</version>
           <configuration>
             <!-- Travis build workaround -->
-            <argLine>-Djava.awt.headless=true -Xms1024m -Xmx2048m --illegal-access=permit
+            <argLine>-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xms1024m -Xmx2048m --illegal-access=permit
               --add-opens java.base/java.lang=ALL-UNNAMED
               --add-opens java.base/java.net=ALL-UNNAMED
               --add-opens java.base/java.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -408,29 +408,47 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- JAXB 2.3 -->
+      <!-- JAXB 3.0 -->
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>2.3.3</version>
+        <version>4.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>4.0.0</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
         <version>2.3.3</version>
         <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
-      <!-- JAX-WS 2.3 (Jakarta EE 8) -->
+      <!-- JAX-WS 3.0 (Jakarta EE 10) -->
       <dependency>
         <groupId>jakarta.xml.ws</groupId>
         <artifactId>jakarta.xml.ws-api</artifactId>
-        <version>2.3.3</version>
+        <version>4.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.ws</groupId>
         <artifactId>jaxws-rt</artifactId>
-        <version>2.3.3</version>
+        <version>4.0.0</version>
         <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>jakarta.annotation</groupId>
@@ -1051,6 +1069,12 @@
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
         <version>3.10.8</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>
@@ -1140,16 +1164,15 @@
         <version>20210817</version>
       </dependency>
       <dependency>
-        <groupId>javax.mail</groupId>
-        <artifactId>mail</artifactId>
-        <version>1.4.7</version>
+        <groupId>jakarta.mail</groupId>
+        <artifactId>jakarta.mail-api</artifactId>
+        <version>2.0.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
-        <scope>provided</scope>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>2.0.1</version>
       </dependency>
       <dependency>
         <groupId>jfree</groupId>

--- a/uncoupled/deegree-spring/pom.xml
+++ b/uncoupled/deegree-spring/pom.xml
@@ -12,8 +12,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>com.evolvedbinary.maven.jvnet</groupId>
+				<artifactId>jaxb30-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/bootstrap.xsd
+++ b/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/bootstrap.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   targetNamespace="http://www.deegree.org/spring/bootstrap" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/db.xsd
+++ b/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/db.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/spring/db"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/generic.xsd
+++ b/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/generic.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/spring/generic"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	
 	<annotation>
 		<appinfo>

--- a/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/layer.xsd
+++ b/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/layer.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/spring/layer"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
 	xmlns:g="http://www.deegree.org/spring/generic"
-	jaxb:version="2.1">
+	jaxb:version="3.0">
 	
 	<import namespace="http://www.deegree.org/spring/generic" schemaLocation="./generic.xsd"/>
 	

--- a/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/metadata.xsd
+++ b/uncoupled/deegree-spring/src/main/resources/META-INF/schemas/spring/3.4.0/metadata.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/spring/metadata"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
 	xmlns:g="http://www.deegree.org/spring/generic"
-	jaxb:version="2.1">
+	jaxb:version="3.0">
 	
 	<import namespace="http://www.deegree.org/spring/generic" schemaLocation="./generic.xsd"/>
 	

--- a/uncoupled/orphaned-after-3.2/deegree-core-observation/pom.xml
+++ b/uncoupled/orphaned-after-3.2/deegree-core-observation/pom.xml
@@ -32,8 +32,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.antlr</groupId>

--- a/uncoupled/orphaned-after-3.2/deegree-core-observation/src/main/resources/META-INF/schemas/datasource/observation/contsql/3.0.0/contsql.xsd
+++ b/uncoupled/orphaned-after-3.2/deegree-core-observation/src/main/resources/META-INF/schemas/datasource/observation/contsql/3.0.0/contsql.xsd
@@ -1,6 +1,6 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:sql="http://www.deegree.org/datasource/observation/contsql" targetNamespace="http://www.deegree.org/datasource/observation/contsql"
-  elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.2/deegree-core-observation/src/main/resources/META-INF/schemas/datasource/observation/simplesql/3.0.0/simplesql.xsd
+++ b/uncoupled/orphaned-after-3.2/deegree-core-observation/src/main/resources/META-INF/schemas/datasource/observation/simplesql/3.0.0/simplesql.xsd
@@ -1,7 +1,7 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.w3.org/2001/XMLSchema"
   xmlns:sql="http://www.deegree.org/datasource/observation/simplesql"
   targetNamespace="http://www.deegree.org/datasource/observation/simplesql" elementFormDefault="qualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.2/deegree-featurestore-couchbase/pom.xml
+++ b/uncoupled/orphaned-after-3.2/deegree-featurestore-couchbase/pom.xml
@@ -32,8 +32,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/uncoupled/orphaned-after-3.2/deegree-featurestore-couchbase/src/main/resources/META-INF/schemas/datasource/feature/geocouch/3.1.0/geocouch.xsd
+++ b/uncoupled/orphaned-after-3.2/deegree-featurestore-couchbase/src/main/resources/META-INF/schemas/datasource/feature/geocouch/3.1.0/geocouch.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.deegree.org/datasource/feature/geocouch"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.2/deegree-processprovider-sextante/pom.xml
+++ b/uncoupled/orphaned-after-3.2/deegree-processprovider-sextante/pom.xml
@@ -32,8 +32,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/uncoupled/orphaned-after-3.2/deegree-processprovider-sextante/src/main/resources/META-INF/schemas/processes/sextante/0.1.0/sextante.xsd
+++ b/uncoupled/orphaned-after-3.2/deegree-processprovider-sextante/src/main/resources/META-INF/schemas/processes/sextante/0.1.0/sextante.xsd
@@ -2,7 +2,7 @@
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:st="http://www.deegree.org/processes/sextante"
   targetNamespace="http://www.deegree.org/processes/sextante"
   elementFormDefault="qualified" attributeFormDefault="unqualified"
-  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.2/deegree-services-sos/pom.xml
+++ b/uncoupled/orphaned-after-3.2/deegree-services-sos/pom.xml
@@ -32,8 +32,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/uncoupled/orphaned-after-3.2/deegree-services-sos/src/main/resources/META-INF/schemas/services/sos/3.0.0/sos_configuration.xsd
+++ b/uncoupled/orphaned-after-3.2/deegree-services-sos/src/main/resources/META-INF/schemas/services/sos/3.0.0/sos_configuration.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:sos="http://www.deegree.org/services/sos" xmlns:xlink="http://www.w3.org/1999/xlink"
-  targetNamespace="http://www.deegree.org/services/sos" elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-  jaxb:version="2.1">
+  targetNamespace="http://www.deegree.org/services/sos" elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+  jaxb:version="3.0">
   <annotation>
     <appinfo>
       <jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/pom.xml
+++ b/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/pom.xml
@@ -31,8 +31,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>com.evolvedbinary.maven.jvnet</groupId>
+        <artifactId>jaxb30-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/jrxmlProcess.xsd
+++ b/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/jrxmlProcess.xsd
@@ -1,7 +1,7 @@
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://www.deegree.org/processes/jrxml"
 	targetNamespace="http://www.deegree.org/processes/jrxml"
 	elementFormDefault="qualified" attributeFormDefault="unqualified"
-	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" jaxb:version="2.1">
+	xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/map/0.1.0/map.xsd
+++ b/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/map/0.1.0/map.xsd
@@ -2,8 +2,8 @@
 <xs:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:n1="http://www.opengis.net/ogc"
 	xmlns:sld="http://www.opengis.net/sld" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	targetNamespace="http://www.deegree.org/processprovider/map" xmlns:map="http://www.deegree.org/processprovider/map"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/map/0.1.0/mapMetadata.xsd
+++ b/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/map/0.1.0/mapMetadata.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	targetNamespace="http://www.deegree.org/processprovider/mapMetadata"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<annotation>
 		<appinfo>
 			<jaxb:schemaBindings>

--- a/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/table/0.1.0/table.xsd
+++ b/uncoupled/orphaned-after-3.3/deegree-processprovider-jrxml/src/main/resources/META-INF/schemas/processes/jrxml/0.1.0/table/0.1.0/table.xsd
@@ -3,8 +3,8 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	targetNamespace="http://www.deegree.org/processprovider/table"
 	xmlns:tbl="http://www.deegree.org/processprovider/table"
-	elementFormDefault="qualified" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	jaxb:version="2.1">
+	elementFormDefault="qualified" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	jaxb:version="3.0">
 	<xs:annotation>
 		<xs:appinfo>
 			<jaxb:schemaBindings>


### PR DESCRIPTION
This pull request contains changes from using jaxb v2 to v3. This means converting the use of javax packages to jakarta.

The only problem with this is that xsd files can't be found anymore when they are in separate modules. It seems that maven can't merge them properly anymore.

A temporary fix could be to duplicate the xsd files where needed. This will make all unit tests pass.

The only thing that still remains broken is the creation of the zip file containing all schema files in the deegree-core-schema module.

depends on #1452