### PR TITLE
Upgrade of woodstox to v5.1.0

### DIFF
--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -39,8 +39,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.woodstox</groupId>
-      <artifactId>woodstox-core-lgpl</artifactId>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ws.commons.axiom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -686,15 +686,9 @@
       </dependency>
       <!-- XML -->
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId>
-        <artifactId>woodstox-core-lgpl</artifactId>
-        <version>4.2.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.stream</groupId>
-            <artifactId>stax-api</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>5.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>


### PR DESCRIPTION
This PR upgrades woodstox library to version 5.1.0 and resolves a duplication of classes introduced by `deegree-core-commons`:
```
[INFO] |  +- org.deegree:deegree-core-commons:jar:3.5.0-SNAPSHOT:compile
[INFO] |  |  +- org.codehaus.woodstox:woodstox-core-lgpl:jar:4.2.1:compile
[INFO] |  |  +- org.apache.ws.commons.axiom:axiom-api:jar:1.2.22:compile
[INFO] |  |  |  +- org.apache.geronimo.specs:geronimo-activation_1.1_spec:jar:1.1:compile
[INFO] |  |  |  +- org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:jar:1.0.1:compile
[INFO] |  |  |  \- org.apache.james:apache-mime4j-core:jar:0.7.2:compile
```

It also resolves the CVE  reported for woodstox-core-lgpl-4.2.0.jar (pkg:maven/org.codehaus.woodstox/woodstox-core-lgpl@4.2.0, cpe:2.3:a:fasterxml:woodstox:4.2.0:*:*:*:*:*:*:*) : CVE-2022-40152.
 
Dependencies of jaxws-rt:jar:2.3.3:
```
[INFO] |  +- com.sun.xml.ws:jaxws-rt:jar:2.3.3:runtime
[INFO] |  |  +- com.sun.xml.ws:policy:jar:2.7.10:runtime
[INFO] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.3.7:runtime
[INFO] |  |  +- org.glassfish.ha:ha-api:jar:3.1.12:runtime
[INFO] |  |  +- org.glassfish.external:management-api:jar:3.2.2:runtime
[INFO] |  |  +- org.glassfish.gmbal:gmbal:jar:4.0.1:runtime
[INFO] |  |  +- org.glassfish.pfl:pfl-tf:jar:4.1.0:runtime
[INFO] |  |  +- org.glassfish.pfl:pfl-basic:jar:4.1.0:runtime
[INFO] |  |  +- org.jvnet.staxex:stax-ex:jar:1.8.3:runtime
[INFO] |  |  +- com.sun.xml.stream.buffer:streambuffer:jar:1.5.9:runtime
[INFO] |  |  +- org.jvnet.mimepull:mimepull:jar:1.9.13:runtime
[INFO] |  |  +- com.sun.xml.fastinfoset:FastInfoset:jar:1.2.13:compile
[INFO] |  |  +- com.sun.activation:jakarta.activation:jar:1.2.2:runtime
[INFO] |  |  +- com.sun.xml.messaging.saaj:saaj-impl:jar:1.5.3:runtime
[INFO] |  |  +- com.fasterxml.woodstox:woodstox-core:jar:5.1.0:runtime
[INFO] |  |  \- org.codehaus.woodstox:stax2-api:jar:4.1:compile
```