### PR TITLE
Upgrade Primefaces to latest bugfix version 13.0.2

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -278,12 +278,12 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>13.0.0</version>
+      <version>13.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>13.0.0</version>
+      <version>13.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR upgrades Primefaces to v13.0.2 used in deegree webservices webapp.

Changelog: https://github.com/primefaces/primefaces/releases