### PR TITLE
Fix for dependency conflicts introduced with ehcache 3.x upgrade (PR #1441)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1051,6 +1051,12 @@
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
         <version>3.10.8</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
This PR fixes the broken JAXB dependencies introduced with PR #1441.

The deegree project uses the `jakarta.xml.bind:jakarta.xml.bind-api`(API) with `com.sun.xml.bind:jaxb-impl` (JAXB implementation).
The ehcache project uses `org.glassfish.jaxb:jaxb-runtime` in the version range of `[2.2,3)`. This brings duplications of types in different versions from the `com.sun.xml.bind` package into the classpath and results in build errors.

To fix this the `org.glassfish.jaxb:jaxb-runtime` dependencies introduced with ehcache are excluded from the dependencies. This shall not affect ehcache at runtime since the difference between `jaxb-impl` and the `jaxb-runtime` JAR is that the `jaxb-impl` JAR also bundles types from `com.sun.istack` and `com.sun.xml.txw2` whereas the `jaxb-runtime`  provides them as separate dependencies.

More info about JAXB https://github.com/eclipse-ee4j/jaxb-ri/.
