### PR TITLE
Upgrading Spring Core to 5.3.27, Spring Boot to 2.5.15 and Spring Batch to 4.3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1152,9 +1152,9 @@
     <oracle.version>19.3.0.0</oracle.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <spring-boot.version>2.5.12</spring-boot.version>
-    <spring-batch.version>4.3.5</spring-batch.version>
-    <spring-framework.version>5.3.18</spring-framework.version>
+    <spring-boot.version>2.5.15</spring-boot.version>
+    <spring-batch.version>4.3.8</spring-batch.version>
+    <spring-framework.version>5.3.27</spring-framework.version>
     <batik.version>1.14</batik.version>
   </properties>
 


### PR DESCRIPTION
This PR bumps the versions of Spring Core to 5.3.27, Spring Boot to 2.5.15 and Spring Batch to 4.3.8 to resolve vulnerabilities.