### PR TITLE
Improved tests for GMLGeometryValidator handling left- and right-handed CRS

### DIFF
--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/geometry/gml/validation/GmlGeometryValidatorTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/geometry/gml/validation/GmlGeometryValidatorTest.java
@@ -110,6 +110,51 @@ public class GmlGeometryValidatorTest {
         Assert.assertTrue( ( (InteriorRingOrientation) ( eventHandler.getEvents().get( 1 ).getEvent() ) ).isClockwise() );
         Assert.assertTrue( ( (InteriorRingOrientation) ( eventHandler.getEvents().get( 2 ).getEvent() ) ).isClockwise() );
     }
+    
+        @Test
+    public void validateLeftHandRightHandClockwiseOrientation()
+                            throws XMLStreamException, UnknownCRSException, FactoryConfigurationError, IOException {
+        TestEventHandler eventHandler = validate( "invalid/LeftHanded_exterior_clockwise_interior_clockwise.gml" );
+        assertEquals( 2, eventHandler.getEvents().size() );
+        Assert.assertTrue( ( (ExteriorRingOrientation) ( eventHandler.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertFalse( ( (InteriorRingOrientation) ( eventHandler.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+        TestEventHandler eventHandler2 = validate( "invalid/LeftHanded_exterior_clockwise_interior_anticlockwise.gml" );
+        assertEquals( 2, eventHandler2.getEvents().size() );
+        Assert.assertTrue( ( (ExteriorRingOrientation) ( eventHandler2.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertTrue( ( (InteriorRingOrientation) ( eventHandler2.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+	TestEventHandler eventHandler3 = validate( "invalid/LeftHanded_exterior_anticlockwise_interior_clockwise.gml" );
+        assertEquals( 2, eventHandler3.getEvents().size() );
+        Assert.assertFalse( ( (ExteriorRingOrientation) ( eventHandler3.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertFalse( ( (InteriorRingOrientation) ( eventHandler3.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+	TestEventHandler eventHandler4 = validate( "invalid/LeftHanded_exterior_anticlockwise_interior_anticlockwise.gml" );
+        assertEquals( 2, eventHandler4.getEvents().size() );
+        Assert.assertFalse( ( (ExteriorRingOrientation) ( eventHandler4.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertTrue( ( (InteriorRingOrientation) ( eventHandler4.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+        TestEventHandler eventHandler5 = validate( "invalid/RightHanded_exterior_clockwise_interior_clockwise.gml" );
+        assertEquals( 2, eventHandler5.getEvents().size() );
+        Assert.assertFalse( ( (ExteriorRingOrientation) ( eventHandler5.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertTrue( ( (InteriorRingOrientation) ( eventHandler5.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+        TestEventHandler eventHandler6 = validate( "invalid/RightHanded_exterior_clockwise_interior_anticlockwise.gml" );
+        assertEquals( 2, eventHandler6.getEvents().size() );
+        Assert.assertFalse( ( (ExteriorRingOrientation) ( eventHandler6.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertFalse( ( (InteriorRingOrientation) ( eventHandler6.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+        TestEventHandler eventHandler7 = validate( "invalid/RightHanded_exterior_anticlockwise_interior_clockwise.gml" );
+        assertEquals( 2, eventHandler7.getEvents().size() );
+        Assert.assertTrue( ( (ExteriorRingOrientation) ( eventHandler7.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertTrue( ( (InteriorRingOrientation) ( eventHandler7.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+        
+        TestEventHandler eventHandler8 = validate( "invalid/RightHanded_exterior_anticlockwise_interior_anticlockwise.gml" );
+        assertEquals( 2, eventHandler8.getEvents().size() );
+        Assert.assertTrue( ( (ExteriorRingOrientation) ( eventHandler8.getEvents().get( 0 ).getEvent() ) ).isExterior() );
+        Assert.assertFalse( ( (InteriorRingOrientation) ( eventHandler8.getEvents().get( 1 ).getEvent() ) ).isInterior() );
+
+	}
 
     private TestEventHandler validate( String resourceName )
                             throws XMLStreamException, UnknownCRSException, FactoryConfigurationError, IOException {

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_anticlockwise_interior_anticlockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_anticlockwise_interior_anticlockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/4258" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570111 2886900 4570122 2886900 4570122 2886911 4570122 2886922 4570111 2886922 4570100 2886922 4570100 2886911 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570111 2886910 4570112 2886910 4570112 2886911 4570112 2886912 4570111 2886912 4570110 2886912 4570110 2886911 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_anticlockwise_interior_clockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_anticlockwise_interior_clockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/4258" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570111 2886900 4570122 2886900 4570122 2886911 4570122 2886922 4570111 2886922 4570100 2886922 4570100 2886911 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570110 2886911 4570110 2886912 4570111 2886912 4570112 2886912 4570112 2886911 4570112 2886910 4570111 2886910 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_clockwise_interior_anticlockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_clockwise_interior_anticlockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/4258" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570100 2886911 4570100 2886922 4570111 2886922 4570122 2886922 4570122 2886911 4570122 2886900 4570111 2886900 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570111 2886910 4570112 2886910 4570112 2886911 4570112 2886912 4570111 2886912 4570110 2886912 4570110 2886911 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_clockwise_interior_clockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/LeftHanded_exterior_clockwise_interior_clockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/4258" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570100 2886911 4570100 2886922 4570111 2886922 4570122 2886922 4570122 2886911 4570122 2886900 4570111 2886900 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570110 2886911 4570110 2886912 4570111 2886912 4570112 2886912 4570112 2886911 4570112 2886910 4570111 2886910 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_anticlockwise_interior_anticlockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_anticlockwise_interior_anticlockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/25830" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570111 2886900 4570122 2886900 4570122 2886911 4570122 2886922 4570111 2886922 4570100 2886922 4570100 2886911 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570111 2886910 4570112 2886910 4570112 2886911 4570112 2886912 4570111 2886912 4570110 2886912 4570110 2886911 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_anticlockwise_interior_clockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_anticlockwise_interior_clockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/25830" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570111 2886900 4570122 2886900 4570122 2886911 4570122 2886922 4570111 2886922 4570100 2886922 4570100 2886911 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570110 2886911 4570110 2886912 4570111 2886912 4570112 2886912 4570112 2886911 4570112 2886910 4570111 2886910 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_clockwise_interior_anticlockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_clockwise_interior_anticlockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/25830" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570100 2886911 4570100 2886922 4570111 2886922 4570122 2886922 4570122 2886911 4570122 2886900 4570111 2886900 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570111 2886910 4570112 2886910 4570112 2886911 4570112 2886912 4570111 2886912 4570110 2886912 4570110 2886911 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_clockwise_interior_clockwise.gml
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/misc/geometry/invalid/RightHanded_exterior_clockwise_interior_clockwise.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Polygon xmlns="http://www.opengis.net/gml" xmlns:gml="http://www.opengis.net/gml" srsName="http://www.opengis.net/def/crs/EPSG/0/25830" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/geometryPrimitives.xsd">
+	<exterior>
+		<LinearRing>
+			<posList>4570100 2886900 4570100 2886911 4570100 2886922 4570111 2886922 4570122 2886922 4570122 2886911 4570122 2886900 4570111 2886900 4570100 2886900</posList>
+		</LinearRing>
+	</exterior>
+	<interior>
+		<LinearRing>
+			<posList>4570110 2886910 4570110 2886911 4570110 2886912 4570111 2886912 4570112 2886912 4570112 2886911 4570112 2886910 4570111 2886910 4570110 2886910</posList>
+		</LinearRing>
+	</interior>
+</Polygon>


### PR DESCRIPTION
A new test has been created in the [GMLGeometryValidatorTest.java](http://gmlgeometryvalidatortest.java/).
It tests the orientations of polygons declared with left-handed CRS and right-handed CRS.
We have added 8 different .gml files, considering all possible scenarios:
* CRS: left-handed, right-handed
* Exterior ring: clockwise, counterclockwise
* Interior ring: clockwise, counterclockwise
Included files are:
- LeftHanded_exterior_anticlockwise_interior_anticlockwise.gml
- LeftHanded_exterior_anticlockwise_interior_clockwise.gml
- LeftHanded_exterior_clockwise_interior_anticlockwise.gml
- LeftHanded_exterior_clockwise_interior_clockwise.gml
- RightHanded_exterior_anticlockwise_interior_anticlockwise.gml
- RightHanded_exterior_anticlockwise_interior_clockwise.gml
- RightHanded_exterior_clockwise_interior_anticlockwise.gml
- RightHanded_exterior_clockwise_interior_clockwise.gml






