### PR TITLE
Upgrade of dependencies of antlr, spring-boot, jaxb, jax-ws, junit, xmlunit to latest bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>2.3.7</version>
+        <version>2.3.8</version>
         <scope>runtime</scope>
       </dependency>
       <!-- JAX-WS 2.3 (Jakarta EE 8) -->
@@ -450,7 +450,7 @@
       <dependency>
         <groupId>com.sun.xml.ws</groupId>
         <artifactId>jaxws-rt</artifactId>
-        <version>2.3.3</version>
+        <version>2.3.6</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -462,7 +462,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -486,7 +486,7 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.9.10</version>
+        <version>1.9.16</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -503,13 +503,13 @@
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-core</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-matchers</artifactId>
-        <version>2.9.0</version>
+        <version>2.9.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -740,7 +740,7 @@
       <dependency>
         <groupId>com.sun.xml.fastinfoset</groupId>
         <artifactId>FastInfoset</artifactId>
-        <version>1.2.13</version>
+        <version>1.2.18</version>
         <exclusions>
           <exclusion>
             <groupId>javax.xml.bind</groupId>
@@ -838,7 +838,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.5.2</version>
+        <version>42.5.4</version>
       </dependency>
       <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>
@@ -881,7 +881,7 @@
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>
-        <version>10.2.2.jre11</version>
+        <version>10.2.3.jre11</version>
       </dependency>
       <!-- Batik -->
       <dependency>
@@ -1212,7 +1212,7 @@
       <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
       </dependency>
       <dependency>
         <!-- Import dependency management from Spring Boot -->
@@ -1230,11 +1230,11 @@
     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
     <site.dir>${user.home}/Sites</site.dir>
     <java.version>11</java.version>
-    <antlr.version>3.5.2</antlr.version>
+    <antlr.version>3.5.3</antlr.version>
     <oracle.version>19.9.0.0</oracle.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <spring-boot.version>2.7.10</spring-boot.version>
+    <spring-boot.version>2.7.14</spring-boot.version>
     <spring-batch.version>4.3.8</spring-batch.version>
     <spring-framework.version>5.3.26</spring-framework.version>
     <batik.version>1.14</batik.version>


### PR DESCRIPTION
This PR upgrades the dependencies of antlr, spring-boot, jaxb, jax-ws, junit, xmlunit, fastinfoset, postgres and mssql jdbc driver to latest bugfix version supporting a successfull build with Maven v3.9.4 and JDK 17+.