### PR TITLE
Improved documentation for setting deegree workspace root

### DIFF
--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/basics.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/basics.adoc
@@ -76,7 +76,7 @@ sections:
 
 For example, to offer a Web Feature Service, a feature store (based on a
 shapefile, database, etc) must be configured. With a rasterfile, like a
-GeoTIFF, you can configured a tile store and a coverage store to offer a
+GeoTIFF, you can configure a tile store and a coverage store to offer a
 Web Map Service.
 
 .Workspace configuration dependencies
@@ -84,38 +84,39 @@ image::workspace-configuration-dependencies.png[Workspace configuration dependen
 
 === Location of the deegree workspace directory
 
-The active deegree workspace is part of the _.deegree_ directory which
+The active deegree workspace is part of the deegree workspace directory which
 stores a few global configuration files along with the workspace. The
 location of this directory depends on your operating system.
 
-==== Linux/Solaris/Mac OS X
+==== UNIX-like/Linux/macOS
 
-On UNIX-like systems (Linux/Solaris/MacOS X), deegree's configuration
-files are located in folder _<$HOME/.deegree/_. Note that _$HOME_ is
+On UNIX-like systems (Linux/macOS), deegree's configuration
+files are located in folder _$HOME/.deegree/_. Note that _$HOME_ is
 determined by the user that started the web application container that
 runs deegree. If you started the Java Servlet container as user
 "kelvin", then the directory will be something like
 _/home/kelvin/.deegree_.
 
 TIP: In order to use a different folder for deegree's configuration files,
-you can set the system environment variable _DEEGREE_WORKSPACE_ROOT_.
-Note that the user running the web application container must have
-read/write access to this directory.
+you can set the environment variable _DEEGREE_WORKSPACE_ROOT_, for example with `export DEEGREE_WORKSPACE_ROOT=/var/lib/tomcat9/.deegree`. When using Tomcat you can also set the path by defining a Java system property and appending the `JAVA_OPTS` or `CATALINA_OPTS` environment variable with `CATALINA_OPTS=-DDEEGREE_WORKSPACE_ROOT=/var/lib/tomcat9/.deegree`.
+
+IMPORTANT: Note that the user running the web application container must have
+read/write access to this directory! Since Debian 11 you have to grant explicitly write access to the default home directory by setting `ReadWritePaths=/var/lib/tomcat9/.deegree` in _/etc/systemd/system/multi-user.target.wants/tomcat9.service_!
 
 ==== Windows
 
-On Windows, deegree's configuration files are located in folder
+On a Windows operating system, deegree's configuration files are located in folder
 _%USERPROFILE%/.deegree/_. Note that _%USERPROFILE%_ is determined
 by the user that started the web application container that runs
 deegree. If you started the Java Servlet container as user "kelvin",
 then the directory will be something like _C:\Users\kelvin\.deegree_
-or _C:\Dokumente und Einstellungen\kelvin\.deegree_.
+or _C:\Documents and Settings\kelvin\.deegree_.
 
 TIP: In order to use a different folder for deegree's configuration files,
-you can set the system environment variable _DEEGREE_WORKSPACE_ROOT_.
-Note that the user running the web application container must have
-read/write access to this directory.
+you can set the system environment variable _DEEGREE_WORKSPACE_ROOT_, for example with `set DEEGREE_WORKSPACE_ROOT=C:\Program Files\Apache Tomcat\deegree`. When using Tomcat you can also set the path by defining a Java system property and appending the `JAVA_OPTS` or `CATALINA_OPTS` environment variable with `CATALINA_OPTS=-DDEEGREE_WORKSPACE_ROOT=C:\Program Files\Apache Tomcat\deegree`.
 
+IMPORTANT: Note that the user running the web application container must have
+read/write access to this directory!
 
 [[anchor-global-configuration]]
 ==== Global configuration files and the active workspace
@@ -141,7 +142,7 @@ files exist:
 |config.apikey |Contains the key to protect the REST API
 |===
 
-Note that only a single workspace can be active at a time. The
+NOTE: Only one single workspace can be active at a time! The
 information on the active one is stored in file _webapps.properties_.
 
 TIP: Usually, you don't need to care about the three files that are located
@@ -150,7 +151,7 @@ modifies them as required (e.g. when switching to a different
 workspace). In order to create a deegree webservices setup, you will
 need to create or edit resource configuration files in the active
 workspace directory. The remaining documentation will always refer to
-files in the (active) workspace directory.
+files in the active workspace directory.
 
 TIP: When multiple deegree webservices instances run on a single machine,
 every instance can use a different workspace. The file

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/index.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/index.adoc
@@ -4,6 +4,7 @@
 :toclevels: 5
 :numbered:
 :imagesdir: images
+:icons: font
 :source-highlighter: coderay
 :title-logo-image: images/logo_deegree.png
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/installation.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/installation.adoc
@@ -9,15 +9,15 @@ installation, including:
 
 * Microsoft Windows
 * Linux
-* MacOS
+* macOS
 
 Supported Java SE 11 versions are
 https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK 11]
 footnote:[Oracle JDK 8 and later requires a subscription from Oracle for use in production environments. Read further in https://www.oracle.com/java/java-se-subscription/[Oracle Java SE subscription].] and https://openjdk.org/projects/jdk/11/[OpenJDK 11]
 footnote:[OpenJDK binaries are provided by https://www.azul.com/downloads/#zulu[Azul Systems]
-or https://adoptium.net/[Temurin].].
+or https://adoptium.net/[Eclipse Temurin].].
 
-NOTE: Newer Java SE versions such as the LTS versions 17 are currently not supported by deegree 3.5. Please check out our wiki page https://github.com/deegree/deegree3/wiki/Java-SE-11-Support[Java 11 support] for further information.
+NOTE: Newer Java SE versions such as the LTS versions 17 are currently not supported by deegree 3.5. Please check out our wiki page https://github.com/deegree/deegree3/wiki/End-of-Life-and-Support-Matrix[End of Life and Support Matrix] for further information.
 
 === Downloading
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/renderstyles.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/renderstyles.adoc
@@ -1016,7 +1016,7 @@ For the cartographic design of text, it is possible to place a rectangular box b
 To enable the rectangular box behind a text use an negative value for the `Radius` of `Halo` in the `TextSymbolizer`.
 
 .Example of regular `Halo` (`Radius` of `3.0`) on the left and rectangular `Halo` (`Radius` of `-3.0`) on the right.
-image::renderstyles_halo_regular_and_boxed.png.png[]
+image::renderstyles_halo_regular_and_boxed.png[]
 
 .Symbolizer used in previous example
 [source,xml]


### PR DESCRIPTION
This PR improves the deegree webserivces handbook how to set the deegree workspace root directory with environment variable or Java system property. It also emphases the necessity that the directory is writable for the process running deegree. The PR contains also some minor enhancements in formating and highlighting content with icons.