### PR TITLE
Add new remote WMTS example resource

### DIFF
--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/src/main/resources/META-INF/schemas/remoteows/wmts/example.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/src/main/resources/META-INF/schemas/remoteows/wmts/example.xml
@@ -1,5 +1,5 @@
 <RemoteWMTS xmlns="http://www.deegree.org/remoteows/wmts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.deegree.org/remoteows/wmts https://schemas.deegree.org/core/3.5/remoteows/wmts/remotewmts.xsd">
   <CapabilitiesDocumentLocation
-    location="http://v2.suite.opengeo.org/geoserver/gwc/service/wmts?service=WMTS&amp;version=1.0.0&amp;request=GetCapabilities" />
+    location="https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0?request=GetCapabilities&amp;service=WMTS" />
 </RemoteWMTS>


### PR DESCRIPTION
As mentioned in #1492, a new WMTS example was proposed. 

The example resource `https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0?request=GetCapabilities&service=WMTS` is now used.

Closes #1492 