### PR TITLE
Upgrade of PostgreSQL JDBC driver to v42.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -812,7 +812,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.4.3</version>
+        <version>42.5.2</version>
       </dependency>
       <!-- Oracle (Offical provided driver from repo1.maven.org) -->
       <dependency>


### PR DESCRIPTION
This PR upgrades the PostgreSQL JDBC driver to v42.5.2. 
Changelog: https://jdbc.postgresql.org/changelogs/2023-01-31-42.5.2-release/