### PR TITLE
Fixed skipReferenceCheck=true in GmlLoader

### DIFF
--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
@@ -194,7 +194,6 @@ public class GmlLoaderConfiguration {
         } else {
             builder.processor( featureReferencesParser );
         }
-        builder.reader( gmlReader ).processor( featureReferencesParser );
 
         if ( dryRun ) {
             return builder.build();


### PR DESCRIPTION
This PR disables the check of the references if `skipReferenceCheck=true` is set. 