### PR TITLE
Upgrade of Spring dependencies

### DIFF
--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/CommonConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/CommonConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.batch.JobLauncherCommandLineRunner;
+import org.springframework.boot.autoconfigure.batch.JobLauncherApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -47,8 +47,8 @@ public class CommonConfiguration {
     private JobRepository jobRepository;
 
     @Bean
-    public JobLauncherCommandLineRunner runner() {
-        return new JobLauncherCommandLineRunner( jobLauncher, jobExplorer, jobRepository );
+    public JobLauncherApplicationRunner runner() {
+        return new JobLauncherApplicationRunner( jobLauncher, jobExplorer, jobRepository );
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1207,9 +1207,9 @@
     <oracle.version>19.9.0.0</oracle.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <spring-boot.version>2.5.14</spring-boot.version>
-    <spring-batch.version>4.3.6</spring-batch.version>
-    <spring-framework.version>5.3.20</spring-framework.version>
+    <spring-boot.version>2.7.10</spring-boot.version>
+    <spring-batch.version>4.3.8</spring-batch.version>
+    <spring-framework.version>5.3.26</spring-framework.version>
     <batik.version>1.14</batik.version>
     <axoim.version>1.2.22</axoim.version>
     <jsonpath.version>2.7.0</jsonpath.version>


### PR DESCRIPTION
This PR upgrades the Spring dependencies:
- Spring Boot from 2.5.15 to 2.7.10 
- Spring Batch from 4.3.6 to 4.3.8
- Spring Core from 5.3.20 to 5.3.26

This fixes a known vulnerability [CVE-2023-20861: Spring Expression DoS Vulnerability](https://spring.io/security/cve-2023-20861) 