### PR TITLE
Upgrade Spring Boot to 2.5.14, Spring Batch 4.3.6 and Spring Core 5.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1196,9 +1196,9 @@
     <oracle.version>19.9.0.0</oracle.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <spring-boot.version>2.5.12</spring-boot.version>
-    <spring-batch.version>4.3.5</spring-batch.version>
-    <spring-framework.version>5.3.18</spring-framework.version>
+    <spring-boot.version>2.5.14</spring-boot.version>
+    <spring-batch.version>4.3.6</spring-batch.version>
+    <spring-framework.version>5.3.20</spring-framework.version>
     <batik.version>1.14</batik.version>
     <axoim.version>1.2.22</axoim.version>
     <jsonpath.version>2.4.0</jsonpath.version>


### PR DESCRIPTION
This PR upgrades the libraries of Spring Boot 2.5.12->2.5.14, Spring Batch 4.3.5->4.3.6 and Spring Core 5.3.18->5.3.20