### PR TITLE
Fix transitive dependency to jai_core to use jai-core instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -810,6 +810,12 @@
         <groupId>com.sun.media</groupId>
         <artifactId>jai_imageio</artifactId>
         <version>1.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.media</groupId>
+            <artifactId>jai_core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- PostgreSQL -->
       <dependency>


### PR DESCRIPTION
This PR excludes the `jai_core` dependency to resolve issues when building deegree and `jai_core` instead of `jai-core` is used. **Note:** within the project `jai-core` should be used as artifactID.
This issue occurs occasionally when building deegree with:  `mvn -T6 clean install` or different order when defining `-pl` option.