### PR TITLE
Enhanced pipeline to publish artifacts on jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
         }
         stage ('Release') {
             when {
-                allOf{
+                allOf {
                     triggeredBy cause: "UserIdCause", detail: "tmc"
                     expression { return params.PERFORM_RELEASE }
                 }
@@ -74,8 +74,8 @@ pipeline {
             }
             post {
                 success {
-                    archiveArtifacts artifacts: 'checkout/**/target/deegree-webservices-*.war', fingerprint: true
-                    archiveArtifacts artifacts: 'checkout/**/target/deegree-webservices-handbook*.zip', fingerprint: true
+                    archiveArtifacts artifacts: '**/target/deegree-webservices-*.war', fingerprint: true
+                    archiveArtifacts artifacts: '**/target/deegree-webservices-handbook*.zip', fingerprint: true
                 }
             }
         }


### PR DESCRIPTION
This PR enhances the pipeline to re-enable the publishing of artifacts created during install **and** release step.
Reverting the change introduced with #1513.