### PR TITLE
Upgrade of Spring Boot, Batch and core Framework to latest bugfix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1229,9 +1229,9 @@
     <oracle.version>19.9.0.0</oracle.version>
     <log4j.version>2.17.2</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <spring-boot.version>2.7.14</spring-boot.version>
-    <spring-batch.version>4.3.8</spring-batch.version>
-    <spring-framework.version>5.3.26</spring-framework.version>
+    <spring-boot.version>2.7.17</spring-boot.version>
+    <spring-batch.version>4.3.9</spring-batch.version>
+    <spring-framework.version>5.3.30</spring-framework.version>
     <batik.version>1.17</batik.version>
     <axoim.version>1.2.22</axoim.version>
     <jsonpath.version>2.7.0</jsonpath.version>


### PR DESCRIPTION
Upgrade of Spring Boot, Batch and core Framework to latest bugfix version available for Java 11.
Next version of Spring Boot requires Java 17, see 
https://spring.io/projects/spring-boot#learn
https://spring.io/projects/spring-boot#support
