### PR TITLE
Bump h2 from 2.1.210 to 2.2.220 and use memory baked instance while testing 

### DIFF
--- a/deegree-tests/deegree-resource-deps-tests/src/test/resources/workspace/jdbc/simplesqlh2.xml
+++ b/deegree-tests/deegree-resource-deps-tests/src/test/resources/workspace/jdbc/simplesqlh2.xml
@@ -2,7 +2,8 @@
   xsi:schemaLocation="http://www.deegree.org/jdbc https://schemas.deegree.org/core/3.5/jdbc/jdbc.xsd">
 
   <!-- [1] JDBC URL (without username / password) -->
-  <Url>jdbc:h2:/tmp/test</Url>
+  <!--<Url>jdbc:h2:/tmp/test</Url>-->
+  <Url>jdbc:h2:mem:</Url>
 
   <!-- [1] DB username -->
   <User>sa</User>

--- a/pom.xml
+++ b/pom.xml
@@ -1098,7 +1098,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.1.210</version>
+        <version>2.2.220</version>
       </dependency>
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>


### PR DESCRIPTION
This PR tries to solve the build issues with #1540 by changing the testing JDBC connection to be memory backed.

For details on the h2 version upgrade see #1540 

There is another variant of this PR #1583 available which also fixes misleading logging messages when logging is enabled.

Closes #1540 
Closes #1583 

References:
* #1540
* #1583