### PR TITLE
Add bbox_cache.properties per SQLFeatureStore

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -1773,9 +1773,10 @@ public class SQLFeatureStore implements FeatureStore {
         }
 
         // TODO make this configurable
+        String sqlFeatureStoreId = getMetadata().getIdentifier().getId();
         FeatureStoreManager fsMgr = this.workspace.getResourceManager( FeatureStoreManager.class );
         if ( fsMgr != null ) {
-            this.bboxCache = fsMgr.getBBoxCache();
+            this.bboxCache = fsMgr.getBBoxCache( sqlFeatureStoreId );
         } else {
             LOG.warn( "Unmanaged feature store." );
         }

--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/DeegreeWorkspaceUpdater.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/DeegreeWorkspaceUpdater.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
@@ -170,9 +171,10 @@ public class DeegreeWorkspaceUpdater {
         final String path = file.getAbsolutePath();
         if ( path.contains( "appschemas" ) )
             return true;
-        if ( "bbox_cache.properties".equals( file.getName() ) )
+        String fileName = file.getName();
+        if ( Pattern.matches( "bbox_cache.*\\.properties", fileName ) )
             return true;
-        if ( "main.xml".equals( file.getName() ) )
+        if ( "main.xml".equals( fileName ) )
             return true;
         return false;
     }

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/featurestores.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/featurestores.adoc
@@ -2009,3 +2009,17 @@ After entering the URL, click *Import*:
 
 .Imported INSPIRE datasets via the Loader
 image::console_featurestore_mapping20.jpg[Imported INSPIRE datasets via the Loader,scaledwidth=50.0%]
+
+==== Spatial extent of FeatureTypes
+
+The spatial extent of all feature types defined in the SQLFeatureStore configuration are cached in a file named bbox_cache_<FeatureStoreId>.properties. The file is created when the workspace is initialised.
+The file contains the bounding box with its coordinate system assigned to the qualified name of each feature type, e.g.:
+
+----
+{http\://www.deegree.org/app}Lakes=epsg\:4326,11.16,51.29,14.83,53.59
+{http\://www.deegree.org/app}Railroads=epsg\:4326,11.16,51.29,14.83,53.59
+----
+
+Inserting new features via WFS-T results in an increased bounding box in the bbox_cache_<FeatureStoreId>.properties file, if the extent did not include the features.
+The file can also be used to configure the bounding box to a larger extent than the data, e.g. if the extent is already known but not all data imported.
+The extent of a FeatureType is written in the capabilities as WGS84BoundingBox (WFS 2.0) of the FeatureType.


### PR DESCRIPTION
This PR replaces the current bbox_cache.properties with bbox_cache_<SQLFeatureStoreId>.properties, therefore enabling the configuration of an individual spatial extend of FeatureTypes with the same name configured in different SQLFeatureStore.

This PR does not solve issue #824!