### PR TITLE
Introduce spring-javaformat-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,20 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>io.spring.javaformat</groupId>
+        <artifactId>spring-javaformat-maven-plugin</artifactId>
+        <version>0.0.38</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <inherited>true</inherited>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,8 @@
         <groupId>io.spring.javaformat</groupId>
         <artifactId>spring-javaformat-maven-plugin</artifactId>
         <version>0.0.38</version>
-        <executions>
+        <!-- Can be activated as soon as formatting was executed -->
+        <!--<executions>
           <execution>
             <phase>validate</phase>
             <inherited>true</inherited>
@@ -397,7 +398,7 @@
               <goal>validate</goal>
             </goals>
           </execution>
-        </executions>
+        </executions>-->
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This PR introduces the spring-javaformat-maven-plugin.
The plugin enables validation if code is formatted correctly (otherwise build fails) and formatting via Maven.
The formatter does not include formatting of imports.
Validation was commented out and can be activated as soon as formatting was executed.

Closes #1260