### PR TITLE
Upgrading maven site plugins 

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -23,9 +23,6 @@
     <module name='RedundantModifier'>
       <property name="severity" value="warning" />
     </module>
-    <module name='RedundantThrows'>
-      <property name="severity" value="warning" />
-    </module>
   </module>
   <module name='FileLength' />
   <module name='NewlineAtEndOfFile'>

--- a/pom.xml
+++ b/pom.xml
@@ -156,12 +156,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.12.1</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-ssh</artifactId>
-              <version>2.4</version>
+              <version>3.5.3</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -1193,7 +1193,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-pmd-plugin</artifactId>
-            <version>3.16.0</version>
+            <version>3.21.0</version>
             <configuration>
               <linkXref>true</linkXref>
               <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
@@ -1210,7 +1210,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>3.1.2</version>
+            <version>3.3.0</version>
             <configuration>
               <configLocation>checkstyle.xml</configLocation>
             </configuration>
@@ -1237,7 +1237,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>3.2.2</version>
+            <version>3.4.4</version>
             <configuration>
               <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
               <dependencyLocationsEnabled>false</dependencyLocationsEnabled>


### PR DESCRIPTION
This PR bumps the version of the maven site plugins: pmd, checkstyle and project-info-report to enable the build of the maven site to publish the last version on https://apidoc.deegree.org/.