### PR TITLE
Use targed gml namespace if boundedBy/geometry is in gml namespace

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -371,7 +371,9 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 				writeNilledElement(propName, attributes);
 			}
 			else {
-				writeStartElementWithNS(propName.getNamespaceURI(), propName.getLocalPart());
+				String namespaceURI = GMLSchemaInfoSet.isGMLNamespace(propName.getNamespaceURI()) ? gmlNs
+						: propName.getNamespaceURI();
+				writeStartElementWithNS(namespaceURI, propName.getLocalPart());
 				if (value != null) {
 					gmlStreamWriter.getGeometryWriter().exportEnvelope((Envelope) value);
 				}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryWriter.java
@@ -119,6 +119,7 @@ import org.deegree.geometry.refs.GeometryReference;
 import org.deegree.geometry.standard.curvesegments.AffinePlacement;
 import org.deegree.gml.GMLStreamWriter;
 import org.deegree.gml.commons.AbstractGMLObjectWriter;
+import org.deegree.gml.schema.GMLSchemaInfoSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1533,7 +1534,7 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
 			throws XMLStreamException, UnknownCRSException, TransformationException {
 
 		GMLObjectType gmlType = geometry.getType();
-		if (gmlType == null) {
+		if (gmlType == null || GMLSchemaInfoSet.isGMLNamespace(gmlType.getName().getNamespaceURI())) {
 			writeStartElementWithNS(gmlNs, localName);
 		}
 		else {


### PR DESCRIPTION
Fixes #1548
Please also see this issue for description of the bug.

The problem is that in Blob mode the GML version of the read features is used (e.g. GML 3.2). This version is also used for the response although another GML version is expected (e.g. GML 3.1) leading to the documented exception.

This PR enables that the targed GML namespace is used if boundedBy/geometry is in GML namespace preventing the mixing of GML versions.