### PR TITLE
Update database information in documentation and include sqldialect for oracle and mssql in regular webservices

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -15,26 +15,6 @@
     <version>3.5.0-SNAPSHOT</version>
   </parent>
 
-  <profiles>
-    <profile>
-      <id>mssql</id>
-      <repositories>
-        <repository>
-          <id>deegree-restricted</id>
-          <name>deegree-restricted</name>
-          <url>https://repo.deegree.org/content/repositories/private3rdparty</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <groupId>com.microsoft.sqlserver</groupId>
-          <artifactId>mssql-jdbc</artifactId>
-          <version>10.2.2.jre11</version>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.deegree</groupId>
@@ -45,6 +25,10 @@
       <groupId>org.deegree</groupId>
       <artifactId>deegree-core-db</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-core/deegree-core-sqldialect/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/pom.xml
@@ -11,20 +11,11 @@
     <version>3.5.0-SNAPSHOT</version>
   </parent>
 
-  <profiles>
-    <profile>
-      <id>mssql</id>
-      <modules>
-        <module>deegree-sqldialect-mssql</module>
-      </modules>
-    </profile>
-  </profiles>
-
   <modules>
     <module>deegree-sqldialect-commons</module>
     <module>deegree-sqldialect-postgis</module>
     <module>deegree-sqldialect-oracle</module>
+    <module>deegree-sqldialect-mssql</module>
   </modules>
-
 </project>
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -48,6 +48,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <artifactId>deegree-sqldialect-mssql</artifactId>
+      <groupId>org.deegree</groupId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -72,26 +78,5 @@
       <artifactId>junidecode</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>mssql</id>
-      <repositories>
-        <repository>
-          <id>deegree-restricted</id>
-          <name>deegree-restricted</name>
-          <url>https://repo.deegree.org/content/repositories/private3rdparty</url>
-        </repository>
-      </repositories>
-      <dependencies>
-        <dependency>
-          <artifactId>deegree-sqldialect-mssql</artifactId>
-          <groupId>org.deegree</groupId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
 </project>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
@@ -107,8 +107,8 @@ The following deegree resources support Oracle Spatial databases:
 
 In order to enable Oracle connectivity for these resources, you need to
 add a compatible Oracle JDBC driver (e.g.
-_ojdbc11.jar_)footnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html
-(registration required)] (see <<anchor-adding-jars>>).
+_ojdbc11.jar_)footnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
+(see <<anchor-adding-jars>>).
 
 ==== Adding Oracle GeoRaster support
 
@@ -151,5 +151,5 @@ The following deegree resources support Microsoft SQL Server:
 
 In order to enable Microsoft SQL Server connectivity for these
 resources, you need to add a compatible Microsoft JDBC driver (e.g.
-_sqljdbc4.jar_)footnote:[http://msdn.microsoft.com/en-us/sqlserver/aa937724.aspx] 
+_sqljdbc4.jar_)footnote:[https://learn.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server] 
 (see <<anchor-adding-jars>>).

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
@@ -118,8 +118,7 @@ in Oracle databases.
 In order to enable Oracle connectivity for these resources, you need to
 add the following JAR files (see <<anchor-adding-jars>>):
 
-* A compatible Oracle JDBC-driverfootnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html
-(registration required)]
+* A compatible Oracle JDBC-driverfootnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
 ** ojdbc11.jar
 * The Oracle Spatial and GeoRaster libraries and their dependencies
 ** sdoapi.jar

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
@@ -106,12 +106,9 @@ The following deegree resources support Oracle Spatial databases:
 * ISOMetadataStore
 
 In order to enable Oracle connectivity for these resources, you need to
-add two JAR files (see <<anchor-adding-jars>>):
-
-* A compatible Oracle JDBC driver (e.g.
-_ojdbc11.jar_)footnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
-* Module
-deegree-sqldialect-oraclefootnote:[https://repo.deegree.org/service/rest/repository/browse/public/org/deegree/deegree-sqldialect-oracle/${project.version}/deegree-sqldialect-oracle-${project.version}.jar]
+add a compatible Oracle JDBC driver (e.g.
+_ojdbc11.jar_)footnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html
+(registration required)] (see <<anchor-adding-jars>>).
 
 ==== Adding Oracle GeoRaster support
 
@@ -121,7 +118,8 @@ in Oracle databases.
 In order to enable Oracle connectivity for these resources, you need to
 add the following JAR files (see <<anchor-adding-jars>>):
 
-* A compatible Oracle JDBC-driverfootnote:[hhttps://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
+* A compatible Oracle JDBC-driverfootnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html
+(registration required)]
 ** ojdbc11.jar
 * The Oracle Spatial and GeoRaster libraries and their dependencies
 ** sdoapi.jar
@@ -130,8 +128,6 @@ add the following JAR files (see <<anchor-adding-jars>>):
 ** sdoutl.jar
 ** xdb6.jar
 ** xmlparserv2_sans_jaxp_services.jar
