### PR TITLE
Replaced org:deegree:junidecode:0.2 with net.gcardone.junidecode:junidecode.0.4.1

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -68,7 +68,7 @@
       <artifactId>antlr-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>net.gcardone.junidecode</groupId>
       <artifactId>junidecode</artifactId>
     </dependency>
   </dependencies>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/MappingContextManager.java
@@ -40,7 +40,7 @@ import java.util.UUID;
 
 import javax.xml.namespace.QName;
 
-import gcardone.junidecode.Junidecode;
+import net.gcardone.junidecode.Junidecode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1172,9 +1172,9 @@
         <version>${antlr.version}</version>
       </dependency>
       <dependency>
-        <groupId>${project.groupId}</groupId>
+        <groupId>net.gcardone.junidecode</groupId>
         <artifactId>junidecode</artifactId>
-        <version>0.2</version>
+        <version>0.4.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
Replaced deegree version of junidecode build from https://github.com/deegree/junidecode build with https://buildserver.deegree.org/view/misc/job/internal/job/junidecode/ with official version from maven central https://central.sonatype.com/artifact/net.gcardone.junidecode/junidecode/0.4.1  