### PR TITLE
Upgrade of Primefaces from 12.0 to 13.0

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -278,12 +278,12 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>12.0.0</version>
+      <version>13.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>12.0.2</version>
+      <version>13.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR upgrades JSF PrimeFaces from version 12.0 to latest 13.0. Verified by build deegree webapp and deploying it to Tomcat 9 with JDK 11 and performed some actions on the console successfully.

Changes for 13.0.0 published here: https://github.com/primefaces/primefaces/releases