### PR TITLE
Remove WFS namespace prefix in the title of a FeatureType

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -270,11 +270,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
             if ( ftMd != null && ftMd.getTitle( null ) != null ) {
                 writer.writeCharacters( ftMd.getTitle( null ).getString() );
             } else {
-                if ( prefix != null ) {
-                    writer.writeCharacters( prefix + ":" + ftName.getLocalPart() );
-                } else {
-                    writer.writeCharacters( ftName.getLocalPart() );
-                }
+                writer.writeCharacters( ftName.getLocalPart() );
             }
             writer.writeEndElement();
 

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -654,7 +654,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
                 if ( ftMd != null && ftMd.getTitle( null ) != null ) {
                     writer.writeCharacters( ftMd.getTitle( null ).getString() );
                 } else {
-                    writer.writeCharacters( prefix + ":" + ftName.getLocalPart() );
+                    writer.writeCharacters( ftName.getLocalPart() );
                 }
                 writer.writeEndElement();
 
@@ -995,7 +995,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
                 if ( ftMd != null && ftMd.getTitle( null ) != null ) {
                     writer.writeCharacters( ftMd.getTitle( null ).getString() );
                 } else {
-                    writer.writeCharacters( prefix + ":" + ftName.getLocalPart() );
+                    writer.writeCharacters( ftName.getLocalPart() );
                 }
                 writer.writeEndElement();
 


### PR DESCRIPTION
With this pull request, the WFS namespace prefix in the title of a FeatureType is removed. 

As example, an excerpt of a FeatureType description in the WFS 2.0.0 capabilities with the proposed changes:

```
<FeatureType>
  <Name xmlns:xplan="http://www.deegree.org/xplanung/1/0">xplan:BP_Plan</Name>
  <Title>BP_Plan</Title>
  <DefaultCRS>EPSG:25832</DefaultCRS> 
```
Additionally, this is how the FeatureTypes titles are displayed with a WFS connection in QGIS:

![Screenshot from 2023-04-17 12-55-46](https://user-images.githubusercontent.com/74777462/232468651-004ce69c-9709-4963-ab52-0036c48a3159.png)

This pull requests closes #1481 