### PR TITLE
GetFeature request with BBOX filter returns error in blob mode

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -1666,12 +1666,12 @@ public class SQLFeatureStore implements FeatureStore {
 
 	private AbstractWhereBuilder getWhereBuilderBlob(OperatorFilter filter, Connection conn)
 			throws FilterEvaluationException, UnmappableException {
-		final String undefinedSrid = dialect.getUndefinedSrid();
+		final String srid = detectConfiguredSrid();
 		PropertyNameMapper mapper = new PropertyNameMapper() {
 			@Override
 			public PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager)
 					throws FilterEvaluationException, UnmappableException {
-				GeometryStorageParams geometryParams = new GeometryStorageParams(blobMapping.getCRS(), undefinedSrid,
+				GeometryStorageParams geometryParams = new GeometryStorageParams(blobMapping.getCRS(), srid,
 						CoordinateDimension.DIM_2);
 				GeometryMapping bboxMapping = new GeometryMapping(null, false, new DBField(blobMapping.getBBoxColumn()),
 						GeometryType.GEOMETRY, geometryParams, null);
@@ -1686,6 +1686,13 @@ public class SQLFeatureStore implements FeatureStore {
 			}
 		};
 		return dialect.getWhereBuilder(mapper, filter, null, null, allowInMemoryFiltering);
+	}
+
+	private String detectConfiguredSrid() {
+		if (this.config.getStorageCRS() != null && this.config.getStorageCRS().getSrid() != null) {
+			return this.config.getStorageCRS().getSrid();
+		}
+		return dialect.getUndefinedSrid();
 	}
 
 	public SQLDialect getDialect() {


### PR DESCRIPTION
**Behavior of the deegree WFS**

When GetFeature request with BBOX filter is sent against a service using blob mode, the response returns an exception.

E.g.:
[WFS_ENDPOINT]?version=2.0.0&service=WFS&request=GetFeature&typenames=prefix:exampleTypename&BBOX=576500,5942536,576505,5942539
```
<wfs:FeatureCollection ...>
...
  <ows:ExceptionReport xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="2.0.0">
    <ows:Exception exceptionCode="NoApplicableCode">
      <ows:ExceptionText>
         Error performing query by operator filter: ERROR: ST_Intersects: Operation on mixed SRID geometries (Point, 25832) != (Polygon, 0)
       </ows:ExceptionText>
    </ows:Exception>
  </ows:ExceptionReport>
</wfs:FeatureCollection>
```

**Setup of deegree**

A SRID is configured in the database:
```
gml_bounded_by | geometry(Geometry,25832) 
```

The FeatureStore configuration looks like this:
```
<SQLFeatureStore xmlns="http://www.deegree.org/datasource/feature/sql"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/core/3.5/datasource/feature/sql/sql.xsd">
    <JDBCConnId>xplan</JDBCConnId>
    <StorageCRS srid="25832" dim="2D">EPSG:25832</StorageCRS>
    <GMLSchema>../../appschemas/test.xsd</GMLSchema>
    <BLOBMapping>
      <BlobTable>test.gml_objects</BlobTable>
      <FeatureTypeTable>test.feature_types</FeatureTypeTable>
    </BLOBMapping>
</SQLFeatureStore>
```

**Solution**

This pull request enables the usage of the configured SRID in blob mode. By that, spatial filter expressions work in blob mode and the above documented example returns features again.