### PR TITLE
Removed SMIL 2.0 namespaces from appNamespaces to avoid wrapper schema

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
@@ -52,8 +52,8 @@ import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GCO_NS;
 import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GSR_NS;
 import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GSS_NS;
 import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GTS_NS;
-import static org.deegree.commons.xml.CommonNamespaces.SMIL_20;
-import static org.deegree.commons.xml.CommonNamespaces.SMIL_20_LANGUAGE;
+import static org.deegree.commons.xml.CommonNamespaces.SMIL_20_NS;
+import static org.deegree.commons.xml.CommonNamespaces.SMIL_20_LANGUAGE_NS;
 import static org.deegree.commons.xml.CommonNamespaces.XLNNS;
 import static org.deegree.commons.xml.CommonNamespaces.XMLNS;
 import static org.deegree.commons.xml.CommonNamespaces.XSNS;
@@ -419,9 +419,8 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 			appNamespaces.remove(ISO_2005_GSR_NS);
 			appNamespaces.remove(ISO_2005_GSS_NS);
 			appNamespaces.remove(ISO_2005_GTS_NS);
-			appNamespaces.remove(SMIL_20);
-			appNamespaces.remove(SMIL_20_LANGUAGE);
-
+			appNamespaces.remove(SMIL_20_NS);
+			appNamespaces.remove(SMIL_20_LANGUAGE_NS);
 		}
 		return appNamespaces;
 	}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
@@ -52,6 +52,8 @@ import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GCO_NS;
 import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GSR_NS;
 import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GSS_NS;
 import static org.deegree.commons.xml.CommonNamespaces.ISO_2005_GTS_NS;
+import static org.deegree.commons.xml.CommonNamespaces.SMIL_20;
+import static org.deegree.commons.xml.CommonNamespaces.SMIL_20_LANGUAGE;
 import static org.deegree.commons.xml.CommonNamespaces.XLNNS;
 import static org.deegree.commons.xml.CommonNamespaces.XMLNS;
 import static org.deegree.commons.xml.CommonNamespaces.XSNS;
@@ -417,6 +419,9 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 			appNamespaces.remove(ISO_2005_GSR_NS);
 			appNamespaces.remove(ISO_2005_GSS_NS);
 			appNamespaces.remove(ISO_2005_GTS_NS);
+			appNamespaces.remove(SMIL_20);
+			appNamespaces.remove(SMIL_20_LANGUAGE);
+
 		}
 		return appNamespaces;
 	}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/CommonNamespaces.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/CommonNamespaces.java
@@ -135,6 +135,10 @@ public class CommonNamespaces {
 
 	public static final String ISO_2005_GTS_NS = "http://www.isotc211.org/2005/gts";
 
+	public static final String SMIL_20 = "http://www.w3.org/2001/SMIL20/";
+
+	public static final String SMIL_20_LANGUAGE = "http://www.w3.org/2001/SMIL20/Language";
+
 	/**
 	 * The APISO namespace is bound to: "http://www.opengis.net/cat/csw/apiso/1.0"
 	 */

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/CommonNamespaces.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/CommonNamespaces.java
@@ -135,9 +135,9 @@ public class CommonNamespaces {
 
 	public static final String ISO_2005_GTS_NS = "http://www.isotc211.org/2005/gts";
 
-	public static final String SMIL_20 = "http://www.w3.org/2001/SMIL20/";
+	public static final String SMIL_20_NS = "http://www.w3.org/2001/SMIL20/";
 
-	public static final String SMIL_20_LANGUAGE = "http://www.w3.org/2001/SMIL20/Language";
+	public static final String SMIL_20_LANGUAGE_NS = "http://www.w3.org/2001/SMIL20/Language";
 
 	/**
 	 * The APISO namespace is bound to: "http://www.opengis.net/cat/csw/apiso/1.0"


### PR DESCRIPTION
Fixes #1537 