### PR TITLE
Upgraded maven surefire, failsafe, enforcer and jetty plugins to latest versions

### DIFF
--- a/deegree-tests/deegree-integration-tests/pom.xml
+++ b/deegree-tests/deegree-integration-tests/pom.xml
@@ -82,7 +82,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M5</version>
         <executions>
           <execution>
             <id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0</version>
           <configuration>
             <!-- Travis build workaround -->
             <argLine>-Djava.awt.headless=true -Xms1024m -Xmx2048m --illegal-access=permit
@@ -154,7 +154,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0</version>
           <configuration>
             <argLine>
               --illegal-access=permit
@@ -238,7 +238,7 @@
         <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>10.0.12</version>
+          <version>10.0.15</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -323,7 +323,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -381,7 +381,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.6.1</version>
+            <version>1.6.2</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
This PR upgrades the maven plugins used for testing:
- surefire
- failsafe
- jetty (running the webapps for integration testing)
- and the enforcer plugins which checks for duplicate classes.