### PR TITLE
Fix Spring annotations for GMLLoader

### DIFF
--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
@@ -87,6 +87,7 @@ public class GmlLoaderConfiguration {
         return summary;
     }
 
+    @JobScope
     @Bean
     public ReportWriter reportWriter( Summary summary,
                                       @Value("#{jobParameters['reportFile'] ?: 'GmlLoader.log'}") String fileName ) {


### PR DESCRIPTION
As changes for the gml-loader were separated for easier manageability, the PR #1390 missed an annotation, which is fixed in this PR.

closes #1465 