### PR TITLE
Fix invalid WMS metadata configuration for Utah workspace

### DIFF
--- a/deegree-workspaces/deegree-workspace-utah/src/main/resources/services/wms_metadata.xml
+++ b/deegree-workspaces/deegree-workspace-utah/src/main/resources/services/wms_metadata.xml
@@ -8,7 +8,7 @@
 
   <ServiceIdentification>
     <Title>deegree WMS metadata</Title>
-    <Abstract>This is the default deegree WMS configuration</Abstract><Keywords>
+    <Abstract>This is the default deegree WMS configuration</Abstract>
     <Keywords>
       <Keyword lang="en">OGC services</Keyword>
       <Keyword lang="en">deegree</Keyword>


### PR DESCRIPTION
This pull request fixes the invalid configuration of WMS metadata file of the Utah demo workspace.
After this fix is applied the validate workspace funtion returns valid.