### PR TITLE
Fix dryRun in GmlLoader

### DIFF
--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
@@ -202,7 +202,8 @@ public class GmlLoaderConfiguration {
 		}
 
 		if (dryRun) {
-			return builder.build();
+			NullWriter nonWritingFeatureStoreWriter = new NullWriter();
+			return builder.writer(nonWritingFeatureStoreWriter).build();
 		}
 		else {
 			return builder.writer(featureStoreWriter).listener(transactionHandler).build();

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/NullWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/NullWriter.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * deegree-cli-utility
+ * %%
+ * Copyright (C) 2023 lat/lon GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.tools.featurestoresql.loader;
+
+import org.deegree.feature.Feature;
+import org.springframework.batch.item.ItemWriter;
+
+import java.util.List;
+
+/**
+ * Dummy ItemWriter not writing any features.
+ *
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class NullWriter implements ItemWriter<Feature> {
+
+	@Override
+	public void write(List<? extends Feature> list) throws Exception {
+
+	}
+
+}


### PR DESCRIPTION
Executing the GmlLoader with the parameter `-dryRun=true` results in 

```
ERROR o.s.batch.core.job.AbstractJob - Encountered fatal error executing job

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'scopedTarget.step' defined in org.deegree.tools.featurestoresql.loader.GmlLoaderConfiguration: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.batch.core.Step]: Factory method ‘step’ threw exception; nested exception is java.lang.IllegalStateException: ItemWriter must be provided 
```

This PR fixes the GmlLoader by adding a NullWriter.