### PR TITLE
Optimize current Build workflow to only Fail-at-end for tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         stage ('Test') {
             steps {
                 echo 'Testing'
-                sh 'mvn -B -C -P integration-tests,oracle install'
+                sh 'mvn -B -C -fae -P integration-tests,oracle install'
             }
             post {
                 always {


### PR DESCRIPTION
Include Parameter in Test Stage to let all tests run before failing (to get a more complete picture)

Solves #1580

Documentation: https://maven.apache.org/guides/mini/guide-multiple-modules.html#command-line-options