### PR TITLE
Upgrade of maven surefire and failsafe plugins to v3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
           <configuration>
             <!-- Travis build workaround -->
             <argLine>-Djava.awt.headless=true -Xms1024m -Xmx2048m --illegal-access=permit
@@ -154,7 +154,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
           <configuration>
             <argLine>
               --illegal-access=permit


### PR DESCRIPTION
This PR upgrades the maven surefire and failsafe plugins to latest version, fixing build error during execution of unit tests in deegree-core-base module.