### PR TITLE
Upgrade of json-path to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1201,7 +1201,7 @@
     <spring-framework.version>5.3.18</spring-framework.version>
     <batik.version>1.14</batik.version>
     <axoim.version>1.2.22</axoim.version>
-    <jsonpath.version>2.4.0</jsonpath.version>
+    <jsonpath.version>2.7.0</jsonpath.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This PR upgrades json-path and json-path-assert to v2.7.0. 