-* Module
-deegree-coveragestore-oracle-georasterfootnote:[https://repo.deegree.org/service/rest/repository/browse/public/org/deegree/deegree-coveragestore-oracle-georaster/${project.version}/deegree-coveragestore-oracle-georaster-${project.version}.jar]
 
 NOTE: The Oracle Spatial and GeoRaster libraries can be found, without version
 number in filename, inside the Oracle Database installation directory.
@@ -154,9 +150,6 @@ The following deegree resources support Microsoft SQL Server:
 * ISOMetadataStore
 
 In order to enable Microsoft SQL Server connectivity for these
-resources, you need to add two JAR files (see <<anchor-adding-jars>>):
-
-* A compatible Microsoft JDBC driver (e.g.
-_sqljdbc4.jar_)footnote:[https://learn.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server]
-* Module
-deegree-sqldialect-mssqlfootnote:[https://repo.deegree.org/service/rest/repository/browse/public/org/deegree/deegree-sqldialect-mssql/${project.version}/deegree-sqldialect-mssql-${project.version}.jar]
+resources, you need to add a compatible Microsoft JDBC driver (e.g.
+_sqljdbc4.jar_)footnote:[http://msdn.microsoft.com/en-us/sqlserver/aa937724.aspx] 
+(see <<anchor-adding-jars>>).

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -30,18 +30,21 @@ PostgreSQL/PostGIS, Oracle Spatial or Microsoft SQL Server.
 
 deegree currently supports the following backends:
 
-* PostgreSQL 9.4, 9.5, 9.6 with PostGIS extension 2.3, 2.4, 2.5
-* Oracle Spatial 19
-* Microsoft SQL Server 2012
+* PostgreSQL 12+ with PostGIS extension 3.0+
+* Oracle Spatial 18.3, 19.x and 21.1  
+** https://www.oracle.com/de/database/technologies/faq-jdbc.html[See compatibility matrix of driver version 19.9]
+* Microsoft SQL Server 2012, 2014, 2016, 2017 and 2019 
+** https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix[See compatibility matrix of driver version 10.2]
 
 TIP: If you want to use Oracle Spatial or Microsoft SQL Server, you will need
 to add additional modules first. This is described in
 <<anchor-db-libraries>>.
 
-NOTE: By default, deegree webservices includes JDBC drivers for connecting to
-PostgreSQL and Derby databases. If you want to make a connection to
-other SQL databases (e.g. Oracle), you will need to add a compatible
-JDBC driver manually. This is described in <<anchor-oraclejars>>.
+NOTE: By default, deegree webservices includes a JDBC driver for connecting to
+PostgreSQL. If you want to make a connection to other SQL databases 
+(e.g. Oracle), you will need to add a compatible JDBC driver manually. 
+This is described in <<anchor-oraclejars>>.
+
 
 ==== Minimal configuration example (PostgreSQL)
 

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -103,40 +103,6 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>mssql</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.deegree</groupId>
-          <artifactId>deegree-sqldialect-mssql</artifactId>
-          <version>${project.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>com.microsoft.sqlserver</groupId>
-              <artifactId>mssql-jdbc</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>oracle</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.deegree</groupId>
-          <artifactId>deegree-sqldialect-oracle</artifactId>
-          <version>${project.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>com.oracle.database.jdbc</groupId>
-              <artifactId>ojdbc8</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
   <dependencies>
     <dependency>
       <groupId>org.deegree</groupId>
@@ -192,6 +158,28 @@
       <groupId>org.deegree</groupId>
       <artifactId>deegree-sqldialect-postgis</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-sqldialect-oracle</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.oracle.database.jdbc</groupId>
+          <artifactId>ojdbc8</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.deegree</groupId>
+      <artifactId>deegree-sqldialect-mssql</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.microsoft.sqlserver</groupId>
+          <artifactId>mssql-jdbc</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.deegree</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -813,7 +813,7 @@
         <artifactId>postgresql</artifactId>
         <version>42.5.2</version>
       </dependency>
-      <!-- Oracle (Offical provided driver from repo1.maven.org) -->
+      <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc8</artifactId>
@@ -849,6 +849,12 @@
         <groupId>com.oracle.database.xml</groupId>
         <artifactId>xdb</artifactId>
         <version>${oracle.version}</version>
+      </dependency>
+      <!-- MSSQL (Official provided driver from repo1.maven.org) -->
+      <dependency>
+        <groupId>com.microsoft.sqlserver</groupId>
+        <artifactId>mssql-jdbc</artifactId>
+        <version>10.2.2.jre11</version>
       </dependency>
       <!-- Batik -->
       <dependency>


### PR DESCRIPTION
With this PR the list of supported database was updated based on the compatibility matrices of the respected database drivers.

Additionally the usage of the profiles mssql and oracle was reduced since the jdbc drivers are available at repo1.maven.org.
For easier usage of webservices war the sqldialects of mssql and oracle will now be included by default (Note: JDBC driver has still to be provided manually)

closes #1474

References:
* #1474  
* https://search.maven.org/artifact/com.microsoft.sqlserver/mssql-jdbc/10.2.2.jre11/jar
  *  https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/10.2.2.jre11/mssql-jdbc-10.2.2.jre11.jar
 