### PR TITLE
Upgrade of JAXB implementation to v2.3.7

### DIFF
--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -181,12 +181,10 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>2.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.3.5</version>
       <scope>runtime</scope>
     </dependency>
     <!--  test -->

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <plugin>
           <groupId>org.jvnet.jaxb2.maven2</groupId>
           <artifactId>maven-jaxb2-plugin</artifactId>
-          <version>0.15.1</version>
+          <version>0.15.2</version>
           <executions>
             <execution>
               <goals>
@@ -417,7 +417,7 @@
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.7</version>
         <scope>runtime</scope>
       </dependency>
       <!-- JAX-WS 2.3 (Jakarta EE 8) -->


### PR DESCRIPTION
This PR upgrades JAXB impl. to v2.3.7, removes overriding of version in deegree-tools-gml submodule
Should be merged with PR #1459.