### PR TITLE
Fix invalid SQL when OrderBy is configured in SQLFeatureStore 

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SortCriterion.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SortCriterion.java
@@ -1,25 +1,33 @@
 package org.deegree.sqldialect;
 
+import org.deegree.commons.jdbc.TableName;
+
 /**
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
  */
 public class SortCriterion {
 
-    private final String columneName;
+    private final String columName;
+
+    private final TableName tableName;
 
     private final boolean sortAscending;
 
-    public SortCriterion( String columneName, boolean sortAscending ) {
-        this.columneName = columneName;
+    public SortCriterion( String columName, TableName tableName, boolean sortAscending ) {
+        this.columName = columName;
         this.sortAscending = sortAscending;
+        this.tableName = tableName;
     }
 
-    public String getColumneName() {
-        return columneName;
+    public String getColumName() {
+        return columName;
+    }
+
+    public TableName getTableName() {
+        return tableName;
     }
 
     public boolean isSortAscending() {
         return sortAscending;
     }
-
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SortCriterion.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SortCriterion.java
@@ -7,20 +7,20 @@ import org.deegree.commons.jdbc.TableName;
  */
 public class SortCriterion {
 
-    private final String columName;
+    private final String columnName;
 
     private final TableName tableName;
 
     private final boolean sortAscending;
 
-    public SortCriterion( String columName, TableName tableName, boolean sortAscending ) {
-        this.columName = columName;
+    public SortCriterion( String columnName, TableName tableName, boolean sortAscending ) {
+        this.columnName = columnName;
         this.sortAscending = sortAscending;
         this.tableName = tableName;
     }
 
-    public String getColumName() {
-        return columName;
+    public String getColumnName() {
+        return columnName;
     }
 
     public TableName getTableName() {

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -981,8 +981,8 @@ public abstract class AbstractWhereBuilder {
             if ( sortCriteria.indexOf( sortCriterion ) > 0 ) {
                 builder.add( "," );
             }
-            String rootTableAlias = aliasManager.getRootTableAlias();
-            String columnName = sortCriterion.getColumneName();
+            String rootTableAlias = aliasManager.getTableAlias( sortCriterion.getTableName() );
+            String columnName = sortCriterion.getColumName();
             builder.add( rootTableAlias == null ? columnName : ( rootTableAlias + "." + columnName ) );
             if ( sortCriterion.isSortAscending() ) {
                 builder.add( " ASC" );

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -982,7 +982,7 @@ public abstract class AbstractWhereBuilder {
                 builder.add( "," );
             }
             String rootTableAlias = aliasManager.getTableAlias( sortCriterion.getTableName() );
-            String columnName = sortCriterion.getColumName();
+            String columnName = sortCriterion.getColumnName();
             builder.add( rootTableAlias == null ? columnName : ( rootTableAlias + "." + columnName ) );
             if ( sortCriterion.isSortAscending() ) {
                 builder.add( " ASC" );

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
@@ -57,7 +57,6 @@ import javax.xml.bind.JAXBElement;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.RecognitionException;
-import org.deegree.commons.config.DeegreeWorkspace;
 import org.deegree.commons.jdbc.SQLIdentifier;
 import org.deegree.commons.jdbc.TableName;
 import org.deegree.commons.tom.primitive.BaseType;
@@ -236,12 +235,13 @@ public abstract class AbstractMappedSchemaBuilder {
         return null;
     }
 
-    protected List<SortCriterion> createSortCriteria( FeatureTypeMappingJAXB ftDecl ) {
+    protected List<SortCriterion> createSortCriteria( FeatureTypeMappingJAXB ftDecl, TableName tableName ) {
         if ( ftDecl.getOrderBy() != null ) {
             List<OrderByJAXB.Column> columns = ftDecl.getOrderBy().getColumn();
             List<SortCriterion> sortCriteria = columns.stream().map(
-                                    o -> new SortCriterion( o.getName(), "ASC".equals( o.getSortOrder() ) ) ).collect(
-                                    Collectors.toList() );
+                            o -> new SortCriterion( o.getName(), tableName, "ASC".equals( o.getSortOrder() )
+                            ) ).collect(
+                            Collectors.toList() );
             return sortCriteria;
         }
         return Collections.emptyList();

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
@@ -331,7 +331,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
             particleMappings.add( buildMapping( ftTable, new Pair<XSElementDeclaration, Boolean>( elDecl, TRUE ),
                                                 particle.getValue() ) );
         }
-        List<SortCriterion> sortCriteria = createSortCriteria( ftMappingConf );
+        List<SortCriterion> sortCriteria = createSortCriteria( ftMappingConf, ftTable );
         return new FeatureTypeMapping( ftName, ftTable, fidMapping, particleMappings, sortCriteria );
     }
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
@@ -103,9 +103,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Generates {@link MappedAppSchema} instances (table-driven mode).
- * 
+ *
  * @author <a href="mailto:schneider@occamlabs.de">Markus Schneider</a>
- * 
+ *
  * @since 3.2
  */
 public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
@@ -129,7 +129,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 
     /**
      * Creates a new {@link MappedSchemaBuilderTable} instance.
-     * 
+     *
      * @param jdbcConnId
      *            identifier of JDBC connection, must not be <code>null</code> (used to determine columns / types)
      * @param ftDecls
@@ -155,7 +155,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 
     /**
      * Returns the {@link MappedAppSchema} derived from configuration / tables.
-     * 
+     *
      * @return mapped application schema, never <code>null</code>
      */
     @Override
@@ -198,7 +198,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
         FIDMapping fidMapping = buildFIDMapping( table, ftName, ftDecl.getFIDMapping() );
 
         List<JAXBElement<? extends AbstractParticleJAXB>> propDecls = ftDecl.getAbstractParticle();
-        List<SortCriterion> sortCriteria = createSortCriteria( ftDecl );
+        List<SortCriterion> sortCriteria = createSortCriteria( ftDecl, table );
         if ( propDecls != null && !propDecls.isEmpty() ) {
             buildFeatureTypeAndMapping( table, ftName, fidMapping, propDecls, sortCriteria );
         } else {


### PR DESCRIPTION
When OrderBy is configured in SQLFeatureStore
```
    </FIDMapping>
    <OrderBy>
      <Column name="a" />
    </OrderBy>
```

A GetFeature request results in a failure because of an invalid SQL Statement:

`SELECT X2.a, X2.b. FROM table X2 ORDER BY X1.a ASC`

The failure is fixed by using the table alias order by is configured for instead of the root alias. 
 