### PR TITLE
Fix Jenkinsfile pipeline to use Warnings NG Jenkins plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,13 +52,12 @@ pipeline {
             }
             steps {
                 echo 'Quality checking'
-                sh 'mvn -B -C -fae -P oracle,mssql com.github.spotbugs:spotbugs-maven-plugin:spotbugs checkstyle:checkstyle javadoc:javadoc'
+                sh 'mvn -B -C -fae -P oracle,mssql com.github.spotbugs:spotbugs-maven-plugin:spotbugs javadoc:javadoc'
             }
             post {
-                success {
-                    findbugs canComputeNew: false, defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', pattern: '**/spotbugsXml.xml', unHealthy: ''
-                    checkstyle canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: '**/checkstyle-result.xml', unHealthy: ''
-                    javadoc javadocDir: '**/target/site/apidocs', keepAll: true
+                always {
+                    recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc()]
+                    recordIssues enabledForFailure: true, tool: spotBugs()
                 }
             }
         }


### PR DESCRIPTION
This PR changes the plugin to report the output of maven plugins such as javadoc, spotbugs, and other to [Jenkins warnings next generation plugin](https://github.com/jenkinsci/warnings-ng-plugin).