### PR TITLE
Parameterize SLF4J's logging statements

### DIFF
--- a/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/component/HtmlInputConfigurationXML.java
+++ b/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/component/HtmlInputConfigurationXML.java
@@ -98,12 +98,12 @@ public class HtmlInputConfigurationXML extends HtmlInputTextarea {
 	@Override
 	protected void validateValue(FacesContext context, Object newValue) {
 		super.validateValue(context, newValue);
-		LOG.debug("validate value " + newValue);
+		LOG.debug("validate value {}", newValue);
 		try {
 			String v = (String) newValue;
 			InputStream xml = new ByteArrayInputStream(v.getBytes("UTF-8"));
 			String s = getSchemaURLS();
-			LOG.debug("Schemas: " + s);
+			LOG.debug("Schemas: {}", s);
 			String[] schemas = null;
 			if (s != null && s.length() > 0) {
 				schemas = s.split(",");

--- a/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/debug/DebugPhaseListener.java
+++ b/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/debug/DebugPhaseListener.java
@@ -55,11 +55,11 @@ public class DebugPhaseListener implements PhaseListener {
 	private static final Logger LOG = getLogger(DebugPhaseListener.class);
 
 	public void afterPhase(PhaseEvent event) {
-		LOG.debug("After phase: " + event.getPhaseId());
+		LOG.debug("After phase: {}", event.getPhaseId());
 	}
 
 	public void beforePhase(PhaseEvent event) {
-		LOG.debug("Before phase: " + event.getPhaseId());
+		LOG.debug("Before phase: {}", event.getPhaseId());
 	}
 
 	public PhaseId getPhaseId() {

--- a/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/filter/EncodingFilter.java
+++ b/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/filter/EncodingFilter.java
@@ -40,7 +40,7 @@ public class EncodingFilter implements Filter {
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
 		String enc = filterConfig.getInitParameter("encoding");
-		LOG.debug("Init paramater 'encoding' is set to: " + enc);
+		LOG.debug("Init paramater 'encoding' is set to: {}", enc);
 		if (enc != null && enc.length() > 0)
 			encoding = enc;
 	}

--- a/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/renderer/InputFileRenderer.java
+++ b/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/renderer/InputFileRenderer.java
@@ -136,7 +136,7 @@ public class InputFileRenderer extends Renderer {
 			targetFile = File.createTempFile("upload", "", tempDir);
 		}
 
-		LOG.info("Uploading file '" + fileName + "' to: '" + targetFile + "'");
+		LOG.info("Uploading file '{}' to: '{}'", fileName, targetFile);
 		return targetFile;
 	}
 

--- a/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/renderer/OutputXMLRenderer.java
+++ b/deegree-client/deegree-jsf-core/src/main/java/org/deegree/client/core/renderer/OutputXMLRenderer.java
@@ -119,7 +119,7 @@ public class OutputXMLRenderer extends Renderer {
 			thread.start();
 		}
 		catch (Exception e) {
-			LOG.warn("Could not write file for download: " + e.getMessage());
+			LOG.warn("Could not write file for download: {}", e.getMessage());
 			return;
 		}
 
@@ -333,19 +333,19 @@ public class OutputXMLRenderer extends Renderer {
 					DeleteThread.sleep(secondesUntilDelete);
 				}
 				catch (InterruptedException e) {
-					LOG.debug("Could not sleep delete thread: " + e.getMessage());
+					LOG.debug("Could not sleep delete thread: {}", e.getMessage());
 				}
 			if (fileToDelete != null) {
 				try {
 					if (fileToDelete.delete()) {
-						LOG.debug("Successfully deleted file " + fileToDelete.getName());
+						LOG.debug("Successfully deleted file {}", fileToDelete.getName());
 					}
 					else {
-						LOG.debug("Could not delete file " + fileToDelete.getName());
+						LOG.debug("Could not delete file {}", fileToDelete.getName());
 					}
 				}
 				catch (Exception e) {
-					LOG.error("Could not delete file " + fileToDelete.getName() + ": " + e.getMessage());
+					LOG.error("Could not delete file {}: {}", fileToDelete.getName(), e.getMessage());
 				}
 			}
 		}

--- a/deegree-client/deegree-wps-webclient/src/main/java/org/deegree/wpsclient/controller/ProcessExecuter.java
+++ b/deegree-client/deegree-wps-webclient/src/main/java/org/deegree/wpsclient/controller/ProcessExecuter.java
@@ -91,15 +91,15 @@ public class ProcessExecuter {
 		FacesContext fc = FacesContext.getCurrentInstance();
 		try {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("execute selected process " + processToExecute.getId());
-				LOG.debug("input parameters (LITERAL): " + literalInputs);
-				LOG.debug("input parameters (XML): " + xmlInputs);
-				LOG.debug("input parameters (XML-REFS): " + xmlRefInputs);
-				LOG.debug("input parameters (BINARY): " + binaryInputs);
-				LOG.debug("input parameters (BBOX): " + bboxInputs);
-				LOG.debug("input formats: " + complexInputFormats);
-				LOG.debug("outputs: " + outputs);
-				LOG.debug("output formats: " + complexOutputFormats);
+				LOG.debug("execute selected process {}", processToExecute.getId());
+				LOG.debug("input parameters (LITERAL): {}", literalInputs);
+				LOG.debug("input parameters (XML): {}", xmlInputs);
+				LOG.debug("input parameters (XML-REFS): {}", xmlRefInputs);
+				LOG.debug("input parameters (BINARY): {}", binaryInputs);
+				LOG.debug("input parameters (BBOX): {}", bboxInputs);
+				LOG.debug("input formats: {}", complexInputFormats);
+				LOG.debug("outputs: {}", outputs);
+				LOG.debug("output formats: {}", complexOutputFormats);
 			}
 			ProcessExecution execution = processToExecute.prepareExecution();
 			InputType[] inputDescription = processToExecute.getInputTypes();
@@ -172,7 +172,7 @@ public class ProcessExecuter {
 					encoding = complexOutputFormats.get(out).getEncoding();
 					mimeType = complexOutputFormats.get(out).getMimeType();
 				}
-				LOG.debug("Append output " + out + " with format " + schema + ", " + encoding + ", " + mimeType);
+				LOG.debug("Append output {} with format {}, {}, {}", out, schema, encoding, mimeType);
 				execution.addOutput(out, null, null, true, mimeType, encoding, schema);
 			}
 			ExecutionOutputs response = execution.execute();
@@ -222,7 +222,7 @@ public class ProcessExecuter {
 			if (fileToDelete != null && fileToDelete.exists()) {
 				boolean delete = fileToDelete.delete();
 				if (!delete) {
-					LOG.debug("File " + fileToDelete + " could not be deletet!");
+					LOG.debug("File {} could not be deletet!", fileToDelete);
 				}
 			}
 		}

--- a/deegree-client/deegree-wps-webclient/src/main/java/org/deegree/wpsclient/gui/FormBean.java
+++ b/deegree-client/deegree-wps-webclient/src/main/java/org/deegree/wpsclient/gui/FormBean.java
@@ -165,7 +165,7 @@ public class FormBean {
 		Process process = cb.getSelectedProcess();
 
 		if (process != null) {
-			LOG.debug("create form for process: " + process.getId());
+			LOG.debug("create form for process: {}", process.getId());
 			if (executeForm == null) {
 				executeForm = new HtmlForm();
 			}

--- a/deegree-client/deegree-wps-webclient/src/main/java/org/deegree/wpsclient/gui/MultipleComponentListener.java
+++ b/deegree-client/deegree-wps-webclient/src/main/java/org/deegree/wpsclient/gui/MultipleComponentListener.java
@@ -116,7 +116,7 @@ public class MultipleComponentListener implements AjaxBehaviorListener {
 					}
 				}
 			}
-			LOG.debug("Updatie from: " + id + "; type: " + type + "; occ: " + occurences);
+			LOG.debug("Updatie from: {}; type: {}; occ: {}", id, type, occurences);
 			if (occurences == null) {
 				occurences = new HashMap<String, Integer>();
 			}

--- a/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/ExecuteBean.java
+++ b/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/ExecuteBean.java
@@ -83,7 +83,7 @@ public class ExecuteBean implements Serializable {
 	}
 
 	public Object print() {
-		LOG.debug("try to print template " + template);
+		LOG.debug("try to print template {}", template);
 		if (template == null) {
 			// TODO: msg
 
@@ -124,7 +124,7 @@ public class ExecuteBean implements Serializable {
 			ComplexOutput o = (ComplexOutput) exe.execute()
 				.get(outputTypes[0].getId().getCode(), outputTypes[0].getId().getCodeSpace());
 			String link = o.getWebAccessibleURI().toASCIIString();
-			LOG.debug("Result can be found here: " + link);
+			LOG.debug("Result can be found here: {}", link);
 			result = link;
 		}
 		catch (Exception e) {

--- a/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/WpsPrinterBean.java
+++ b/deegree-client/deegree-wpsprinter-webclient/src/main/java/org/deegree/client/wpsprinter/WpsPrinterBean.java
@@ -258,7 +258,7 @@ public class WpsPrinterBean implements Serializable {
 	}
 
 	public void renderMetaInfo(ComponentSystemEvent event) throws AbortProcessingException {
-		LOG.debug("append template GUI elements for template " + template);
+		LOG.debug("append template GUI elements for template {}", template);
 
 		if (metaInfoGrp == null) {
 			metaInfoGrp = new HtmlPanelGrid();

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceConnectionProvider.java
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceConnectionProvider.java
@@ -123,8 +123,9 @@ class DataSourceConnectionProvider implements ConnectionProvider {
 			}
 		}
 		else {
-			LOG.warn("Unable to close connection pool {}. Check the DataSource configuration if the attribute "
-					+ "'destroyMethod' is configured.", resourceMetadata.getIdentifier());
+			LOG.warn(
+					"Unable to close connection pool {}. Check the DataSource configuration if the attribute 'destroyMethod' is configured.",
+					resourceMetadata.getIdentifier());
 		}
 	}
 

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/JndiLookup.java
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/JndiLookup.java
@@ -69,7 +69,7 @@ public class JndiLookup {
 	 * <code>javax.sql.DataSource</code>
 	 */
 	public static final DataSource lookup(final String jndiName) throws NamingException, ClassCastException {
-		LOG.debug("Looking up JNDI DataSource '" + jndiName + "'");
+		LOG.debug("Looking up JNDI DataSource '{}'", jndiName);
 		Object object = null;
 		try {
 			final InitialContext initialContext = new InitialContext();

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/MultiresolutionMesh.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/MultiresolutionMesh.java
@@ -150,13 +150,13 @@ public class MultiresolutionMesh {
 		blobBuffer.limit(arcsSegmentStart);
 		ByteBuffer nodesBuffer = blobBuffer.slice();
 
-		LOG.info("MultiresolutionMesh: flags=" + flags + ", #rowsPerMt: " + rowsPerMt + ", #fragments: " + numFragments
-				+ ", #nodes: " + numNodes + ", #arcs: " + numArcs);
-		LOG.debug("- nodesBuffer: [" + nodesSegmentStart + '-' + (arcsSegmentStart - 1) + "]");
-		LOG.debug("- arcsBuffer: [" + arcsSegmentStart + '-' + (fragmentsSegmentStart - 1) + "]");
-		LOG.debug("- patchesBuffer: [" + fragmentsSegmentStart + '-' + (blobBuffer.capacity() - 1) + "]");
+		LOG.info("MultiresolutionMesh: flags={}, #rowsPerMt: {}, #fragments: {}, #nodes: {}, #arcs: {}", flags,
+				rowsPerMt, numFragments, numNodes, numArcs);
+		LOG.debug("- nodesBuffer: [{}-{}]", nodesSegmentStart, (arcsSegmentStart - 1));
+		LOG.debug("- arcsBuffer: [{}-{}]", arcsSegmentStart, (fragmentsSegmentStart - 1));
+		LOG.debug("- patchesBuffer: [{}-{}]", fragmentsSegmentStart, (blobBuffer.capacity() - 1));
 		elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("mrindex_init=" + elapsed);
+		LOG.debug("mrindex_init={}", elapsed);
 
 		nodes = createNodes(nodesBuffer);
 		arcs = createArcs(arcsBuffer);

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/SelectiveRefinement.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/SelectiveRefinement.java
@@ -151,7 +151,7 @@ public class SelectiveRefinement {
 		}
 
 		long elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("Selective refinement (top-down): " + elapsed + " ms");
+		LOG.debug("Selective refinement (top-down): {} ms", elapsed);
 	}
 
 	/**

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/SpatialSelection.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/SpatialSelection.java
@@ -159,7 +159,7 @@ public class SpatialSelection {
 		}
 
 		long elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("Spatial selection (top-down): " + elapsed + " ms");
+		LOG.debug("Spatial selection (top-down): {} ms", elapsed);
 	}
 
 	/**

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/crit/ViewFrustumCrit.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/crit/ViewFrustumCrit.java
@@ -155,15 +155,14 @@ public class ViewFrustumCrit implements LODCriterion {
 			resolution = 0.00001;
 		}
 		double textureSize = getMaxSideLen(fragment) / resolution;
-		LOG.debug("Side len: " + getMaxSideLen(fragment) + ", resolution: " + resolution + ", texture size: "
-				+ textureSize);
+		LOG.debug("Side len: {}, resolution: {}, texture size: {}", getMaxSideLen(fragment), resolution, textureSize);
 		if (textureSize > maxTextureSize) {
-			LOG.debug("Side len: " + getMaxSideLen(fragment) + ", resolution: " + resolution + ", texture size: "
-					+ textureSize);
+			LOG.debug("Side len: {}, resolution: {}, texture size: {}", getMaxSideLen(fragment), resolution,
+					textureSize);
 		}
 		else {
-			LOG.debug("No refinement needed, Side len: " + getMaxSideLen(fragment) + ", resolution: " + resolution
-					+ ", texture size: " + textureSize);
+			LOG.debug("No refinement needed, Side len: {}, resolution: {}, texture size: {}", getMaxSideLen(fragment),
+					resolution, textureSize);
 		}
 
 		return textureSize <= maxTextureSize;

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/io/MeshFragmentDataReader.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/multiresolution/io/MeshFragmentDataReader.java
@@ -110,11 +110,11 @@ public class MeshFragmentDataReader {
 		ByteBuffer rawTileBuffer = pooledByteBuffer.getBuffer();
 		// rawTileBuffer.order( ByteOrder.nativeOrder() );
 
-		LOG.debug("Reading mesh fragment with id " + fragmentId + " (offset: " + offset + ", length: " + length + ").");
+		LOG.debug("Reading mesh fragment with id {} (offset: {}, length: {}).", fragmentId, offset, length);
 		long begin = System.currentTimeMillis();
 		channel.read(rawTileBuffer, offset);
 		long elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("Reading took " + elapsed + " milliseconds.");
+		LOG.debug("Reading took {} milliseconds.", elapsed);
 
 		rawTileBuffer.rewind();
 		int numVertices = rawTileBuffer.getInt();

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/LODAnalyzer.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/LODAnalyzer.java
@@ -220,7 +220,7 @@ public class LODAnalyzer extends GLCanvas implements GLEventListener {
 
 	@Override
 	public void reshape(GLAutoDrawable drawable, int x, int y, int width, int height) {
-		LOG.trace("reshape( GLAutoDrawable, " + x + ", " + y + ", " + width + ", " + height + " ) called");
+		LOG.trace("reshape( GLAutoDrawable, {}, {}, {}, {} ) called", x, y, width, height);
 
 		GL gl = drawable.getGL();
 		gl.glViewport(x, y, width, height);

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/OpenGLEventHandler.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/OpenGLEventHandler.java
@@ -171,11 +171,11 @@ public class OpenGLEventHandler implements GLEventListener {
 		trackBall.multModelMatrix(gl, centroid);
 		float[] newEye = JOGLUtils.getEyeFromModelView(gl);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("farClippingPlane:" + farClippingPlane);
-			LOG.debug("centroid:" + centroid[0] + "," + centroid[1] + "," + centroid[2]);
-			LOG.debug("lookAt:" + lookAt[0] + "," + lookAt[1] + "," + lookAt[2]);
-			LOG.debug("eye:" + eye[0] + "," + eye[1] + "," + eye[2]);
-			LOG.debug("Eye in model space: " + Vectors3f.asString(newEye));
+			LOG.debug("farClippingPlane:{}", farClippingPlane);
+			LOG.debug("centroid:{},{},{}", centroid[0], centroid[1], centroid[2]);
+			LOG.debug("lookAt:{},{},{}", lookAt[0], lookAt[1], lookAt[2]);
+			LOG.debug("eye:{},{},{}", eye[0], eye[1], eye[2]);
+			LOG.debug("Eye in model space: {}", Vectors3f.asString(newEye));
 		}
 
 		Point3d newEyeP = new Point3d(newEye[0], newEye[1], newEye[2]);

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/TextureTileAnalyzer.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/TextureTileAnalyzer.java
@@ -186,7 +186,7 @@ public class TextureTileAnalyzer extends GLCanvas implements GLEventListener {
 
 	@Override
 	public void reshape(GLAutoDrawable drawable, int x, int y, int width, int height) {
-		LOG.trace("reshape( GLAutoDrawable, " + x + ", " + y + ", " + width + ", " + height + " ) called");
+		LOG.trace("reshape( GLAutoDrawable, {}, {}, {}, {} ) called", x, y, width, height);
 
 		GL gl = drawable.getGL();
 		gl.glViewport(x, y, width, height);

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/TrackBall.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/display/TrackBall.java
@@ -188,11 +188,10 @@ public class TrackBall extends MouseAdapter {
 	@SuppressWarnings("null")
 	public void multModelMatrix(GL context, float[] worldTranslation) {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(
-					"worldTranslation: " + worldTranslation[0] + "," + worldTranslation[1] + "," + worldTranslation[2]);
-			LOG.debug("tbRot: " + tbRot[0] + "," + tbRot[1] + "," + tbRot[2] + "," + tbRot[3]);
-			LOG.debug("rotationVector: " + rotationVector[0] + "," + rotationVector[1] + "," + rotationVector[2] + ","
-					+ rotationVector[3]);
+			LOG.debug("worldTranslation: {},{},{}", worldTranslation[0], worldTranslation[1], worldTranslation[2]);
+			LOG.debug("tbRot: {},{},{},{}", tbRot[0], tbRot[1], tbRot[2], tbRot[3]);
+			LOG.debug("rotationVector: {},{},{},{}", rotationVector[0], rotationVector[1], rotationVector[2],
+					rotationVector[3]);
 		}
 		boolean translate = (worldTranslation != null) && (worldTranslation.length == 3);
 		if (translate) {
@@ -262,11 +261,11 @@ public class TrackBall extends MouseAdapter {
 			startPoint[2] = ((float) Math.sqrt((radius * radius) - xxyy));
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("width: " + windowWidth);
-			LOG.debug("height: " + windowHeight);
-			LOG.debug("center: " + center);
-			LOG.debug("radius: " + radius);
-			LOG.debug("startpoint: " + startPoint[0] + "," + startPoint[1] + "," + startPoint[2]);
+			LOG.debug("width: {}", windowWidth);
+			LOG.debug("height: {}", windowHeight);
+			LOG.debug("center: {}", center);
+			LOG.debug("radius: {}", radius);
+			LOG.debug("startpoint: {},{},{}", startPoint[0], startPoint[1], startPoint[2]);
 		}
 	}
 

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/ShaderProgram.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/ShaderProgram.java
@@ -64,7 +64,7 @@ public class ShaderProgram {
 	 * @throws RuntimeException if the shader could not be compiled or linked.
 	 */
 	public int createVertexShader(GL glContext, String vertexShaderSource) throws RuntimeException {
-		LOG.debug("Adding vertex shader source: " + vertexShaderSource);
+		LOG.debug("Adding vertex shader source: {}", vertexShaderSource);
 		return compileShader(glContext, GL.GL_VERTEX_SHADER, vertexShaderSource);
 	}
 
@@ -76,7 +76,7 @@ public class ShaderProgram {
 	 * @throws RuntimeException if the shader could not be compiled or linked.
 	 */
 	public int createFragmentShader(GL glContext, String fragmentShaderSource) throws RuntimeException {
-		LOG.debug("Adding fragment shader source: " + fragmentShaderSource);
+		LOG.debug("Adding fragment shader source: {}", fragmentShaderSource);
 		return compileShader(glContext, GL.GL_FRAGMENT_SHADER, fragmentShaderSource);
 	}
 
@@ -98,8 +98,9 @@ public class ShaderProgram {
 			shaderId = compileShaderProgram(gl, GL_SHADER_ID, shaderSource);
 		}
 		catch (RuntimeException r) {
-			LOG.error("Could not compile " + ((GL.GL_VERTEX_SHADER == GL_SHADER_ID) ? "vertex" : "fragment")
-					+ " shader from source: \n" + shaderSource + " \nbecause: " + r.getLocalizedMessage(), r);
+			LOG.error("Could not compile {} shader from source: \n{} \nbecause: {}",
+					((GL.GL_VERTEX_SHADER == GL_SHADER_ID) ? "vertex" : "fragment"), shaderSource,
+					r.getLocalizedMessage(), r);
 			throw (r);
 		}
 
@@ -212,8 +213,8 @@ public class ShaderProgram {
 			result = true;
 		}
 		else {
-			LOG.warn("Either the program id: " + oglProgramId + " or the given shader id: " + shaderId
-					+ " are not valid, cannot attach the shader.");
+			LOG.warn("Either the program id: {} or the given shader id: {} are not valid, cannot attach the shader.",
+					oglProgramId, shaderId);
 		}
 		return result;
 	}
@@ -231,7 +232,7 @@ public class ShaderProgram {
 			result = true;
 		}
 		catch (RuntimeException r) {
-			LOG.error("Could not link shader because: " + r.getLocalizedMessage(), r);
+			LOG.error("Could not link shader because: {}", r.getLocalizedMessage(), r);
 			throw (r);
 		}
 		// if ( LOG.isDebugEnabled() ) {
@@ -239,7 +240,7 @@ public class ShaderProgram {
 			validateShaderProgram(gl);
 		}
 		catch (RuntimeException r) {
-			LOG.warn("Shader program source: was not valid because: " + r.getLocalizedMessage());
+			LOG.warn("Shader program source: was not valid because: {}", r.getLocalizedMessage());
 			result = false;
 		}
 		return result;
@@ -258,8 +259,8 @@ public class ShaderProgram {
 			result = true;
 		}
 		else {
-			LOG.warn("Either the program id: " + oglProgramId + " or the given shader id: " + shaderId
-					+ " are not valid, cannot detach the shader.");
+			LOG.warn("Either the program id: {} or the given shader id: {} are not valid, cannot detach the shader.",
+					oglProgramId, shaderId);
 		}
 		return result;
 	}

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/RenderMeshFragment.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/RenderMeshFragment.java
@@ -316,8 +316,8 @@ public class RenderMeshFragment implements Comparable<RenderMeshFragment> {
 
 						}
 						else {
-							LOG.warn("No texture id or no texture coordinates for texture(" + i
-									+ "), ignoring this texture.");
+							LOG.warn("No texture id or no texture coordinates for texture({}), ignoring this texture.",
+									i);
 						}
 					}
 
@@ -447,10 +447,10 @@ public class RenderMeshFragment implements Comparable<RenderMeshFragment> {
 				}
 				catch (IOException e) {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug("(Stack) Exception occurred: " + e.getLocalizedMessage(), e);
+						LOG.debug("(Stack) Exception occurred: {}", e.getLocalizedMessage(), e);
 					}
 					else {
-						LOG.error("Exception occurred: " + e.getLocalizedMessage());
+						LOG.error("Exception occurred: {}", e.getLocalizedMessage());
 					}
 				}
 				if (!isLoaded()) {

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/RenderFragmentManager.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/RenderFragmentManager.java
@@ -134,7 +134,7 @@ public class RenderFragmentManager {
 			// memoryCache.put( fragment.getId(), fragment );
 		}
 		long elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("Preparing of " + fragments.size() + " fragments (" + loaded + " new): " + elapsed + " ms");
+		LOG.debug("Preparing of {} fragments ({} new): {} ms", fragments.size(), loaded, elapsed);
 	}
 
 	/**
@@ -160,7 +160,7 @@ public class RenderFragmentManager {
 			}
 		}
 		long elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("Preparing (GPU) of " + fragments.size() + " fragments (" + loaded + " new): " + elapsed + " ms");
+		LOG.debug("Preparing (GPU) of {} fragments ({} new): {} ms", fragments.size(), loaded, elapsed);
 	}
 
 	/**
@@ -182,7 +182,7 @@ public class RenderFragmentManager {
 			}
 		}
 		long elapsed = System.currentTimeMillis() - begin;
-		LOG.debug("Releasing (GPU) of " + fragments.size() + " fragments: " + elapsed + " ms");
+		LOG.debug("Releasing (GPU) of {} fragments: {} ms", fragments.size(), elapsed);
 	}
 
 	@Override

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/TerrainRenderingManager.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/TerrainRenderingManager.java
@@ -196,7 +196,7 @@ public class TerrainRenderingManager {
 			}
 		}
 		catch (Throwable t) {
-			LOG.error("Rendering did not succeed because: " + t.getLocalizedMessage(), t);
+			LOG.error("Rendering did not succeed because: {}", t.getLocalizedMessage(), t);
 		}
 	}
 
@@ -249,11 +249,10 @@ public class TerrainRenderingManager {
 		}
 		catch (IOException e) {
 			LOG.error("Could not load all required DEM LOD fragments for the given render context stack.", e);
-			LOG.error("Could not load all required DEM LOD fragments for the given render context because: "
-					+ e.getLocalizedMessage());
+			LOG.error("Could not load all required DEM LOD fragments for the given render context because: {}",
+					e.getLocalizedMessage());
 		}
-		LOG.debug("Loading of " + activeLOD.size() + " fragments: " + (System.currentTimeMillis() - begin)
-				+ " milliseconds.");
+		LOG.debug("Loading of {} fragments: {} milliseconds.", activeLOD.size(), (System.currentTimeMillis() - begin));
 	}
 
 	/**
@@ -269,7 +268,7 @@ public class TerrainRenderingManager {
 
 		long begin = System.currentTimeMillis();
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Texturizing " + fragments.size() + " fragments, managers: " + textureManagers.length);
+			LOG.debug("Texturizing {} fragments, managers: {}", fragments.size(), textureManagers.length);
 			LOG.debug(" Requested texture managers: {}", Arrays.toString(textureManagers));
 		}
 
@@ -288,7 +287,7 @@ public class TerrainRenderingManager {
 		}
 		catch (InterruptedException e) {
 			LOG.debug("Could not fetch the textures, stack.", e);
-			LOG.error("Could not fetch the textures because: " + e.getMessage());
+			LOG.error("Could not fetch the textures because: {}", e.getMessage());
 		}
 		Map<RenderMeshFragment, List<FragmentTexture>> meshFragmentToTexture = new HashMap<RenderMeshFragment, List<FragmentTexture>>();
 		if (results != null) {
@@ -321,7 +320,7 @@ public class TerrainRenderingManager {
 					// e.getMessage() );
 				}
 			}
-			LOG.debug("Fetching of textures: " + (System.currentTimeMillis() - begin) + " milliseconds.");
+			LOG.debug("Fetching of textures: {} milliseconds.", (System.currentTimeMillis() - begin));
 		}
 		else {
 			LOG.warn("No textures retrieved from the datasources.");
@@ -342,10 +341,10 @@ public class TerrainRenderingManager {
 		}
 		catch (IOException e) {
 			LOG.debug("Could not load the fragments on the gpu, stack.", e);
-			LOG.error("Could not load the fragments on the gpu because: " + e.getMessage());
+			LOG.error("Could not load the fragments on the gpu because: {}", e.getMessage());
 		}
-		LOG.debug("GPU upload of " + activeLOD.size() + " fragments: " + (System.currentTimeMillis() - begin)
-				+ " milliseconds.");
+		LOG.debug("GPU upload of {} fragments: {} milliseconds.", activeLOD.size(),
+				(System.currentTimeMillis() - begin));
 
 	}
 

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/TextureManager.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/TextureManager.java
@@ -120,7 +120,7 @@ public class TextureManager {
 	 */
 	public Map<RenderMeshFragment, FragmentTexture> getTextures(RenderContext glRenderContext,
 			float maxProjectedTexelSize, Set<RenderMeshFragment> fragments) {
-		LOG.debug("Texturizing " + fragments.size() + " fragments");
+		LOG.debug("Texturizing {} fragments", fragments.size());
 		Map<RenderMeshFragment, FragmentTexture> result = new HashMap<RenderMeshFragment, FragmentTexture>();
 
 		// create texture requests for each fragment
@@ -131,7 +131,7 @@ public class TextureManager {
 		// System.out.println( "requests: " + requests.size() );
 		// System.out.println( "tileRequests: " + tileRequests.size() );
 
-		LOG.debug(tileRequests.size() + " tile requests");
+		LOG.debug("{} tile requests", tileRequests.size());
 
 		// fetch texture tiles and assign textures to fragments
 		for (TextureRequest request : requests) {
@@ -173,7 +173,7 @@ public class TextureManager {
 				}
 			}
 			else {
-				LOG.warn("Found no matching tile request for request: " + request);
+				LOG.warn("Found no matching tile request for request: {}", request);
 			}
 		}
 		return result;
@@ -277,7 +277,7 @@ public class TextureManager {
 				minimizedRequests.add(request);
 			}
 		}
-		LOG.debug("Tile requests: " + requests.size() + ", minimized: " + minimizedRequests.size());
+		LOG.debug("Tile requests: {}, minimized: {}", requests.size(), minimizedRequests.size());
 		return minimizedRequests;
 	}
 

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/TextureTileManager.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/manager/TextureTileManager.java
@@ -121,9 +121,9 @@ public class TextureTileManager {
 	private TextureTile getMatchingTileWithLogging(TextureTileRequest request) {
 		TextureTile tile = null;
 		// System.out.println( "Cached tiles: " + cachedTiles.size() );
-		LOG.debug("testing: " + request.toString());
+		LOG.debug("testing: {}", request.toString());
 		for (TextureTile candidate : cachedTiles) {
-			LOG.debug("against: " + candidate);
+			LOG.debug("against: {}", candidate);
 			if (request.isFullfilled(candidate)) {
 				LOG.debug("-- a match ");
 				tile = candidate;
@@ -165,7 +165,7 @@ public class TextureTileManager {
 			}
 			provider = providers[i];
 		}
-		LOG.debug("Using povider with native resolution: " + provider.getNativeResolution());
+		LOG.debug("Using povider with native resolution: {}", provider.getNativeResolution());
 		return provider;
 	}
 
@@ -297,10 +297,10 @@ public class TextureTileManager {
 		}
 
 		if (LOG.isTraceEnabled()) {
-			LOG.trace("frag (world) bbox: " + fragmentBBoxWorldCoordinates[0][0] + ","
-					+ fragmentBBoxWorldCoordinates[0][1] + " | " + fragmentBBoxWorldCoordinates[1][0] + ","
-					+ fragmentBBoxWorldCoordinates[1][1]);
-			LOG.trace("requ bbox: " + minX + "," + minY + " | " + maxX + "," + maxY);
+			LOG.trace("frag (world) bbox: {},{} | {},{}", fragmentBBoxWorldCoordinates[0][0],
+					fragmentBBoxWorldCoordinates[0][1], fragmentBBoxWorldCoordinates[1][0],
+					fragmentBBoxWorldCoordinates[1][1]);
+			LOG.trace("requ bbox: {},{} | {},{}", minX, minY, maxX, maxY);
 		}
 
 		return new TextureRequest(fragment, minX, minY, maxX, maxY, (float) unitsPerPixel);

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/FragmentTexture.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/FragmentTexture.java
@@ -119,7 +119,7 @@ public class FragmentTexture {
 		double tileXMax = texture.getDataMaxX() - minX;
 		double tileYMax = texture.getDataMaxY() - minY;
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(tileXMin + ", " + tileYMin + ", " + tileXMax + ", " + tileYMax);
+			LOG.debug("{}, {}, {}, {}", tileXMin, tileYMin, tileXMax, tileYMax);
 		}
 
 		double tileWidth = texture.getDataMaxX() - texture.getDataMinX();

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/RasterAPITextureTileProvider.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/RasterAPITextureTileProvider.java
@@ -128,8 +128,8 @@ public class RasterAPITextureTileProvider implements TextureTileProvider {
 		long begin2 = System.currentTimeMillis();
 		SimpleRaster simpleRaster = subset.getAsSimpleRaster();
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("#getTextureTile(): as simple raster: " + (System.currentTimeMillis() - begin2) + ", env: "
-					+ simpleRaster.getEnvelope());
+			LOG.debug("#getTextureTile(): as simple raster: {}, env: {}", (System.currentTimeMillis() - begin2),
+					simpleRaster.getEnvelope());
 		}
 		PixelInterleavedRasterData rasterData = (PixelInterleavedRasterData) simpleRaster.getRasterData();
 		if (rasterData.isOutside()) {

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/StyledGeometryTTProvider.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/StyledGeometryTTProvider.java
@@ -266,7 +266,7 @@ public class StyledGeometryTTProvider implements TextureTileProvider {
 
 				}
 				catch (Exception e) {
-					LOG.debug("Found a cached file but could not read it because: " + e.getLocalizedMessage(), e);
+					LOG.debug("Found a cached file but could not read it because: {}", e.getLocalizedMessage(), e);
 				}
 			}
 		}
@@ -314,10 +314,10 @@ public class StyledGeometryTTProvider implements TextureTileProvider {
 				frs = this.featureStore.query(q);
 			}
 			catch (FeatureStoreException e) {
-				LOG.error("Could not create a geometry layer texture because: " + e.getLocalizedMessage(), e);
+				LOG.error("Could not create a geometry layer texture because: {}", e.getLocalizedMessage(), e);
 			}
 			catch (FilterEvaluationException e) {
-				LOG.error("Could not create a geometry layer texture because: " + e.getLocalizedMessage(), e);
+				LOG.error("Could not create a geometry layer texture because: {}", e.getLocalizedMessage(), e);
 			}
 			if (frs == null || !frs.iterator().hasNext()) {
 				// no objects found
@@ -362,8 +362,8 @@ public class StyledGeometryTTProvider implements TextureTileProvider {
 				}
 			}
 			catch (Exception e) {
-				LOG.debug("Could not create a styled geometry texture because: " + e.getLocalizedMessage(), e);
-				LOG.warn("Error while creating styled geometry texture: " + e);
+				LOG.debug("Could not create a styled geometry texture because: {}", e.getLocalizedMessage(), e);
+				LOG.warn("Error while creating styled geometry texture: {}", e);
 				return null;
 			}
 		}
@@ -402,9 +402,9 @@ public class StyledGeometryTTProvider implements TextureTileProvider {
 		}
 		catch (IOException e) {
 			// could not create a grid writer, don't add to cache
-			LOG.debug("Not adding styled geometry to cache because no grid writer could be created: "
-					+ e.getLocalizedMessage(), e);
-			LOG.warn("Not writing cachefile becaue: " + e.getLocalizedMessage());
+			LOG.debug("Not adding styled geometry to cache because no grid writer could be created: {}",
+					e.getLocalizedMessage(), e);
+			LOG.warn("Not writing cachefile becaue: {}", e.getLocalizedMessage());
 			newCacheFile.delete();
 			return;
 		}
@@ -448,7 +448,7 @@ public class StyledGeometryTTProvider implements TextureTileProvider {
 			// 268435456 == maximum size of texture with textureside 8192 and 4 bytes.
 			super((int) Math.ceil(freeSpace / 268435456d), 0.75f, false);
 			this.freeSpace = freeSpace;
-			LOG.info("Styled geometry dataset cache will use: " + freeSpace / (1024 * 1024d) + " Mb.");
+			LOG.info("Styled geometry dataset cache will use: {} Mb.", freeSpace / (1024 * 1024d));
 		}
 
 		public Pair<TextureTileRequest, File> get(TextureTileRequest req) {
@@ -498,9 +498,9 @@ public class StyledGeometryTTProvider implements TextureTileProvider {
 					this.freeSpace += fSize;
 				}
 				else {
-					LOG.warn("Could not delete file: " + eldest.getValue()
-							+ " from the styled geometry cache, please clear some files from the cache directory: "
-							+ eldest.getValue().getParent() + " manually.");
+					LOG.warn(
+							"Could not delete file: {} from the styled geometry cache, please clear some files from the cache directory: {} manually.",
+							eldest.getValue(), eldest.getValue().getParent());
 				}
 
 				return true;

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/TextureTile.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/TextureTile.java
@@ -303,7 +303,7 @@ public class TextureTile {
 	public void disable(GL gl, int refID) {
 		synchronized (LOCK) {
 			if (!referencedRenderFragments.contains(refID)) {
-				LOG.warn("Trying to remove a reference, which was not registered, this is strange: " + textureID);
+				LOG.warn("Trying to remove a reference, which was not registered, this is strange: {}", textureID);
 				if (textureID == null) {
 					return;
 				}
@@ -331,9 +331,9 @@ public class TextureTile {
 		if (textureID == null) {
 			if (imageData != null) {
 				if (imageData.capacity() != dataSize) {
-					LOG.warn("The data of the texture tile was not set correctly, excpected are: " + dataSize
-							+ " bytes of " + (hasAlpha ? "RGBA" : "RGB") + " values, supplied were: "
-							+ imageData.capacity() + ". This texture will not be rendered.");
+					LOG.warn(
+							"The data of the texture tile was not set correctly, excpected are: {} bytes of {} values, supplied were: {}. This texture will not be rendered.",
+							dataSize, (hasAlpha ? "RGBA" : "RGB"), imageData.capacity());
 				}
 				else {
 					textureID = new int[1];

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/WMSTextureTileProvider.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/dem/texturing/WMSTextureTileProvider.java
@@ -139,7 +139,7 @@ public class WMSTextureTileProvider implements TextureTileProvider {
 		int width = (int) ((maxX - minX) / res);
 		int height = (int) ((maxY - minY) / res);
 
-		LOG.debug("Fetching texture tile (" + width + "x" + height + ") via WMSClient.");
+		LOG.debug("Fetching texture tile ({}x{}) via WMSClient.", width, height);
 
 		Envelope bbox = fac.createEnvelope(minX, minY, maxX, maxY, requestedCRS);
 		SimpleRaster raster = null;
@@ -150,7 +150,7 @@ public class WMSTextureTileProvider implements TextureTileProvider {
 			LOG.debug("Success");
 		}
 		catch (IOException e) {
-			LOG.debug("Failed: " + e.getMessage(), e);
+			LOG.debug("Failed: {}", e.getMessage(), e);
 			// this must never happen, cause the above request uses errorsInImage=true
 			throw new RuntimeException(e.getMessage());
 		}

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/geometry/DirectGeometryBuffer.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/geometry/DirectGeometryBuffer.java
@@ -66,10 +66,10 @@ public class DirectGeometryBuffer {
 	 * @param textureCapacity
 	 */
 	public DirectGeometryBuffer(int coordinateCapacity, int textureCapacity) {
-		LOG.info("Allocating directbuffer for " + 2 * coordinateCapacity + " oordinates (normals and vertices): "
-				+ (2 * coordinateCapacity * AllocatedHeapMemory.FLOAT_SIZE) / 1048576 + " MB");
-		LOG.info("Allocating directbuffer for " + textureCapacity + " texture oordinates: "
-				+ (textureCapacity * AllocatedHeapMemory.FLOAT_SIZE) / 1048576 + " MB");
+		LOG.info("Allocating directbuffer for {} oordinates (normals and vertices): {} MB", 2 * coordinateCapacity,
+				(2 * coordinateCapacity * AllocatedHeapMemory.FLOAT_SIZE) / 1048576);
+		LOG.info("Allocating directbuffer for {} texture oordinates: {} MB", textureCapacity,
+				(textureCapacity * AllocatedHeapMemory.FLOAT_SIZE) / 1048576);
 		// LOG.info( "VM has total mb of direct memory: " + VM.maxDirectMemory() / 1048576
 		// );
 

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/geometry/RenderableGeometry.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/geometry/RenderableGeometry.java
@@ -234,7 +234,7 @@ public class RenderableGeometry implements RenderableQualityModelPart {
 			normal[2] = normalBuffer.get();
 			float length = Vectors3f.length(normal);
 			if (length > 1) {
-				LOG.warn("Normal is larger 1: " + length + ", this may not be. ");
+				LOG.warn("Normal is larger 1: {}, this may not be. ", length);
 			}
 		}
 		normalBuffer.rewind();

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/manager/BuildingRenderer.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/manager/BuildingRenderer.java
@@ -111,8 +111,8 @@ public class BuildingRenderer extends RenderableManager<WorldRenderableObject> {
 			// LOG.debug( "Sorting of " + allBillBoards.size() + " buildings took: "
 			// + ( System.currentTimeMillis() - begin ) + " ms" );
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Number of buildings from viewparams: " + buildings.size());
-				LOG.debug("Total number of buildings : " + size());
+				LOG.debug("Number of buildings from viewparams: {}", buildings.size());
+				LOG.debug("Total number of buildings : {}", size());
 			}
 			context.glPushAttrib(GL.GL_CURRENT_BIT | GL.GL_LIGHTING_BIT);
 			Iterator<WorldRenderableObject> it = buildings.iterator();
@@ -124,8 +124,8 @@ public class BuildingRenderer extends RenderableManager<WorldRenderableObject> {
 			}
 			context.glPopAttrib();
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Rendering of " + buildings.size() + " buildings took: "
-						+ (System.currentTimeMillis() - begin) + " ms");
+				LOG.debug("Rendering of {} buildings took: {} ms", buildings.size(),
+						(System.currentTimeMillis() - begin));
 			}
 		}
 		else {

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/manager/LODSwitcher.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/manager/LODSwitcher.java
@@ -92,8 +92,9 @@ public class LODSwitcher {
 					}
 					if (i > 0) {
 						if (Math.abs(min - this.levels[i - 1][1]) > 1E-3) {
-							LOG.warn("Min (" + min + ") does not match previous max interval value ("
-									+ this.levels[i - 1][1] + ") adjusting to this value.");
+							LOG.warn(
+									"Min ({}) does not match previous max interval value ({}) adjusting to this value.",
+									min, this.levels[i - 1][1]);
 							min = this.levels[i - 1][1] + 0.0001;
 							if (min > max) {
 								LOG.warn("Min is larger as max, inversing min and max.");

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/manager/TreeRenderer.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/manager/TreeRenderer.java
@@ -120,8 +120,8 @@ public class TreeRenderer extends RenderableManager<BillBoard> {
 			List<BillBoard> allBillBoards = new ArrayList<BillBoard>(boards);
 			Collections.sort(allBillBoards, new DistComparator(eye));
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Number of trees from viewparams: " + allBillBoards.size());
-				LOG.debug("Total number of trees : " + size());
+				LOG.debug("Number of trees from viewparams: {}", allBillBoards.size());
+				LOG.debug("Total number of trees : {}", size());
 			}
 			context.glPushAttrib(GL.GL_CURRENT_BIT | GL.GL_LIGHTING_BIT | GL.GL_ENABLE_BIT);
 			context.glMaterialfv(GL.GL_FRONT, GL.GL_DIFFUSE, new float[] { 1, 1, 1, 1 }, 0);
@@ -183,8 +183,7 @@ public class TreeRenderer extends RenderableManager<BillBoard> {
 			context.glBindBuffer(GL.GL_ARRAY_BUFFER, 0);
 
 			context.glPopAttrib();
-			LOG.debug("Rendering of " + allBillBoards.size() + " trees took: " + (System.currentTimeMillis() - begin)
-					+ " ms");
+			LOG.debug("Rendering of {} trees took: {} ms", allBillBoards.size(), (System.currentTimeMillis() - begin));
 		}
 		else {
 			LOG.debug("Not rendering any trees.");

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/prototype/PrototypePool.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/prototype/PrototypePool.java
@@ -79,7 +79,7 @@ public class PrototypePool {
 		RenderablePrototype model = prototypes.get(prototype.getPrototypeID());
 
 		if (model == null) {
-			LOG.warn("No model found for prototype: " + prototype.getPrototypeID());
+			LOG.warn("No model found for prototype: {}", prototype.getPrototypeID());
 			return;
 		}
 

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/texture/TexturePool.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/rendering/model/texture/TexturePool.java
@@ -106,16 +106,16 @@ public class TexturePool {
 	public static synchronized void addTexture(String key, File textureFile) {
 		if (key != null && !"".equals(key) && textureFile.exists() && !textureFile.isDirectory()) {
 			if (idToFile.containsKey(key)) {
-				LOG.warn("Ignoring texture key: " + key
-						+ " because it is already present in the texture pool with file: " + idToFile.get(key));
+				LOG.warn("Ignoring texture key: {} because it is already present in the texture pool with file: {}",
+						key, idToFile.get(key));
 			}
 			else {
 				idToFile.put(key, textureFile.getAbsolutePath());
 			}
 		}
 		else {
-			LOG.warn("Ignoring texture key: " + key
-					+ " because it is null, empty or the file does not exist or is a directory.");
+			LOG.warn("Ignoring texture key: {} because it is null, empty or the file does not exist or is a directory.",
+					key);
 		}
 	}
 
@@ -137,7 +137,7 @@ public class TexturePool {
 
 		Texture tex = getTexture(glRenderContext, texture);
 		if (tex == null) {
-			LOG.warn("No texture for id: " + texture);
+			LOG.warn("No texture for id: {}", texture);
 			return;
 		}
 		tex.bind();
@@ -171,12 +171,12 @@ public class TexturePool {
 				result = TextureIO.newTexture(f, true);
 			}
 			catch (GLException e) {
-				LOG.error("Error while trying to load texture with fileName:" + fileName + " cause: "
-						+ e.getLocalizedMessage(), e);
+				LOG.error("Error while trying to load texture with fileName:{} cause: {}", fileName,
+						e.getLocalizedMessage(), e);
 			}
 			catch (IOException e) {
-				LOG.error("Error while trying to load texture with fileName:" + fileName + " cause: "
-						+ e.getLocalizedMessage(), e);
+				LOG.error("Error while trying to load texture with fileName:{} cause: {}", fileName,
+						e.getLocalizedMessage(), e);
 			}
 			if (result != null) {
 				idToTexture.put(textureID, result);

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/tesselation/GeometryCallBack.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/tesselation/GeometryCallBack.java
@@ -93,7 +93,7 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 					sb.append("line loop");
 					break;
 				default:
-					LOG.warn("Don't know open gl type: " + openGLType);
+					LOG.warn("Don't know open gl type: {}", openGLType);
 					break;
 			}
 			LOG.trace(sb.toString());
@@ -120,7 +120,7 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 			Object originalVertex) {
 		LOG.trace("Tesselation combining data.");
 
-		LOG.trace("Coordinates of vertex: " + coords[0] + "," + coords[1] + "," + coords[2]);
+		LOG.trace("Coordinates of vertex: {},{},{}", coords[0], coords[1], coords[2]);
 		Vertex[] cd = new Vertex[coordinateData.length];
 		for (int i = 0; i < coordinateData.length; ++i) {
 			cd[i] = (Vertex) coordinateData[i];
@@ -218,7 +218,7 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 				calcNormalsForTriangleFan(normals);
 				break;
 			default:
-				LOG.warn("Don't know open gl type: " + glu.gluGetString(openGLType));
+				LOG.warn("Don't know open gl type: {}", glu.gluGetString(openGLType));
 				break;
 		}
 		return normals;
@@ -303,8 +303,8 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 	private void averageNormal(float[] normals, float[] normal, int vertexIndex) {
 		int offset = vertexIndex * 3;
 		if (offset > normals.length) {
-			LOG.warn("Given vertex: " + vertexIndex + " (offset: " + offset
-					+ ") would be outside the normal array with length: " + normals.length);
+			LOG.warn("Given vertex: {} (offset: {}) would be outside the normal array with length: {}", vertexIndex,
+					offset, normals.length);
 			return;
 		}
 		normals[offset] += normal[0];
@@ -323,8 +323,8 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 	private void setNormalForVertex(float[] normals, float[] normal, int vertexIndex) {
 		int offset = vertexIndex * 3;
 		if (offset > normals.length) {
-			LOG.warn("Given vertex: " + vertexIndex + " (offset: " + offset
-					+ ") would be outside the normal array with length: " + normals.length);
+			LOG.warn("Given vertex: {} (offset: {}) would be outside the normal array with length: {}", vertexIndex,
+					offset, normals.length);
 			return;
 		}
 		normals[offset] = normal[0];
@@ -349,8 +349,8 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 			// the last triangle is not complete, lets set the normals to the last
 			// triangle
 			int lastIndices = tesselatedVertices.size() - vertex;
-			LOG.warn("The last triangle was not complete, ( missing " + lastIndices
-					+ ((lastIndices > 1) ? "vertices" : "vertex") + "; using normal of last triangle");
+			LOG.warn("The last triangle was not complete, ( missing {}{}; using normal of last triangle", lastIndices,
+					((lastIndices > 1) ? "vertices" : "vertex"));
 			for (; vertex < tesselatedVertices.size(); ++vertex) {
 				setNormalForVertex(normals, calculatedNormal, vertex);
 			}
@@ -360,7 +360,7 @@ public class GeometryCallBack extends GLUtessellatorCallbackAdapter {
 	private void calcNormal(Vertex a, Vertex b, Vertex c, float[] normal) {
 		Vectors3f.normalizedNormal(a.getCoords(), b.getCoords(), c.getCoords(), normal);
 		if (LOG.isTraceEnabled()) {
-			LOG.trace("resulting normal: " + Vectors3f.asString(normal));
+			LOG.trace("resulting normal: {}", Vectors3f.asString(normal));
 		}
 	}
 

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/tesselation/Tesselator.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/tesselation/Tesselator.java
@@ -98,15 +98,15 @@ public class Tesselator {
 				try {
 					RenderableGeometry result = tesselatePolygon(tess, callBack);
 					if (result != null) {
-						LOG.trace("Resulting renderable has " + result.getVertexCount() + " number of vertices.");
+						LOG.trace("Resulting renderable has {} number of vertices.", result.getVertexCount());
 						results.add(result);
 					}
 				}
 				catch (Exception e) {
-					LOG.warn("Error while tesselating following geometry (from a quality model"
-							+ (objectID == null || "".equals(objectID) ? ")" : " with id: " + objectID + ")") + ":\n"
-							+ geom.toString() + "\n(are the vertices colinear?). Original error message was:"
-							+ e.getLocalizedMessage());
+					LOG.warn(
+							"Error while tesselating following geometry (from a quality model{}:\n{}\n(are the vertices colinear?). Original error message was:{}",
+							(objectID == null || "".equals(objectID) ? ")" : " with id: " + objectID + ")"),
+							geom.toString(), e.getLocalizedMessage());
 				}
 			}
 		}
@@ -143,7 +143,7 @@ public class Tesselator {
 		GeometryCallBack callBack = createAndRegisterCallBack(tess, originalGeometry);
 		RenderableGeometry result = tesselatePolygon(tess, callBack);
 		if (result != null && LOG.isTraceEnabled()) {
-			LOG.trace("Resulting renderable has " + result.getVertexCount() + " number of vertices.");
+			LOG.trace("Resulting renderable has {} number of vertices.", result.getVertexCount());
 		}
 		glu.gluDeleteTess(tess);
 		return result;
@@ -185,7 +185,7 @@ public class Tesselator {
 		// end of the ring in the 3d float array, if no rings, just use the whole geometry
 		int ringEnd = numberOfVertices;
 		boolean hasRings = (innerRings != null && innerRings.length > 0);
-		LOG.trace("SimpleAccessGeometry has " + numberOfVertices + " number of vertices.");
+		LOG.trace("SimpleAccessGeometry has {} number of vertices.", numberOfVertices);
 		glu.gluTessBeginPolygon(tess, null);
 		{
 			do {
@@ -200,8 +200,8 @@ public class Tesselator {
 						ringEnd = numberOfVertices;
 					}
 				}
-				LOG.trace("polygon begin vertex: " + ringBegin);
-				LOG.trace("polygon end vertex: " + ringEnd);
+				LOG.trace("polygon begin vertex: {}", ringBegin);
+				LOG.trace("polygon end vertex: {}", ringEnd);
 
 				tesselateRing(tess, ringBegin, ringEnd, callBack);
 				// the beginning of the new ring or coords.length if no more rings.

--- a/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/tesselation/TexturedGeometryCallBack.java
+++ b/deegree-core/deegree-core-3d/src/main/java/org/deegree/rendering/r3d/opengl/tesselation/TexturedGeometryCallBack.java
@@ -62,7 +62,7 @@ public class TexturedGeometryCallBack extends GeometryCallBack {
 	public void combineData(double[] coords, Object[] coordinateData, float[] weights, Object[] outData,
 			Object originalVertex) {
 		LOG.trace("Tesselation combining textured vertex data.");
-		LOG.trace("Coordinates of vertex: " + coords[0] + "," + coords[1] + "," + coords[2]);
+		LOG.trace("Coordinates of vertex: {},{},{}", coords[0], coords[1], coords[2]);
 		TexturedVertex[] cd = new TexturedVertex[coordinateData.length];
 		for (int i = 0; i < coordinateData.length; ++i) {
 			cd[i] = (TexturedVertex) coordinateData[i];

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/Features.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/Features.java
@@ -142,7 +142,7 @@ public class Features {
 							}
 						}
 						catch (Exception e) {
-							LOG.debug("Cannot compare values: " + e.getMessage());
+							LOG.debug("Cannot compare values: {}", e.getMessage());
 						}
 					}
 					return order;

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/GenericFeature.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/GenericFeature.java
@@ -87,7 +87,7 @@ public class GenericFeature extends AbstractFeature {
 	@Override
 	public void setPropertyValue(QName propName, int occurrence, TypedObjectNode value) {
 
-		LOG.debug("Setting property value for " + occurrence + ". " + propName + " property");
+		LOG.debug("Setting property value for {}. {} property", occurrence, propName);
 
 		// check if change would violate minOccurs/maxOccurs constraint
 		int current = getProperties(propName).size();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/i18n/Messages.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -111,7 +111,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -179,7 +179,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/GenericAppSchema.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/GenericAppSchema.java
@@ -355,7 +355,7 @@ public class GenericAppSchema implements AppSchema {
 			LOG.debug("Testing substitutability against null feature type.");
 			return true;
 		}
-		LOG.debug("ft: " + ft.getName() + ", substitution: " + substitution.getName());
+		LOG.debug("ft: {}, substitution: {}", ft.getName(), substitution.getName());
 		if (ft == substitution) {
 			return true;
 		}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/property/FeaturePropertyType.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/feature/types/property/FeaturePropertyType.java
@@ -93,8 +93,9 @@ public class FeaturePropertyType extends ObjectPropertyType {
 
 	public void resolve(FeatureType valueFt) {
 		if (valueFt == null) {
-			LOG.warn("Setting reference to feature type '" + valueFtName
-					+ "' to null -- repairing definition by clearing value feature type name as well.");
+			LOG.warn(
+					"Setting reference to feature type '{}' to null -- repairing definition by clearing value feature type name as well.",
+					valueFtName);
 			valueFtName = null;
 		}
 		// TODO (reenable?)

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/expression/ValueReference.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/expression/ValueReference.java
@@ -113,16 +113,16 @@ public class ValueReference implements Expression {
 
 		try {
 			xpath = new BaseXPath(text, null).getRootExpr();
-			LOG.debug("XPath: " + xpath);
+			LOG.debug("XPath: {}", xpath);
 		}
 		catch (JaxenException e) {
-			LOG.debug("'" + text + "' does not denote a valid XPath 1.0 expression.");
+			LOG.debug("'{}' does not denote a valid XPath 1.0 expression.", text);
 			return;
 		}
 
 		for (String prefix : XPathUtils.extractPrefixes(xpath)) {
 			String ns = nsContext == null ? null : nsContext.translateNamespacePrefixToUri(prefix);
-			LOG.debug(prefix + " -> " + ns);
+			LOG.debug("{} -> {}", prefix, ns);
 			bindings.addNamespace(prefix, ns);
 		}
 
@@ -142,7 +142,7 @@ public class ValueReference implements Expression {
 							String ns = this.bindings.translateNamespacePrefixToUri(prefix);
 							qName = new QName(ns, step.getLocalName(), prefix);
 						}
-						LOG.debug("QName: " + qName);
+						LOG.debug("QName: {}", qName);
 					}
 				}
 			}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/expression/custom/CustomExpressionManager.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/expression/custom/CustomExpressionManager.java
@@ -66,10 +66,11 @@ public class CustomExpressionManager {
 			elNameToExpression = new HashMap<QName, CustomExpression>();
 			try {
 				for (CustomExpression expr : customExpressionLoader) {
-					LOG.debug("Expression: " + expr + ", element name: " + expr.getElementName());
+					LOG.debug("Expression: {}, element name: {}", expr, expr.getElementName());
 					if (elNameToExpression.containsKey(expr.getElementName())) {
-						LOG.error("Multiple CustomExpression instances for element name: '" + expr.getElementName()
-								+ "' on classpath -- omitting '" + expr.getClass().getName() + "'.");
+						LOG.error(
+								"Multiple CustomExpression instances for element name: '{}' on classpath -- omitting '{}'.",
+								expr.getElementName(), expr.getClass().getName());
 						continue;
 					}
 					elNameToExpression.put(expr.getElementName(), expr);

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/function/FunctionManager.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/function/FunctionManager.java
@@ -68,11 +68,11 @@ public class FunctionManager implements Initializable, Destroyable {
 			nameToFunction = new HashMap<String, FunctionProvider>();
 			try {
 				for (FunctionProvider function : functionLoader) {
-					LOG.debug("Function: " + function + ", name: " + function.getName());
+					LOG.debug("Function: {}, name: {}", function, function.getName());
 					String name = function.getName().toLowerCase();
 					if (nameToFunction.containsKey(name)) {
-						LOG.error("Multiple CustomFunction instances for name: '" + name
-								+ "' on classpath -- omitting '" + function.getClass().getName() + "'.");
+						LOG.error("Multiple CustomFunction instances for name: '{}' on classpath -- omitting '{}'.",
+								name, function.getClass().getName());
 						continue;
 					}
 					nameToFunction.put(name, function);
@@ -105,7 +105,7 @@ public class FunctionManager implements Initializable, Destroyable {
 				fp.init(ws);
 			}
 			catch (Throwable t) {
-				LOG.error("Initialization of FunctionProvider " + fp.getName() + " failed: " + t.getMessage());
+				LOG.error("Initialization of FunctionProvider {} failed: {}", fp.getName(), t.getMessage());
 			}
 		}
 	}
@@ -117,7 +117,7 @@ public class FunctionManager implements Initializable, Destroyable {
 				fp.destroy();
 			}
 			catch (Throwable t) {
-				LOG.error("Destroying of FunctionProvider " + fp.getName() + " failed: " + t.getMessage());
+				LOG.error("Destroying of FunctionProvider {} failed: {}", fp.getName(), t.getMessage());
 			}
 		}
 		functionLoader = null;

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/i18n/Messages.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -111,7 +111,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -179,7 +179,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/spatial/SpatialOperator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/spatial/SpatialOperator.java
@@ -249,8 +249,8 @@ public abstract class SpatialOperator implements Operator {
 		ICRS paramCRS = param.getCoordinateSystem();
 		ICRS literalCRS = literal.getCoordinateSystem();
 		if (literalCRS != null && !(paramCRS.equals(literalCRS))) {
-			LOG.debug("Need transformed literal geometry for evaluation: " + literalCRS.getAlias() + " -> "
-					+ paramCRS.getAlias());
+			LOG.debug("Need transformed literal geometry for evaluation: {} -> {}", literalCRS.getAlias(),
+					paramCRS.getAlias());
 			transformedLiteral = srsNameToTransformedGeometry.get(paramCRS.getAlias());
 			if (transformedLiteral == null) {
 				try {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/Filter100XMLDecoder.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/filter/xml/Filter100XMLDecoder.java
@@ -275,10 +275,10 @@ public class Filter100XMLDecoder {
 			Operator rootOperator = parseOperator(xmlStream);
 			filter = new OperatorFilter(rootOperator);
 			nextElement(xmlStream);
-			LOG.debug("Local name: " + xmlStream.getLocalName());
+			LOG.debug("Local name: {}", xmlStream.getLocalName());
 		}
 
-		LOG.debug("Local name: " + xmlStream.getLocalName());
+		LOG.debug("Local name: {}", xmlStream.getLocalName());
 		xmlStream.require(XMLStreamConstants.END_ELEMENT, OGC_NS, "Filter");
 		return filter;
 	}
@@ -911,7 +911,7 @@ public class Filter100XMLDecoder {
 		for (Enum<?> e : enumClass.getEnumConstants()) {
 			QName qname = map.get(e);
 			if (qname == null) {
-				LOG.warn("No value for " + e);
+				LOG.warn("No value for {}", e);
 			}
 			else {
 				names.add(qname.toString());

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonWriter.java
@@ -228,7 +228,7 @@ public class GeoJsonWriter extends JsonWriter implements GeoJsonFeatureWriter, G
 	private void exportFeaturePropertyType(Property property)
 			throws IOException, UnknownCRSException, TransformationException {
 		QName propertyName = property.getName();
-		LOG.debug("Exporting feature property '" + propertyName + "'");
+		LOG.debug("Exporting feature property '{}'", propertyName);
 		if (property instanceof Feature) {
 			if (property == null) {
 				nullValue();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/commons/AbstractGMLObjectReader.java
@@ -209,8 +209,8 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 			throws XMLParsingException, XMLStreamException, UnknownCRSException {
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("- parsing property (begin): " + xmlStream.getCurrentEventInfo());
-			LOG.debug("- property declaration: " + propDecl);
+			LOG.debug("- parsing property (begin): {}", xmlStream.getCurrentEventInfo());
+			LOG.debug("- property declaration: {}", propDecl);
 		}
 
 		Property property = null;
@@ -244,7 +244,7 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 		}
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(" - parsing property (end): " + xmlStream.getCurrentEventInfo());
+			LOG.debug(" - parsing property (end): {}", xmlStream.getCurrentEventInfo());
 		}
 		return property;
 	}
@@ -636,7 +636,7 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 			ICRS crs) throws NoSuchElementException, XMLStreamException, XMLParsingException, UnknownCRSException {
 
 		QName elName = xmlStream.getName();
-		LOG.debug("Parsing complex XML element " + elName);
+		LOG.debug("Parsing complex XML element {}", elName);
 		if (gmlStreamReader.getGeometryReader().isGeometryElement(xmlStream)) {
 			return gmlStreamReader.getGeometryReader().parse(xmlStream);
 		}
@@ -730,7 +730,7 @@ public abstract class AbstractGMLObjectReader extends XMLAdapter {
 			throws NoSuchElementException, XMLStreamException, XMLParsingException, UnknownCRSException {
 
 		QName elName = xmlStream.getName();
-		LOG.debug("Parsing complex XML element " + elName + " (without schema information)");
+		LOG.debug("Parsing complex XML element {} (without schema information)", elName);
 		if (gmlStreamReader.getGeometryReader().isGeometryElement(xmlStream)) {
 			return gmlStreamReader.getGeometryReader().parse(xmlStream);
 		}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureReader.java
@@ -183,17 +183,17 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 		String fid = parseFeatureId(xmlStream);
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("- parsing feature, gml:id=" + fid + " (begin): " + xmlStream.getCurrentEventInfo());
+			LOG.debug("- parsing feature, gml:id={} (begin): {}", fid, xmlStream.getCurrentEventInfo());
 		}
 
 		QName featureName = xmlStream.getName();
 		FeatureType ft = lookupFeatureType(xmlStream, featureName, false);
 		if (ft == null) {
-			LOG.debug("- adding feature type '" + featureName + "'");
+			LOG.debug("- adding feature type '{}'", featureName);
 			ft = appSchema.addFeatureType(featureName);
 		}
 		else {
-			LOG.debug("- found feature type '" + featureName + "'");
+			LOG.debug("- found feature type '{}'", featureName);
 		}
 
 		ICRS activeCRS = crs;
@@ -204,7 +204,7 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 
 		while (xmlStream.getEventType() == START_ELEMENT) {
 			QName propName = xmlStream.getName();
-			LOG.debug("- property '" + propName + "'");
+			LOG.debug("- property '{}'", propName);
 
 			Property property = null;
 			PropertyType propDecl = ft.getPropertyDeclaration(propName);
@@ -223,7 +223,7 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 					Envelope bbox = (Envelope) property.getValue();
 					if (bbox.getCoordinateSystem() != null) {
 						activeCRS = bbox.getCoordinateSystem();
-						LOG.debug("- crs (from boundedBy): '" + activeCRS + "'");
+						LOG.debug("- crs (from boundedBy): '{}'", activeCRS);
 					}
 				}
 
@@ -269,21 +269,21 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 		PropertyType propDecl = null;
 		if (xmlStream.isEndElement()) {
 			if (propAttributes.containsKey(new QName(XLNNS, "href"))) {
-				LOG.debug("Detected complex (xlink-valued) property '" + propName + "'. Treating as feature property.");
+				LOG.debug("Detected complex (xlink-valued) property '{}'. Treating as feature property.", propName);
 				propDecl = ((DynamicFeatureType) ft).addFeaturePropertyDeclaration(lastPropDecl, propName, null);
 			}
 			else {
-				LOG.debug("Detected simple property '" + propName + "'.");
+				LOG.debug("Detected simple property '{}'.", propName);
 				propDecl = ((DynamicFeatureType) ft).addSimplePropertyDeclaration(lastPropDecl, propName);
 			}
 		}
 		else {
 			if (gmlStreamReader.getGeometryReader().isGeometryElement(xmlStream)) {
-				LOG.debug("Detected geometry property '" + propName + "'.");
+				LOG.debug("Detected geometry property '{}'.", propName);
 				propDecl = ((DynamicFeatureType) ft).addGeometryPropertyDeclaration(lastPropDecl, propName);
 			}
 			else {
-				LOG.debug("Detected complex non-geometry property '" + propName + "'. Treating as feature property.");
+				LOG.debug("Detected complex non-geometry property '{}'. Treating as feature property.", propName);
 				FeatureType valueFt = schema.getFeatureType(childElName);
 				if (valueFt == null) {
 					valueFt = appSchema.addFeatureType(childElName);
@@ -331,11 +331,11 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 		FeatureType ft = lookupFeatureType(xmlStream, featureName, true);
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("- parsing feature, gml:id=" + fid + " (begin): " + xmlStream.getCurrentEventInfo());
+			LOG.debug("- parsing feature, gml:id={} (begin): {}", fid, xmlStream.getCurrentEventInfo());
 		}
 		List<Property> propertyList = parseProperties(xmlStream, crs, ft);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(" - parsing feature (end): " + xmlStream.getCurrentEventInfo());
+			LOG.debug(" - parsing feature (end): {}", xmlStream.getCurrentEventInfo());
 		}
 
 		int extraPropertyIdx = -1;
@@ -381,11 +381,11 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 		while (xmlStream.getEventType() == START_ELEMENT) {
 			QName propName = xmlStream.getName();
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("- property '" + propName + "'");
+				LOG.debug("- property '{}'", propName);
 			}
 
 			if (propName.getNamespaceURI() != null && propName.getNamespaceURI().startsWith(EXTRA_PROP_NS)) {
-				LOG.debug("Parsing extra property: " + propName);
+				LOG.debug("Parsing extra property: {}", propName);
 				PropertyType pt = null;
 				if (EXTRA_PROP_NS_GEOMETRY.equals(propName.getNamespaceURI())) {
 					pt = new GeometryPropertyType(propName, 1, 1, null, null, GEOMETRY, DIM_2_OR_3, INLINE);
@@ -438,7 +438,7 @@ public class GMLFeatureReader extends AbstractGMLObjectReader {
 					Envelope bbox = (Envelope) property.getValue();
 					if (bbox != null && bbox.getCoordinateSystem() != null) {
 						activeCRS = bbox.getCoordinateSystem();
-						LOG.debug("- crs (from boundedBy): '" + activeCRS + "'");
+						LOG.debug("- crs (from boundedBy): '{}'", activeCRS);
 					}
 				}
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -266,7 +266,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 		PropertyType pt = property.getType();
 		pathTracker.startStep(propName);
 		if (pt.getMinOccurs() == 0) {
-			LOG.debug("Optional property '" + propName + "', checking if it is requested.");
+			LOG.debug("Optional property '{}', checking if it is requested.", propName);
 			if (!isPropertyRequested()) {
 				pathTracker.stopStep(propName);
 				LOG.debug("Skipping it.");
@@ -504,7 +504,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 				}
 			}
 			catch (FilterEvaluationException e) {
-				LOG.warn("Unable to evaluate time slice projection filter: " + e.getMessage());
+				LOG.warn("Unable to evaluate time slice projection filter: {}", e.getMessage());
 			}
 		}
 		return false;
@@ -646,7 +646,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 			throws XMLStreamException, UnknownCRSException, TransformationException {
 
 		QName propName = pt.getName();
-		LOG.debug("Exporting feature property '" + propName + "'");
+		LOG.debug("Exporting feature property '{}'", propName);
 		if (subFeature == null) {
 			exportEmptyProperty(propName, attributes);
 		}
@@ -680,7 +680,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 			throws XMLStreamException, UnknownCRSException, TransformationException {
 		final ObjectPropertyType pt = (ObjectPropertyType) prop.getType();
 		final QName propName = pt.getName();
-		LOG.debug("Exporting object property '" + propName + "'");
+		LOG.debug("Exporting object property '{}'", propName);
 		if (object == null) {
 			exportEmptyProperty(propName, prop.getAttributes());
 		}
@@ -771,7 +771,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 			throws XMLStreamException, UnknownCRSException, TransformationException {
 		QName elName = xmlContent.getName();
 		pathTracker.startStep(elName);
-		LOG.debug("Exporting " + elName);
+		LOG.debug("Exporting {}", elName);
 		XSElementDeclaration elDecl = xmlContent.getXSType();
 		int minOccurs = 1;
 		if (elDecl != null && schemaInfoset != null) {
@@ -841,14 +841,14 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 							}
 							else {
 								LOG.debug(
-										"Only simple qualified element names and XPath expression are allowed for PropertyName projections. Ignoring '"
-												+ propName.getPropertyName() + "'");
+										"Only simple qualified element names and XPath expression are allowed for PropertyName projections. Ignoring '{}'",
+										propName.getPropertyName());
 							}
 						}
 						else {
 							LOG.debug(
-									"Only simple qualified element names and XPath expression are allowed for PropertyName projections. Ignoring '"
-											+ propName.getPropertyName() + "'");
+									"Only simple qualified element names and XPath expression are allowed for PropertyName projections. Ignoring '{}'",
+									propName.getPropertyName());
 						}
 					}
 					else if (projectionOfFeatureType instanceof TimeSliceProjection) {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/StreamFeatureCollection.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/StreamFeatureCollection.java
@@ -159,7 +159,7 @@ public class StreamFeatureCollection implements FeatureInputStream {
 		if (event == START_ELEMENT) {
 			QName propName = xmlStream.getName();
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("- property '" + propName + "'");
+				LOG.debug("- property '{}'", propName);
 			}
 			if (featureReader.findConcretePropertyType(propName, activeDecl) != null) {
 				// current property element is equal to active declaration
@@ -214,7 +214,7 @@ public class StreamFeatureCollection implements FeatureInputStream {
 						Envelope bbox = (Envelope) property.getValue();
 						if (bbox.getCoordinateSystem() != null) {
 							activeCRS = bbox.getCoordinateSystem();
-							LOG.debug("- crs (from boundedBy): '" + activeCRS + "'");
+							LOG.debug("- crs (from boundedBy): '{}'", activeCRS);
 						}
 					}
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML2GeometryReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML2GeometryReader.java
@@ -343,7 +343,7 @@ public class GML2GeometryReader extends AbstractGMLObjectReader implements GMLGe
 		Polygon polygon = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			polygon = new PolygonReference(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) polygon);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -417,7 +417,7 @@ public class GML2GeometryReader extends AbstractGMLObjectReader implements GMLGe
 		LineString lineString = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			lineString = new LineStringReference(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) lineString);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -489,7 +489,7 @@ public class GML2GeometryReader extends AbstractGMLObjectReader implements GMLGe
 		Point point = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			point = new PointReference(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) point);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -562,7 +562,7 @@ public class GML2GeometryReader extends AbstractGMLObjectReader implements GMLGe
 		Geometry geometry = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			geometry = new GeometryReference<Geometry>(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) geometry);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML2GeometryWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML2GeometryWriter.java
@@ -120,8 +120,9 @@ public class GML2GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
 				// geoTransformer = new GeometryTransformer( crs );
 			}
 			catch (Exception e) {
-				LOG.debug("Could not create transformer for CRS '" + outputCRS + "': " + e.getMessage()
-						+ ". Encoding will fail if a transformation is actually necessary.");
+				LOG.debug(
+						"Could not create transformer for CRS '{}': {}. Encoding will fail if a transformation is actually necessary.",
+						outputCRS, e.getMessage());
 			}
 		}
 		formatter = gmlStream.getCoordinateFormatter();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryBaseReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryBaseReader.java
@@ -126,8 +126,9 @@ class GML3GeometryBaseReader extends AbstractGMLObjectReader {
 		}
 		if (coordDim == -1) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Parsing posList, but not coordinate dimension information from CRS available. Defaulting to "
-						+ defaultCoordDim);
+				LOG.debug(
+						"Parsing posList, but not coordinate dimension information from CRS available. Defaulting to {}",
+						defaultCoordDim);
 			}
 			coordDim = defaultCoordDim;
 		}

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryReader.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryReader.java
@@ -2581,7 +2581,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		Point point = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			point = new PointReference(getResolver(), href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) point);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2632,7 +2632,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		LineString lineString = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			lineString = new LineStringReference(getResolver(), href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) lineString);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2682,7 +2682,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		Curve curve = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			curve = new CurveReference<Curve>(getResolver(), href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) curve);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2727,7 +2727,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		Polygon polygon = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			polygon = new PolygonReference(getResolver(), href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) polygon);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2777,7 +2777,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		Surface surface = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			surface = new SurfaceReference<Surface>(getResolver(), href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) surface);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2822,7 +2822,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		Solid solid = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			solid = new SolidReference<Solid>(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) solid);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2873,7 +2873,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		GeometricPrimitive primitive = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			primitive = new GeometricPrimitiveReference<GeometricPrimitive>(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) primitive);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2918,7 +2918,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 		Geometry geometry = null;
 		String href = xmlStream.getAttributeValue(CommonNamespaces.XLNNS, "href");
 		if (href != null && href.length() > 0) {
-			LOG.debug("Found geometry reference (xlink): '" + href + "'");
+			LOG.debug("Found geometry reference (xlink): '{}'", href);
 			geometry = new GeometryReference<Geometry>(idContext, href, xmlStream.getSystemId());
 			idContext.addReference((GeometryReference<?>) geometry);
 			if (xmlStream.nextTag() == XMLStreamConstants.START_ELEMENT) {
@@ -2992,7 +2992,7 @@ public class GML3GeometryReader extends GML3GeometryBaseReader implements GMLGeo
 			QName name = xmlStream.getName();
 			type = schema.getGeometryType(name);
 			if (type == null) {
-				LOG.debug("GML geometry element '" + name + "' is not defined in application schema!?");
+				LOG.debug("GML geometry element '{}' is not defined in application schema!?", name);
 			}
 		}
 		return type;

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GML3GeometryWriter.java
@@ -168,8 +168,9 @@ public class GML3GeometryWriter extends AbstractGMLObjectWriter implements GMLGe
 				geoTransformer = new GeometryTransformer(crs);
 			}
 			catch (Exception e) {
-				LOG.debug("Could not create transformer for CRS '" + outputCRS + "': " + e.getMessage()
-						+ ". Encoding will fail if a transformation is actually necessary.");
+				LOG.debug(
+						"Could not create transformer for CRS '{}': {}. Encoding will fail if a transformation is actually necessary.",
+						outputCRS, e.getMessage());
 			}
 		}
 		formatter = gmlStreamWriter.getCoordinateFormatter();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GMLGeometryVersionHelper.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/GMLGeometryVersionHelper.java
@@ -75,7 +75,7 @@ public class GMLGeometryVersionHelper {
 			gmlVersion = GML_32;
 		}
 		else {
-			LOG.warn("Unable to determine GML version for element: " + elName + ". Falling back to GML 2.");
+			LOG.warn("Unable to determine GML version for element: {}. Falling back to GML 2.", elName);
 			gmlVersion = GML_2;
 		}
 		return GMLInputFactory.createGMLStreamReader(gmlVersion, xmlStream).getGeometryReader();

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/validation/GmlStreamGeometryValidator.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/geometry/validation/GmlStreamGeometryValidator.java
@@ -110,8 +110,8 @@ public class GmlStreamGeometryValidator {
 	private void validateGeometryElement() throws UnknownCRSException {
 
 		Location location = xmlStream.getLocation();
-		LOG.debug("Validating GML geometry element ('" + xmlStream.getLocalName() + "') at line: "
-				+ location.getLineNumber() + ", column: " + location.getColumnNumber() + ".");
+		LOG.debug("Validating GML geometry element ('{}') at line: {}, column: {}.", xmlStream.getLocalName(),
+				location.getLineNumber(), location.getColumnNumber());
 
 		GmlElementIdentifier identifier = new GmlElementIdentifier(xmlStream);
 		ValidationEventRedirector eventRedirector = new ValidationEventRedirector(gmlErrorHandler, identifier);

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/i18n/Messages.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -111,7 +111,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -179,7 +179,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLAppSchemaWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLAppSchemaWriter.java
@@ -451,8 +451,8 @@ public class GMLAppSchemaWriter {
 			}
 		}
 
-		LOG.debug("Exporting feature type declaration: " + ft.getName());
-		LOG.debug("Parent: " + ft.getSchema().getParent(ft));
+		LOG.debug("Exporting feature type declaration: {}", ft.getName());
+		LOG.debug("Parent: {}", ft.getSchema().getParent(ft));
 		writer.writeStartElement("element");
 		writer.writeAttribute("name", ft.getName().getLocalPart());
 
@@ -539,10 +539,10 @@ public class GMLAppSchemaWriter {
 		if (schema != null) {
 			for (PropertyType pt : schema.getNewPropertyDecls(ft)) {
 				if (pt == null) {
-					LOG.warn("Property type null inside " + ft.getName());
+					LOG.warn("Property type null inside {}", ft.getName());
 					continue;
 				}
-				LOG.debug("Exporting property type " + pt);
+				LOG.debug("Exporting property type {}", pt);
 				export(writer, pt);
 			}
 		}
@@ -596,7 +596,7 @@ public class GMLAppSchemaWriter {
 
 	private void export(XMLStreamWriter writer, PropertyType pt) throws XMLStreamException {
 
-		LOG.debug("Exporting property type " + pt.getName());
+		LOG.debug("Exporting property type {}", pt.getName());
 
 		// TODO is there more to this decision?
 		boolean byRef = !pt.getName().getNamespaceURI().equals(targetNs);
@@ -855,7 +855,7 @@ public class GMLAppSchemaWriter {
 		XSComplexTypeDefinition xsTypeDef = pt.getXSDValueType();
 
 		if (xsTypeDef == null) {
-			LOG.warn("Type definition null inside " + pt.getName() + " property type.");
+			LOG.warn("Type definition null inside {} property type.", pt.getName());
 		}
 		else {
 			export(writer, xsTypeDef);
@@ -868,7 +868,7 @@ public class GMLAppSchemaWriter {
 		XSTypeDefinition xsTypeDef = xsElDecl != null ? xsElDecl.getTypeDefinition() : null;
 
 		if (xsTypeDef == null) {
-			LOG.warn("Type definition null inside " + pt.getName() + " property type.");
+			LOG.warn("Type definition null inside {} property type.", pt.getName());
 		}
 		else {
 			export(writer, xsTypeDef);
@@ -881,7 +881,7 @@ public class GMLAppSchemaWriter {
 			writer.writeAttribute("type", getPrefixedName(qName));
 		}
 		else {
-			LOG.debug("Exporting anonymous type " + xsTypeDef);
+			LOG.debug("Exporting anonymous type {}", xsTypeDef);
 			exportType(writer, xsTypeDef);
 		}
 	}
@@ -943,7 +943,7 @@ public class GMLAppSchemaWriter {
 
 	private void exportComplexType(XMLStreamWriter writer, XSComplexTypeDefinition complex) throws XMLStreamException {
 
-		LOG.debug("Exporting complex type, name: " + complex.getName());
+		LOG.debug("Exporting complex type, name: {}", complex.getName());
 
 		writer.writeStartElement("complexType");
 		if (!complex.getAnonymous()) {
@@ -990,8 +990,8 @@ public class GMLAppSchemaWriter {
 				derivationBegin = true;
 				break;
 			case DERIVATION_LIST:
-				LOG.warn("Exporting derivation by list is not implemented. Occured for complex element "
-						+ complex.getName());
+				LOG.warn("Exporting derivation by list is not implemented. Occured for complex element {}",
+						complex.getName());
 				break;
 			case DERIVATION_NONE:
 				// nothing to do, handled above
@@ -1008,12 +1008,12 @@ public class GMLAppSchemaWriter {
 				}
 				break;
 			case DERIVATION_SUBSTITUTION:
-				LOG.warn("Exporting derivation by substitution is not implemented. Occured for complex element "
-						+ complex.getName());
+				LOG.warn("Exporting derivation by substitution is not implemented. Occured for complex element {}",
+						complex.getName());
 				break;
 			case DERIVATION_UNION:
-				LOG.warn("Exporting derivation by union is not implemented. Occured for complex element "
-						+ complex.getName());
+				LOG.warn("Exporting derivation by union is not implemented. Occured for complex element {}",
+						complex.getName());
 				break;
 		}
 
@@ -1114,7 +1114,7 @@ public class GMLAppSchemaWriter {
 	private void exportElement(XMLStreamWriter writer, XSElementDeclaration element, int minOccurs, int maxOccurs,
 			boolean maxUnbounded) throws XMLStreamException {
 
-		LOG.debug("Exporting generic element " + element.getNamespace() + "/" + element.getName());
+		LOG.debug("Exporting generic element {}/{}", element.getNamespace(), element.getName());
 
 		writer.writeStartElement("element");
 		writer.writeAttribute("name", element.getName());
@@ -1229,7 +1229,7 @@ public class GMLAppSchemaWriter {
 
 		String prefix = nsToPrefix.get(name.getNamespaceURI());
 		if (prefix == null) {
-			LOG.warn("No prefix for namespace '" + name.getNamespaceURI() + "' defined.");
+			LOG.warn("No prefix for namespace '{}' defined.", name.getNamespaceURI());
 			return "app:" + name.getLocalPart();
 		}
 		if (prefix.equals(DEFAULT_NS_PREFIX)) {

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GMLSchemaInfoSet.java
@@ -629,7 +629,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 				}
 			}
 			else {
-				LOG.warn("Unhandled term type: " + term.getClass());
+				LOG.warn("Unhandled term type: {}", term.getClass());
 			}
 		}
 	}
@@ -702,8 +702,9 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 			final GMLPropertySemantics semantics = derivePropertySemantics(elDecl);
 			if (semantics == null
 					|| (semantics.getValueCategory() != TIME_OBJECT && semantics.getValueCategory() != TIME_SLICE)) {
-				LOG.debug("Identified generic object property declaration ({" + elDecl.getNamespace() + "}"
-						+ elDecl.getName() + "), but handling is not implemented yet.");
+				LOG.debug(
+						"Identified generic object property declaration ({{}}{}), but handling is not implemented yet.",
+						elDecl.getNamespace(), elDecl.getName());
 			}
 			else {
 				pt = new ObjectPropertyType(ptName, minOccurs, maxOccurs, elDecl, ptSubstitutions,
@@ -737,7 +738,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 	private FeaturePropertyType buildFeaturePropertyType(QName ptName, XSElementDeclaration elementDecl,
 			XSComplexTypeDefinition typeDef, int minOccurs, int maxOccurs, List<PropertyType> ptSubstitutions) {
 
-		LOG.trace("Checking if element declaration '" + ptName + "' defines a feature property type.");
+		LOG.trace("Checking if element declaration '{}' defines a feature property type.", ptName);
 		FeaturePropertyType pt = null;
 
 		XMLAdapter annotationXML = null;
@@ -791,8 +792,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 								LOG.trace("Found sequence / choice.");
 								XSObjectList sequence = modelGroup.getParticles();
 								if (sequence.getLength() != 1) {
-									LOG.trace(
-											"Length = '" + sequence.getLength() + "' -> cannot be a feature property.");
+									LOG.trace("Length = '{}' -> cannot be a feature property.", sequence.getLength());
 									return null;
 								}
 								XSParticle particle2 = (XSParticle) sequence.item(0);
@@ -971,8 +971,8 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 												: geomChoiceParticle.getMaxOccurs();
 										if (minOccurs3 != 1 || maxOccurs3 != 1) {
 											LOG.debug(
-													"Only single geometries are currently supported, ignoring in choice (property '"
-															+ ptName + "').");
+													"Only single geometries are currently supported, ignoring in choice (property '{}').",
+													ptName);
 											return null;
 										}
 										QName elementName = new QName(geomChoiceElement.getNamespace(),
@@ -983,7 +983,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 											allowedTypes.add(geometryType);
 										}
 										else {
-											LOG.debug("Unknown geometry type '" + elementName + "'.");
+											LOG.debug("Unknown geometry type '{}'.", elementName);
 										}
 									}
 									else if (geomChoiceTerm.getType() == MODEL_GROUP) {
@@ -993,7 +993,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 										LOG.warn("Unhandled particle: WILDCARD");
 									}
 									else {
-										LOG.warn("Unexpected XSTerm type: " + geomChoiceTerm.getType());
+										LOG.warn("Unexpected XSTerm type: {}", geomChoiceTerm.getType());
 									}
 								}
 								if (!allowedTypes.isEmpty()) {
@@ -1006,8 +1006,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 								LOG.trace("Found sequence.");
 								XSObjectList sequence = modelGroup.getParticles();
 								if (sequence.getLength() != 1) {
-									LOG.trace("Length = '" + sequence.getLength()
-											+ "' -> cannot be a geometry property.");
+									LOG.trace("Length = '{}' -> cannot be a geometry property.", sequence.getLength());
 									return null;
 								}
 								XSParticle particle2 = (XSParticle) sequence.item(0);
@@ -1076,7 +1075,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 															allowedTypes.add(geometryType);
 														}
 														else {
-															LOG.debug("Unknown geometry type '" + elementName + "'.");
+															LOG.debug("Unknown geometry type '{}'.", elementName);
 														}
 													}
 													else {
@@ -1134,10 +1133,10 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 			result = GeometryType.fromGMLTypeName(localPart);
 		}
 		catch (Exception e) {
-			LOG.debug("Unmappable geometry type: " + gmlGeometryName.toString()
-					+ " (currently not supported by geometry model)");
+			LOG.debug("Unmappable geometry type: {} (currently not supported by geometry model)",
+					gmlGeometryName.toString());
 		}
-		LOG.trace("Mapping '" + gmlGeometryName + "' -> " + result);
+		LOG.trace("Mapping '{}' -> {}", gmlGeometryName, result);
 		return result;
 	}
 
@@ -1186,7 +1185,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 			return null;
 		}
 		final QName ptName = new QName(elDecl.getNamespace(), elDecl.getName());
-		LOG.trace("Checking if element declaration '" + ptName + "' defines a complex-valued GML property type.");
+		LOG.trace("Checking if element declaration '{}' defines a complex-valued GML property type.", ptName);
 		final XSComplexTypeDefinition typeDef = (XSComplexTypeDefinition) elDecl.getTypeDefinition();
 		final boolean allowsXlink = allowsXLink(typeDef);
 		final XSElementDeclaration valueElementDeclFromAnnotations = determineAnnotationDefinedValueElement(elDecl);
@@ -1239,7 +1238,7 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 					childDeclMap.put(name, decl);
 					for (XSElementDeclaration substitution : getSubstitutions(decl, null, true, true)) {
 						name = new QName(substitution.getNamespace(), substitution.getName());
-						LOG.debug("Adding: " + name);
+						LOG.debug("Adding: {}", name);
 						childDeclMap.put(name, substitution);
 					}
 				}
@@ -1365,8 +1364,8 @@ public class GMLSchemaInfoSet extends XMLSchemaInfoSet {
 								LOG.trace("Found sequence / choice.");
 								XSObjectList sequence = modelGroup.getParticles();
 								if (sequence.getLength() != 1) {
-									LOG.trace("Length = '" + sequence.getLength()
-											+ "' -> cannot be a property declaration.");
+									LOG.trace("Length = '{}' -> cannot be a property declaration.",
+											sequence.getLength());
 									return null;
 								}
 								XSParticle particle2 = (XSParticle) sequence.item(0);

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GmlObjectTypeFactory.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/schema/GmlObjectTypeFactory.java
@@ -64,7 +64,7 @@ class GmlObjectTypeFactory {
 	GMLObjectType build(final XSElementDeclaration elDecl) {
 		final QName elName = createQName(elDecl.getNamespace(), elDecl.getName());
 		final GMLObjectCategory category = gmlSchema.getObjectCategory(elName);
-		LOG.debug("Building object type declaration: '" + elName + "'");
+		LOG.debug("Building object type declaration: '{}'", elName);
 		if (elDecl.getTypeDefinition().getType() == SIMPLE_TYPE) {
 			final String msg = "Schema type of element '" + elName
 					+ "' is simple, but object elements must have a complex type.";
@@ -165,7 +165,7 @@ class GmlObjectTypeFactory {
 	private PropertyType buildPropertyType(XSElementDeclaration elementDecl, int minOccurs, int maxOccurs) {
 		PropertyType pt = null;
 		final QName ptName = createQName(elementDecl.getNamespace(), elementDecl.getName());
-		LOG.trace("*** Found property declaration: '" + elementDecl.getName() + "'.");
+		LOG.trace("*** Found property declaration: '{}'.", elementDecl.getName());
 		// parse substitutable property declarations (e.g. genericProperty in CityGML)
 		List<PropertyType> ptSubstitutions = new ArrayList<PropertyType>();
 		XSObjectList list = gmlSchema.getXSModel().getSubstitutionGroup(elementDecl);
@@ -202,7 +202,7 @@ class GmlObjectTypeFactory {
 			int minOccurs, int maxOccurs, List<PropertyType> ptSubstitutions) {
 		PropertyType pt = null;
 		QName ptName = createQName(elementDecl.getNamespace(), elementDecl.getName());
-		LOG.trace("- Property definition '" + ptName + "' uses a complex type for content definition.");
+		LOG.trace("- Property definition '{}' uses a complex type for content definition.", ptName);
 		// check for well known GML property declarations first
 		if (typeDef.getName() != null) {
 			QName typeName = createQName(typeDef.getNamespace(), typeDef.getName());
@@ -282,7 +282,7 @@ class GmlObjectTypeFactory {
 
 	private BaseType getPrimitiveType(final XSSimpleType typeDef) {
 		final BaseType pt = BaseType.valueOf(typeDef);
-		LOG.trace("Mapped '" + typeDef.getName() + "' (base type: '" + typeDef.getBaseType() + "') -> '" + pt + "'");
+		LOG.trace("Mapped '{}' (base type: '{}') -> '{}'", typeDef.getName(), typeDef.getBaseType(), pt);
 		return pt;
 	}
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/filter/xml/Filter110XMLDecoderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/filter/xml/Filter110XMLDecoderTest.java
@@ -159,9 +159,9 @@ public class Filter110XMLDecoderTest {
 			.createXMLStreamReader(url.toString(), url.openStream());
 		xmlStream.nextTag();
 		Location loc = xmlStream.getLocation();
-		LOG.debug("" + loc.getLineNumber());
-		LOG.debug("" + loc.getSystemId());
-		LOG.debug("" + loc.getColumnNumber());
+		LOG.debug("{}", loc.getLineNumber());
+		LOG.debug("{}", loc.getSystemId());
+		LOG.debug("{}", loc.getColumnNumber());
 		return Filter110XMLDecoder.parse(xmlStream);
 	}
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureReaderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureReaderTest.java
@@ -270,9 +270,9 @@ public class GMLFeatureReaderTest {
 
 		// work with the fc
 		for (Feature feature : fc) {
-			LOG.debug("member fid: " + feature.getId());
+			LOG.debug("member fid: {}", feature.getId());
 		}
-		LOG.debug("member features: " + fc.size());
+		LOG.debug("member features: {}", fc.size());
 	}
 
 	// @Test

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/geometry/GML3GeometryReaderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/geometry/GML3GeometryReaderTest.java
@@ -858,8 +858,8 @@ public class GML3GeometryReaderTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		for (Point p : geom.getControlPoints()) {
-			LOG.debug(p.getId() + ", " + p.getClass());
-			LOG.debug("get0: " + p.get0());
+			LOG.debug("{}, {}", p.getId(), p.getClass());
+			LOG.debug("get0: {}", p.get0());
 		}
 	}
 
@@ -878,8 +878,8 @@ public class GML3GeometryReaderTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 		LineString ls = (LineString) geom.get(2);
 		for (Point p : ls.getControlPoints()) {
-			LOG.debug(p.getId() + ", " + p.getClass());
-			LOG.debug("get0: " + p.get0());
+			LOG.debug("{}, {}", p.getId(), p.getClass());
+			LOG.debug("get0: {}", p.get0());
 		}
 	}
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/geometry/GML3GeometryWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/geometry/GML3GeometryWriterTest.java
@@ -213,7 +213,7 @@ public class GML3GeometryWriterTest {
 		for (String patchSource : patchSources) {
 			URL docURL = GML3GeometryWriterTest.class.getResource(PATCH_DIR + patchSource);
 			if (docURL == null)
-				LOG.debug("patch dir: " + GML3GeometryWriterTest.class.getResource(PATCH_DIR + patchSource));
+				LOG.debug("patch dir: {}", GML3GeometryWriterTest.class.getResource(PATCH_DIR + patchSource));
 			GMLStreamReader parser = getGML31StreamReader(docURL);
 			XMLStreamReaderWrapper xmlReader = new XMLStreamReaderWrapper(parser.getXMLReader(), docURL.toString());
 			SurfacePatch surfPatch = ((GML3GeometryReader) parser.getGeometryReader()).getSurfacePatchReader()

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/schema/GMLAppSchemaWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/schema/GMLAppSchemaWriterTest.java
@@ -82,20 +82,20 @@ public class GMLAppSchemaWriterTest {
 		List<XSElementDeclaration> featureElementDecls = analyzer
 			.getFeatureElementDeclarations("http://www.deegree.org/app", false);
 		for (XSElementDeclaration featureElementDecl : featureElementDecls) {
-			LOG.debug("- Feature type: " + featureElementDecl.getName());
+			LOG.debug("- Feature type: {}", featureElementDecl.getName());
 		}
 		List<XSElementDeclaration> featureCollectionElementDecls = analyzer
 			.getFeatureCollectionElementDeclarations(null, false);
 		for (XSElementDeclaration featureCollectionElementDecl : featureCollectionElementDecls) {
-			LOG.debug("- Feature collection type: " + featureCollectionElementDecl.getName());
+			LOG.debug("- Feature collection type: {}", featureCollectionElementDecl.getName());
 		}
 		List<XSElementDeclaration> geometryElementDecls = analyzer.getGeometryElementDeclarations(null, true);
 		for (XSElementDeclaration geometryElementDecl : geometryElementDecls) {
-			LOG.debug("- Geometry type: " + geometryElementDecl.getName());
+			LOG.debug("- Geometry type: {}", geometryElementDecl.getName());
 		}
 		List<XSTypeDefinition> featureTypeDefinitions = analyzer.getFeatureTypeDefinitions(null, true);
 		for (XSTypeDefinition xsTypeDefinition : featureTypeDefinitions) {
-			LOG.debug("- Feature type definition: " + xsTypeDefinition.getName());
+			LOG.debug("- Feature type definition: {}", xsTypeDefinition.getName());
 		}
 	}
 
@@ -120,7 +120,7 @@ public class GMLAppSchemaWriterTest {
 		for (String string : substitutionts) {
 			LOG.debug(string);
 		}
-		LOG.debug("" + substitutionts.size());
+		LOG.debug("{}", substitutionts.size());
 	}
 
 	@Test
@@ -133,7 +133,7 @@ public class GMLAppSchemaWriterTest {
 		for (String string : substitutionts) {
 			LOG.debug(string);
 		}
-		LOG.debug("" + substitutionts.size());
+		LOG.debug("{}", substitutionts.size());
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class GMLAppSchemaWriterTest {
 		for (String string : substitutionts) {
 			LOG.debug(string);
 		}
-		LOG.debug("" + substitutionts.size());
+		LOG.debug("{}", substitutionts.size());
 	}
 
 	@Test
@@ -159,7 +159,7 @@ public class GMLAppSchemaWriterTest {
 		for (String string : substitutionts) {
 			LOG.debug(string);
 		}
-		LOG.debug("" + substitutionts.size());
+		LOG.debug("{}", substitutionts.size());
 	}
 
 	@Test
@@ -283,7 +283,7 @@ public class GMLAppSchemaWriterTest {
 		for (XSElementDeclaration elementDecl : elementDecls) {
 			LOG.debug(elementDecl.getName());
 		}
-		LOG.debug("" + elementDecls.size());
+		LOG.debug("{}", elementDecls.size());
 	}
 
 	private Set<String> getConcreteSubstitutions(String localName, GMLSchemaInfoSet analyzer) {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/config/DeegreeWorkspace.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/config/DeegreeWorkspace.java
@@ -361,14 +361,14 @@ public class DeegreeWorkspace {
 	 */
 	public static String getWorkspaceRoot() {
 		String workspaceRoot = System.getProperty(VAR_WORKSPACE_ROOT);
-		LOG.trace(VAR_WORKSPACE_ROOT + " retrieved from system property: " + workspaceRoot);
+		LOG.trace("{} retrieved from system property: {}", VAR_WORKSPACE_ROOT, workspaceRoot);
 		if (workspaceRoot == null || workspaceRoot.isEmpty()) {
 			workspaceRoot = System.getenv(VAR_WORKSPACE_ROOT);
-			LOG.trace(VAR_WORKSPACE_ROOT + " retrieved from environment variable:" + workspaceRoot);
+			LOG.trace("{} retrieved from environment variable:{}", VAR_WORKSPACE_ROOT, workspaceRoot);
 		}
 		if (workspaceRoot == null || workspaceRoot.isEmpty()) {
 			workspaceRoot = System.getProperty("user.home") + separator + ".deegree";
-			LOG.trace("Using default workspace root directory: " + workspaceRoot);
+			LOG.trace("Using default workspace root directory: {}", workspaceRoot);
 		}
 		return workspaceRoot;
 	}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/dataaccess/CSVReader.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/dataaccess/CSVReader.java
@@ -110,7 +110,7 @@ public class CSVReader extends LineNumberReader {
 		}
 		List<String> result = new LinkedList<String>();
 		if (LOG.isTraceEnabled()) {
-			LOG.trace("Trying to parse (line: " + getLineNumber() + "): " + line);
+			LOG.trace("Trying to parse (line: {}): {}", getLineNumber(), line);
 		}
 		if (!"".equals(line)) {
 			String[] quoted = splitQuoted(line);
@@ -119,7 +119,7 @@ public class CSVReader extends LineNumberReader {
 				for (String d : delimited) {
 					if (!"".equals(d)) {
 						if (LOG.isTraceEnabled()) {
-							LOG.trace("Adding parsed value: " + d);
+							LOG.trace("Adding parsed value: {}", d);
 						}
 						result.add(d);
 					}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/index/QTree.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/index/QTree.java
@@ -460,8 +460,7 @@ public class QTree<T> extends SpatialIndex<T> implements Serializable {
 			}
 		}
 		if (leafObjects != null && leafObjects.size() < objectsInLeaf) {
-			LOG.error("leaf counter (" + objectsInLeaf + ") is larger then actual objects in leaf: "
-					+ leafObjects.size());
+			LOG.error("leaf counter ({}) is larger then actual objects in leaf: {}", objectsInLeaf, leafObjects.size());
 		}
 
 	}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/InsertRow.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/InsertRow.java
@@ -118,7 +118,7 @@ public class InsertRow extends TransactionRow {
 	public Map<SQLIdentifier, Object> performInsert(Connection conn) throws SQLException {
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Inserting: " + this);
+			LOG.debug("Inserting: {}", this);
 		}
 
 		String sql = getSql();
@@ -134,8 +134,7 @@ public class InsertRow extends TransactionRow {
 			int columnId = 1;
 			for (Entry<SQLIdentifier, Object> entry : columnToObject.entrySet()) {
 				if (entry.getValue() != null) {
-					LOG.debug("- Argument " + entry.getKey() + " = " + entry.getValue() + " ("
-							+ entry.getValue().getClass() + ")");
+					LOG.debug("- Argument {} = {} ({})", entry.getKey(), entry.getValue(), entry.getValue().getClass());
 					if (entry.getValue() instanceof ParticleConversion<?>) {
 						ParticleConversion<?> conversion = (ParticleConversion<?>) entry.getValue();
 						conversion.setParticle(stmt, columnId++);
@@ -145,7 +144,7 @@ public class InsertRow extends TransactionRow {
 					}
 				}
 				else {
-					LOG.debug("- Argument " + entry.getKey() + " = NULL");
+					LOG.debug("- Argument {} = NULL", entry.getKey());
 					stmt.setObject(columnId++, null);
 				}
 			}
@@ -158,7 +157,7 @@ public class InsertRow extends TransactionRow {
 					if (rs.next()) {
 						Object key = rs.getObject(1);
 						columnToAutoKey.put(autogenColumn, key);
-						LOG.debug("Retrieved auto generated key: " + autogenColumn + "=" + key);
+						LOG.debug("Retrieved auto generated key: {}={}", autogenColumn, key);
 					}
 				}
 				finally {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/UpdateRow.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/jdbc/UpdateRow.java
@@ -99,7 +99,7 @@ public class UpdateRow extends TransactionRow {
 
 	public void performUpdate(Connection conn) throws SQLException {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Updating: " + this);
+			LOG.debug("Updating: {}", this);
 		}
 
 		String sql = getSql();
@@ -109,8 +109,7 @@ public class UpdateRow extends TransactionRow {
 		int columnId = 1;
 		for (Entry<SQLIdentifier, Object> entry : columnToObject.entrySet()) {
 			if (entry.getValue() != null) {
-				LOG.debug("- Argument " + entry.getKey() + " = " + entry.getValue() + " (" + entry.getValue().getClass()
-						+ ")");
+				LOG.debug("- Argument {} = {} ({})", entry.getKey(), entry.getValue(), entry.getValue().getClass());
 				if (entry.getValue() instanceof ParticleConversion<?>) {
 					ParticleConversion<?> conversion = (ParticleConversion<?>) entry.getValue();
 					conversion.setParticle(stmt, columnId++);
@@ -120,7 +119,7 @@ public class UpdateRow extends TransactionRow {
 				}
 			}
 			else {
-				LOG.debug("- Argument " + entry.getKey() + " = NULL");
+				LOG.debug("- Argument {} = NULL", entry.getKey());
 				stmt.setObject(columnId++, null);
 			}
 		}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/mail/MailHelper.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/mail/MailHelper.java
@@ -145,8 +145,8 @@ public final class MailHelper {
 		}
 		try {
 			int k = eMess.getMessageBody().length() > 60 ? 60 : eMess.getMessageBody().length() - 1;
-			LOG.debug("Sending message, From: " + eMess.getSender() + "\nTo: " + eMess.getReceiver() + "\nSubject: "
-					+ eMess.getSubject() + "\nContents: " + eMess.getMessageBody().substring(0, k) + "...");
+			LOG.debug("Sending message, From: {}\nTo: {}\nSubject: {}\nContents: {}...", eMess.getSender(),
+					eMess.getReceiver(), eMess.getSubject(), eMess.getMessageBody().substring(0, k));
 			// construct the message
 			MimeMessage msg = new MimeMessage(session);
 			msg.setFrom(new InternetAddress(eMess.getSender()));
@@ -180,7 +180,7 @@ public final class MailHelper {
 			msg.setContent(mp);
 			// send the mail off
 			Transport.send(msg);
-			LOG.debug("Mail sent successfully! Header=" + eMess.getHeader());
+			LOG.debug("Mail sent successfully! Header={}", eMess.getHeader());
 		}
 		catch (Exception e) {
 			LOG.error(e.getMessage(), e);
@@ -204,8 +204,8 @@ public final class MailHelper {
 		}
 		try {
 			int k = eMess.getMessageBody().length() > 60 ? 60 : eMess.getMessageBody().length() - 1;
-			LOG.debug("Sending message, From: " + eMess.getSender() + "\nTo: " + eMess.getReceiver() + "\nSubject: "
-					+ eMess.getSubject() + "\nContents: " + eMess.getMessageBody().substring(0, k) + "...");
+			LOG.debug("Sending message, From: {}\nTo: {}\nSubject: {}\nContents: {}...", eMess.getSender(),
+					eMess.getReceiver(), eMess.getSubject(), eMess.getMessageBody().substring(0, k));
 			// construct the message
 			MimeMessage msg = new MimeMessage(session);
 			msg.setFrom(new InternetAddress(eMess.getSender()));
@@ -239,7 +239,7 @@ public final class MailHelper {
 			msg.setContent(mp);
 			// send the mail off
 			Transport.send(msg);
-			LOG.debug("Mail sent successfully! Header=" + eMess.getHeader());
+			LOG.debug("Mail sent successfully! Header={}", eMess.getHeader());
 		}
 		catch (Exception e) {
 			LOG.error(e.getMessage(), e);

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/primitive/XMLValueMangler.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/primitive/XMLValueMangler.java
@@ -118,7 +118,7 @@ public class XMLValueMangler {
 				break;
 			}
 			default: {
-				LOG.warn("Unhandled primitive type " + pt + " -- treating as string value.");
+				LOG.warn("Unhandled primitive type {} -- treating as string value.", pt);
 			}
 		}
 		return value;
@@ -134,7 +134,7 @@ public class XMLValueMangler {
 							xml = "" + formatDate((Temporal) o);
 						}
 						else {
-							LOG.warn("Unhandled Date class " + o.getClass() + " -- converting via #toString()");
+							LOG.warn("Unhandled Date class {} -- converting via #toString()", o.getClass());
 							xml = "" + o;
 						}
 						break;
@@ -143,7 +143,7 @@ public class XMLValueMangler {
 							xml = "" + formatDateTime((Temporal) o);
 						}
 						else {
-							LOG.warn("Unhandled Date class " + o.getClass() + " -- converting via #toString()");
+							LOG.warn("Unhandled Date class {} -- converting via #toString()", o.getClass());
 							xml = "" + o;
 						}
 						break;
@@ -152,7 +152,7 @@ public class XMLValueMangler {
 							xml = "" + formatTime((Temporal) o);
 						}
 						else {
-							LOG.warn("Unhandled Date class " + o.getClass() + " -- converting via #toString()");
+							LOG.warn("Unhandled Date class {} -- converting via #toString()", o.getClass());
 							xml = "" + o;
 						}
 						break;
@@ -178,7 +178,7 @@ public class XMLValueMangler {
 						xml = "" + o;
 						break;
 					default: {
-						LOG.warn("Unhandled primitive type " + pt + " -- treating as string value.");
+						LOG.warn("Unhandled primitive type {} -- treating as string value.", pt);
 						xml = "" + o;
 					}
 				}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/DeegreeAALogoUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/DeegreeAALogoUtils.java
@@ -69,7 +69,7 @@ public class DeegreeAALogoUtils {
 			}
 		}
 		catch (Exception e) {
-			LOG.error("Could not read deegree logo '" + DEEGREE_AA_LOGO_FILE + "'.");
+			LOG.error("Could not read deegree logo '{}'.", DEEGREE_AA_LOGO_FILE);
 		}
 	}
 

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/EncodingGuesser.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/EncodingGuesser.java
@@ -140,8 +140,8 @@ public class EncodingGuesser {
 					}
 				}
 
-				LOG.debug("For encoding '" + charset.displayName() + "' we have " + sum + " matches, and " + otherSum
-						+ " mismatches.");
+				LOG.debug("For encoding '{}' we have {} matches, and {} mismatches.", charset.displayName(), sum,
+						otherSum);
 
 				if (otherSum == 0) {
 					return charset;
@@ -157,10 +157,10 @@ public class EncodingGuesser {
 			Entry<Double, Charset> first = ratios.firstEntry();
 			Double key = first.getKey();
 			Charset val = first.getValue();
-			LOG.debug("Guessing encoding '" + val.displayName() + "' with a mismatch ratio of " + key);
+			LOG.debug("Guessing encoding '{}' with a mismatch ratio of {}", val.displayName(), key);
 			LOG.debug("Map was:");
 			for (Integer i : map.keySet()) {
-				LOG.debug(i + " (" + new String(new byte[] { i.byteValue() }, "iso-8859-1") + "): " + map.get(i));
+				LOG.debug("{} ({}): {}", i, new String(new byte[] { i.byteValue() }, "iso-8859-1"), map.get(i));
 			}
 
 			return val;
@@ -168,7 +168,7 @@ public class EncodingGuesser {
 
 		LOG.debug("Unknown encoding:");
 		for (Integer i : map.keySet()) {
-			LOG.debug(i + " (" + new String(new byte[] { i.byteValue() }, "iso-8859-1") + "): " + map.get(i));
+			LOG.debug("{} ({}): {}", i, new String(new byte[] { i.byteValue() }, "iso-8859-1"), map.get(i));
 		}
 
 		return null;

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/FileUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/FileUtils.java
@@ -237,7 +237,7 @@ public class FileUtils {
 		if (charset == null) {
 			charset = DEFAULT_CHARSET;
 		}
-		LOG.debug("Using system charset: " + charset);
+		LOG.debug("Using system charset: {}", charset);
 		return charset;
 	}
 

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/JDBCUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/JDBCUtils.java
@@ -121,7 +121,7 @@ public final class JDBCUtils {
 			}
 			catch (SQLException e) {
 				if (log != null) {
-					log.error("Unable to close ResultSet: " + e.getMessage());
+					log.error("Unable to close ResultSet: {}", e.getMessage());
 				}
 			}
 		}
@@ -131,7 +131,7 @@ public final class JDBCUtils {
 			}
 			catch (SQLException e) {
 				if (log != null) {
-					log.error("Unable to close Statement: " + e.getMessage());
+					log.error("Unable to close Statement: {}", e.getMessage());
 				}
 			}
 		}
@@ -141,7 +141,7 @@ public final class JDBCUtils {
 			}
 			catch (SQLException e) {
 				if (log != null) {
-					log.error("Unable to close Connection: " + e.getMessage());
+					log.error("Unable to close Connection: {}", e.getMessage());
 				}
 			}
 		}
@@ -170,11 +170,11 @@ public final class JDBCUtils {
 		String version = determinePostGISVersion(conn, log);
 		if (version.startsWith("0.") || version.startsWith("1.0") || version.startsWith("1.1")
 				|| version.startsWith("1.2")) {
-			log.debug("PostGIS version is " + version + " -- using legacy (pre-SQL-MM) predicates.");
+			log.debug("PostGIS version is {} -- using legacy (pre-SQL-MM) predicates.", version);
 			useLegacyPredicates = true;
 		}
 		else {
-			log.debug("PostGIS version is " + version + " -- using modern (SQL-MM) predicates.");
+			log.debug("PostGIS version is {} -- using modern (SQL-MM) predicates.", version);
 		}
 		return useLegacyPredicates;
 	}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/TempFileManager.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/TempFileManager.java
@@ -87,9 +87,9 @@ public class TempFileManager {
 			}
 		}
 		catch (UnsupportedEncodingException e) {
-			LOG.error("Internal error: Cannot encode '" + contextId + "' for creating unique tempdir.");
+			LOG.error("Internal error: Cannot encode '{}' for creating unique tempdir.", contextId);
 		}
-		LOG.info("Using '" + baseDir + "' for storing temporary files.");
+		LOG.info("Using '{}' for storing temporary files.", baseDir);
 	}
 
 	/**

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/fam/FileAlterationMonitor.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/fam/FileAlterationMonitor.java
@@ -183,7 +183,7 @@ public class FileAlterationMonitor {
 
 		@SuppressWarnings("synthetic-access")
 		private void fileChanged(File file) {
-			LOG.debug("Detected file change: '" + file + "'.");
+			LOG.debug("Detected file change: '{}'.", file);
 			for (FileAlterationListener listener : listeners) {
 				listener.fileChanged(file);
 			}
@@ -191,7 +191,7 @@ public class FileAlterationMonitor {
 
 		@SuppressWarnings("synthetic-access")
 		private void newFile(File file) {
-			LOG.debug("Detected new file: '" + file + "'.");
+			LOG.debug("Detected new file: '{}'.", file);
 			for (FileAlterationListener listener : listeners) {
 				listener.newFile(file);
 			}
@@ -199,7 +199,7 @@ public class FileAlterationMonitor {
 
 		@SuppressWarnings("synthetic-access")
 		private void fileDeleted(File file) {
-			LOG.debug("Detected file deletion: '" + file + "'.");
+			LOG.debug("Detected file deletion: '{}'.", file);
 			for (FileAlterationListener listener : listeners) {
 				listener.fileDeleted(file);
 			}
@@ -221,7 +221,7 @@ public class FileAlterationMonitor {
 		@SuppressWarnings("synthetic-access")
 		private void scanDir(File dir, boolean recurse, FileFilter filter, Map<File, Long> foundFiles,
 				Set<File> scannedDirs) throws IOException {
-			LOG.debug("Scanning directory: '" + dir + "'");
+			LOG.debug("Scanning directory: '{}'", dir);
 			File[] files = dir.listFiles(filter);
 			for (File file : files) {
 				if (filter == null || filter.accept(file)) {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/io/StreamBufferStore.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/io/StreamBufferStore.java
@@ -198,14 +198,14 @@ public class StreamBufferStore extends OutputStream {
 	}
 
 	private void switchToFile() throws IOException {
-		LOG.debug("Memory limit of " + limit + " bytes reached. Switching to file-based storage.");
+		LOG.debug("Memory limit of {} bytes reached. Switching to file-based storage.", limit);
 		if (targetFile == null) {
 			tmpFile = File.createTempFile("store", ".tmp");
 		}
 		else {
 			tmpFile = targetFile;
 		}
-		LOG.debug("Using file: " + tmpFile);
+		LOG.debug("Using file: {}", tmpFile);
 		OutputStream fileOs = new BufferedOutputStream(new FileOutputStream(tmpFile));
 		((ByteArrayOutputStream) os).writeTo(fileOs);
 		os = fileOs;

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/nio/BufferSerializer.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/nio/BufferSerializer.java
@@ -105,7 +105,7 @@ public class BufferSerializer {
 				writeBuffer((CharBuffer) buffer, out);
 			}
 			else {
-				LOG.warn("Not able to serialize Buffers of given type: " + buffer.getClass().getCanonicalName());
+				LOG.warn("Not able to serialize Buffers of given type: {}", buffer.getClass().getCanonicalName());
 			}
 		}
 		catch (IOException ie) {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/nio/DirectByteBufferPool.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/nio/DirectByteBufferPool.java
@@ -213,7 +213,7 @@ public class DirectByteBufferPool {
 			buffer = new PooledByteBuffer(capacity, this, id++);
 			totalCapacity += capacity;
 			allBuffers.add(buffer);
-			LOG.debug("New buffer: " + buffer);
+			LOG.debug("New buffer: {}", buffer);
 		}
 		return buffer;
 	}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/XMLAdapter.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/XMLAdapter.java
@@ -532,7 +532,7 @@ public class XMLAdapter {
 	 */
 	public URL resolve(String url) throws MalformedURLException {
 
-		LOG.debug("Resolving URL '" + url + "' against SystemID '" + systemId + "'.");
+		LOG.debug("Resolving URL '{}' against SystemID '{}'.", url, systemId);
 
 		// check if url is an absolute path
 		File file = new File(url);
@@ -542,7 +542,7 @@ public class XMLAdapter {
 
 		// TODO this is not really nice, also think about handling url specs here
 		URL resolvedURL = new URL(new URL(systemId), url.replace(" ", "%20"));
-		LOG.debug("-> resolvedURL: '" + resolvedURL + "'");
+		LOG.debug("-> resolvedURL: '{}'", resolvedURL);
 		return resolvedURL;
 	}
 

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/jaxb/JAXBUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/jaxb/JAXBUtils.java
@@ -70,11 +70,11 @@ public class JAXBUtils {
 			o = u.unmarshal(input);
 		}
 		catch (JAXBException e) {
-			LOG.error("Error in configuration file: " + e.getLocalizedMessage());
+			LOG.error("Error in configuration file: {}", e.getLocalizedMessage());
 			// whyever they use the linked exception here...
 			// http://www.jaxb.com/how/to/hide/important/information/from/the/user/of/the/api/unknown_xml_format.xml
 			if (e.getLinkedException() != null) {
-				LOG.error("Error: " + e.getLinkedException().getLocalizedMessage());
+				LOG.error("Error: {}", e.getLinkedException().getLocalizedMessage());
 			}
 			LOG.error("Hint: Try validating the file with an XML-schema aware editor.");
 			throw e;
@@ -166,8 +166,7 @@ public class JAXBUtils {
 				result = sf.newSchema(list.toArray(new Source[list.size()]));
 			}
 			catch (Exception e) {
-				LOG.error(
-						"No schema could be loaded from file: " + schemaFile + " because: " + e.getLocalizedMessage());
+				LOG.error("No schema could be loaded from file: {} because: {}", schemaFile, e.getLocalizedMessage());
 				LOG.trace("Stack trace:", e);
 			}
 		}

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/GrammarPoolManager.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/GrammarPoolManager.java
@@ -113,7 +113,7 @@ class GrammarPoolManager {
 		for (String uri : sortedUris) {
 			id.append(":").append(uri);
 		}
-		LOG.debug("Looking up grammar pool for combined URI id: '" + id + "'.");
+		LOG.debug("Looking up grammar pool for combined URI id: '{}'.", id);
 
 		GrammarPool pool = idToPool.get(id.toString());
 		if (pool == null) {
@@ -133,7 +133,7 @@ class GrammarPoolManager {
 					s += ", ";
 				}
 			}
-			LOG.debug("Creating grammar pool for schemas: {" + s + "}.");
+			LOG.debug("Creating grammar pool for schemas: {{}}.", s);
 		}
 
 		XMLEntityResolver resolver = new RedirectingEntityResolver();

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
@@ -65,8 +65,9 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 	static {
 		baseURL = RedirectingEntityResolver.class.getResource(ROOT);
 		if (baseURL == null) {
-			LOG.warn("'" + ROOT
-					+ "' could not be found on the classpath. Schema references to 'http://schemas.opengis.net' will not be redirected, but fetched from their original location.  ");
+			LOG.warn(
+					"'{}' could not be found on the classpath. Schema references to 'http://schemas.opengis.net' will not be redirected, but fetched from their original location.  ",
+					ROOT);
 		}
 	}
 
@@ -81,7 +82,7 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 			String localPart = systemId.substring(SCHEMAS_OPENGIS_NET_URL.length());
 			URL u = RedirectingEntityResolver.class.getResource(ROOT + localPart);
 			if (u != null) {
-				LOG.debug("Local hit: " + systemId);
+				LOG.debug("Local hit: {}", systemId);
 				return u.toString();
 			}
 		}
@@ -104,7 +105,7 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 
 		String systemId = identifier.getExpandedSystemId();
 		String redirectedSystemId = systemId != null ? redirect(systemId) : null;
-		LOG.debug("'" + systemId + "' -> '" + redirectedSystemId + "'");
+		LOG.debug("'{}' -> '{}'", systemId, redirectedSystemId);
 		return new XMLInputSource(null, redirectedSystemId, null);
 	}
 

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/SchemaValidator.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/SchemaValidator.java
@@ -246,21 +246,21 @@ public class SchemaValidator {
 			@SuppressWarnings("synthetic-access")
 			@Override
 			public void error(String domain, String key, XMLParseException e) throws XNIException {
-				LOG.debug("Encountered error: " + toString(e));
+				LOG.debug("Encountered error: {}", toString(e));
 				errors.add("Error: " + toString(e));
 			}
 
 			@SuppressWarnings("synthetic-access")
 			@Override
 			public void fatalError(String domain, String key, XMLParseException e) throws XNIException {
-				LOG.debug("Encountered fatal error: " + toString(e));
+				LOG.debug("Encountered fatal error: {}", toString(e));
 				errors.add("Fatal error: " + toString(e));
 			}
 
 			@SuppressWarnings("synthetic-access")
 			@Override
 			public void warning(String domain, String key, XMLParseException e) throws XNIException {
-				LOG.debug("Encountered warning: " + toString(e));
+				LOG.debug("Encountered warning: {}", toString(e));
 				errors.add("Warning: " + toString(e));
 			}
 

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XMLSchemaInfoSet.java
@@ -213,7 +213,7 @@ public class XMLSchemaInfoSet {
 				for (String componentLocation : getComponentLocations(ns)) {
 					InputStream is = null;
 					try {
-						LOG.debug("Scanning schema component '" + componentLocation + "'");
+						LOG.debug("Scanning schema component '{}'", componentLocation);
 						is = new URL(componentLocation).openStream();
 						XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader(is);
 						while (xmlStream.next() != END_DOCUMENT) {
@@ -224,8 +224,8 @@ public class XMLSchemaInfoSet {
 										String nsUri = xmlStream.getNamespaceURI(i);
 										String oldPrefix = nsToPrefix.get(nsUri);
 										if (oldPrefix != null && !oldPrefix.equals(prefix)) {
-											LOG.debug("Multiple prefices for namespace '" + nsUri + "': " + prefix
-													+ " / " + oldPrefix);
+											LOG.debug("Multiple prefices for namespace '{}': {} / {}", nsUri, prefix,
+													oldPrefix);
 										}
 										else {
 											nsToPrefix.put(nsUri, prefix);
@@ -236,8 +236,8 @@ public class XMLSchemaInfoSet {
 						}
 					}
 					catch (Exception e) {
-						LOG.error("Error determining namespaces from schema component '" + componentLocation + "': "
-								+ e.getMessage());
+						LOG.error("Error determining namespaces from schema component '{}': {}", componentLocation,
+								e.getMessage());
 					}
 					finally {
 						if (is != null) {

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/XMLStreamUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/stax/XMLStreamUtils.java
@@ -158,7 +158,7 @@ public class XMLStreamUtils {
 			return new URL(url);
 		}
 
-		LOG.debug("Resolving URL '" + url + "' against SystemID '" + systemId + "'.");
+		LOG.debug("Resolving URL '{}' against SystemID '{}'.", url, systemId);
 
 		// check if url is an absolute path
 		File file = new File(url);
@@ -169,7 +169,7 @@ public class XMLStreamUtils {
 		try {
 			URL sysIdUrl = new URL(systemId);
 			URL resolvedURL = new URL(sysIdUrl, url);
-			LOG.debug("-> resolvedURL: '" + resolvedURL + "'");
+			LOG.debug("-> resolvedURL: '{}'", resolvedURL);
 			return resolvedURL;
 		}
 		catch (MalformedURLException e) {
@@ -179,7 +179,7 @@ public class XMLStreamUtils {
 		file = new File(systemId);
 
 		URL resolvedURL = new URL(file.toURI().toURL(), url);
-		LOG.debug("-> resolvedURL: '" + resolvedURL + "'");
+		LOG.debug("-> resolvedURL: '{}'", resolvedURL);
 		return resolvedURL;
 	}
 
@@ -650,8 +650,8 @@ public class XMLStreamUtils {
 					}
 				}
 				catch (NumberFormatException nfe) {
-					LOG.debug(reader.getLocation() + ") Value " + s + " in element: " + elementName
-							+ " was not a parsable double, returning double value: " + defaultValue);
+					LOG.debug("{}) Value {} in element: {} was not a parsable double, returning double value: {}",
+							reader.getLocation(), s, elementName, defaultValue);
 				}
 			}
 		}
@@ -685,8 +685,8 @@ public class XMLStreamUtils {
 					}
 				}
 				catch (NumberFormatException nfe) {
-					LOG.debug(reader.getLocation() + ") Value " + s + " in element: " + elementName
-							+ " was not a parsable integer, returning integer value: " + defaultValue);
+					LOG.debug("{}) Value {} in element: {} was not a parsable integer, returning integer value: {}",
+							reader.getLocation(), s, elementName, defaultValue);
 				}
 			}
 		}
@@ -780,7 +780,7 @@ public class XMLStreamUtils {
 			try {
 				if (LOG.isDebugEnabled()) {
 					if (reader.isStartElement() || reader.isEndElement()) {
-						LOG.debug("Skipping element: " + reader.getName());
+						LOG.debug("Skipping element: {}", reader.getName());
 					}
 				}
 				nextElement(reader);

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/xml/schema/XSModelAnalyzerTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/xml/schema/XSModelAnalyzerTest.java
@@ -98,8 +98,8 @@ public class XSModelAnalyzerTest {
 		analyzer.getXSModel();
 		XSElementDeclaration a = analyzer.getElementDecl("Philosopher", "http://www.deegree.org/app");
 		XSElementDeclaration b = analyzer.getElementDecl("FeatureCollection", "http://www.opengis.net/wfs");
-		LOG.debug("" + a.getSubstitutionGroupAffiliation());
-		LOG.debug("" + b.getSubstitutionGroupAffiliation().getSubstitutionGroupAffiliation());
+		LOG.debug("{}", a.getSubstitutionGroupAffiliation());
+		LOG.debug("{}", b.getSubstitutionGroupAffiliation().getSubstitutionGroupAffiliation());
 
 		QName abstractFeatureElementName = new QName("http://www.opengis.net/gml", "_Feature");
 		analyzer.getSubstitutions(abstractFeatureElementName, null, true, true);
@@ -117,7 +117,7 @@ public class XSModelAnalyzerTest {
 		for (XSElementDeclaration decl : geometryElements) {
 
 			XSComplexTypeDefinition typeDef = (XSComplexTypeDefinition) decl.getTypeDefinition();
-			LOG.debug("element: " + decl.getName() + ", type: " + typeDef.getName());
+			LOG.debug("element: {}, type: {}", decl.getName(), typeDef.getName());
 
 			switch (typeDef.getContentType()) {
 				case XSComplexTypeDefinition.CONTENTTYPE_ELEMENT:
@@ -150,7 +150,7 @@ public class XSModelAnalyzerTest {
 							int minOccurs2 = particle2.getMinOccurs();
 							int maxOccurs2 = particle2.getMaxOccursUnbounded() ? -1 : particle2.getMaxOccurs();
 							QName elementName = new QName(elementDecl2.getNamespace(), elementDecl2.getName());
-							LOG.debug("- property: " + elementName + ", min: " + minOccurs2 + ", max: " + maxOccurs2);
+							LOG.debug("- property: {}, min: {}, max: {}", elementName, minOccurs2, maxOccurs2);
 							break;
 						}
 						case XSConstants.WILDCARD: {
@@ -176,7 +176,7 @@ public class XSModelAnalyzerTest {
 							int minOccurs2 = particle2.getMinOccurs();
 							int maxOccurs2 = particle2.getMaxOccursUnbounded() ? -1 : particle2.getMaxOccurs();
 							QName elementName = new QName(elementDecl2.getNamespace(), elementDecl2.getName());
-							LOG.debug("- property: " + elementName + ", min: " + minOccurs2 + ", max: " + maxOccurs2);
+							LOG.debug("- property: {}, min: {}, max: {}", elementName, minOccurs2, maxOccurs2);
 							break;
 						}
 						case XSConstants.WILDCARD: {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/DefaultCoverageBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/DefaultCoverageBuilder.java
@@ -146,8 +146,9 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
 					result.add(f);
 				}
 				else {
-					LOG.info("Directory: " + f.getAbsolutePath()
-							+ " can not be added to a Multiresolution raster, because it does not denote a resolution.");
+					LOG.info(
+							"Directory: {} can not be added to a Multiresolution raster, because it does not denote a resolution.",
+							f.getAbsolutePath());
 				}
 			}
 		}
@@ -261,7 +262,7 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
 					file = file.trim();
 					final File loc = location.resolveToFile(file);
 					if (!loc.exists()) {
-						LOG.warn("Given raster file location does not exist: " + loc.getAbsolutePath());
+						LOG.warn("Given raster file location does not exist: {}", loc.getAbsolutePath());
 						return null;
 					}
 					rOptions.add(RasterIOOptions.OPT_FORMAT, file.substring(file.lastIndexOf('.') + 1));
@@ -333,8 +334,9 @@ public class DefaultCoverageBuilder implements ResourceBuilder<Coverage> {
 				result = Double.parseDouble(dirRes);
 			}
 			catch (NumberFormatException e) {
-				LOG.debug("No resolution found in raster datasource defintion, nor in the directory name: " + dirRes
-						+ " returning 0");
+				LOG.debug(
+						"No resolution found in raster datasource defintion, nor in the directory name: {} returning 0",
+						dirRes);
 				result = Double.NaN;
 			}
 		}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageBuilder.java
@@ -160,7 +160,7 @@ public class PyramidCoverageBuilder implements ResourceBuilder<Coverage> {
 					return CRSManager.lookup("EPSG:" + epsgCode);
 				}
 				catch (UnknownCRSException e) {
-					LOG.error("No coordinate system found for EPSG:" + epsgCode);
+					LOG.error("No coordinate system found for EPSG:{}", epsgCode);
 				}
 			}
 		}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/AbstractRaster.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/AbstractRaster.java
@@ -309,32 +309,32 @@ public abstract class AbstractRaster extends AbstractCoverage {
 		}
 		catch (IllegalArgumentException e1) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("(Stack) Exception occurred: " + e1.getLocalizedMessage(), e1);
+				LOG.debug("(Stack) Exception occurred: {}", e1.getLocalizedMessage(), e1);
 			}
 			else {
-				LOG.error("Exception occurred: " + e1.getLocalizedMessage());
+				LOG.error("Exception occurred: {}", e1.getLocalizedMessage());
 			}
 		}
 		catch (UnknownCRSException e1) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("(Stack) Exception occurred: " + e1.getLocalizedMessage(), e1);
+				LOG.debug("(Stack) Exception occurred: {}", e1.getLocalizedMessage(), e1);
 			}
 			else {
-				LOG.error("Exception occurred: " + e1.getLocalizedMessage());
+				LOG.error("Exception occurred: {}", e1.getLocalizedMessage());
 			}
 		}
 		catch (TransformationException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("(Stack) Exception occurred: " + e.getLocalizedMessage(), e);
+				LOG.debug("(Stack) Exception occurred: {}", e.getLocalizedMessage(), e);
 			}
 			else {
-				LOG.error("Exception occurred: " + e.getLocalizedMessage());
+				LOG.error("Exception occurred: {}", e.getLocalizedMessage());
 			}
 		}
 
 		if (rect == null) {
-			LOG.warn("Unable to determine new raster size of requested Envelope: " + spatialExtent + " at resolution: "
-					+ resolution);
+			LOG.warn("Unable to determine new raster size of requested Envelope: {} at resolution: {}", spatialExtent,
+					resolution);
 			return null;
 		}
 
@@ -346,10 +346,10 @@ public abstract class AbstractRaster extends AbstractCoverage {
 		}
 		catch (TransformationException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("(Stack) Exception occurred: " + e.getLocalizedMessage(), e);
+				LOG.debug("(Stack) Exception occurred: {}", e.getLocalizedMessage(), e);
 			}
 			else {
-				LOG.error("Exception occurred: " + e.getLocalizedMessage());
+				LOG.error("Exception occurred: {}", e.getLocalizedMessage());
 			}
 		}
 		return result;

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/RasterTransformer.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/RasterTransformer.java
@@ -202,7 +202,7 @@ public class RasterTransformer extends Transformer {
 			// the envelope from which we have data
 			Geometry dataEnvGeom = workEnv.getIntersection(dataEnvelope);
 			if (dataEnvGeom == null) {
-				LOG.debug("no intersection for " + sourceRaster + " and " + dstEnvelope);
+				LOG.debug("no intersection for {} and {}", sourceRaster, dstEnvelope);
 				// todo create subclass of TransformationException
 				throw new TransformationException("no source data found");
 

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/TiledRaster.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/TiledRaster.java
@@ -258,7 +258,7 @@ public class TiledRaster extends AbstractRaster {
 		}
 		SimpleRaster originalSimpleRaster = tiles.get(0).getAsSimpleRaster();
 		SimpleRaster result = originalSimpleRaster.createCompatibleSimpleRaster(getRasterReference(), env);
-		LOG.debug("Tiled to simple -> result(w,h): " + result.getColumns() + ", " + result.getRows());
+		LOG.debug("Tiled to simple -> result(w,h): {}, {}", result.getColumns(), result.getRows());
 
 		for (AbstractRaster r : tiles) {
 			Geometry intersec = r.getEnvelope().getIntersection(env);

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/CacheRasterReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/CacheRasterReader.java
@@ -176,7 +176,7 @@ public class CacheRasterReader extends GridFileReader {
 		super.instantiate(readValues, cacheFile);
 		if (shouldUseCachefile) {
 			try {
-				LOG.debug("Writing to file: " + cacheFile.getAbsolutePath());
+				LOG.debug("Writing to file: {}", cacheFile.getAbsolutePath());
 				this.gridWriter = new GridWriter(getTileColumns(), getTileRows(), getEnvelope(), getGeoReference(),
 						cacheFile, getRasterDataInfo());
 			}
@@ -225,7 +225,7 @@ public class CacheRasterReader extends GridFileReader {
 									sampleSize);
 						}
 						catch (IOException e) {
-							LOG.error("Could not create tile from buffer because: " + e.getLocalizedMessage(), e);
+							LOG.error("Could not create tile from buffer because: {}", e.getLocalizedMessage(), e);
 						}
 						this.inMemorySize += entry.setBuffer(entryBuffer);
 					}
@@ -372,7 +372,7 @@ public class CacheRasterReader extends GridFileReader {
 					if (metaInfo.exists()) {
 						boolean mR = metaInfo.delete();
 						if (!mR) {
-							LOG.warn("Could not delete meta info file for raster cache file: " + f.getAbsolutePath());
+							LOG.warn("Could not delete meta info file for raster cache file: {}", f.getAbsolutePath());
 						}
 					}
 				}
@@ -644,12 +644,12 @@ public class CacheRasterReader extends GridFileReader {
 									}
 									catch (IOException e) {
 										if (LOG.isDebugEnabled()) {
-											LOG.debug("(Stack) Exception occurred while writing tile to cache file: "
-													+ e.getLocalizedMessage(), e);
+											LOG.debug("(Stack) Exception occurred while writing tile to cache file: {}",
+													e.getLocalizedMessage(), e);
 										}
 										else {
-											LOG.error("Exception occurred while writing tile to cache file: "
-													+ e.getLocalizedMessage());
+											LOG.error("Exception occurred while writing tile to cache file: {}",
+													e.getLocalizedMessage());
 										}
 									}
 								}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/RasterCache.java
@@ -320,13 +320,13 @@ public class RasterCache {
 							try {
 								boolean deleted = f.delete();
 								if (!deleted) {
-									LOG.warn("Could not delete raster cache dir: " + f.getAbsolutePath()
-											+ " please delete manually.");
+									LOG.warn("Could not delete raster cache dir: {} please delete manually.",
+											f.getAbsolutePath());
 								}
 							}
 							catch (Exception e) {
-								LOG.warn("Could not delete raster cache dir: " + f.getAbsolutePath()
-										+ " please delete manually.");
+								LOG.warn("Could not delete raster cache dir: {} please delete manually.",
+										f.getAbsolutePath());
 							}
 						}
 					}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/container/GriddedBlobTileContainer.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/container/GriddedBlobTileContainer.java
@@ -160,7 +160,7 @@ public class GriddedBlobTileContainer extends GriddedTileContainer {
 			throw new IOException("Given blobfile:" + blobFile + " does not exist.");
 		}
 		long totalSize = blobFile.length();
-		LOG.debug("Real blob size: " + totalSize);
+		LOG.debug("Real blob size: {}", totalSize);
 
 		// blobReaders = new GridFileReader[1];
 		blobReader = new GridFileReader(metaInfoFile, blobFile);
@@ -202,7 +202,7 @@ public class GriddedBlobTileContainer extends GriddedTileContainer {
 			result = blobReader.getTile(columnId, rowId);
 		}
 		catch (IOException e) {
-			LOG.error("Error reading tile data from blob: " + e.getMessage(), e);
+			LOG.error("Error reading tile data from blob: {}", e.getMessage(), e);
 		}
 		return result;
 	}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/container/GriddedTileContainer.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/container/GriddedTileContainer.java
@@ -111,8 +111,8 @@ public abstract class GriddedTileContainer implements TileContainer {
 		this.tileHeight = envelopeHeight / rows;
 
 		this.rasterReference = infoFile.getGeoReference();
-		LOG.debug("envelope: " + envelope);
-		LOG.debug("raster reference: " + rasterReference);
+		LOG.debug("envelope: {}", envelope);
+		LOG.debug("raster reference: {}", rasterReference);
 		SampleResolution sr = new SampleResolution(
 				new double[] { rasterReference.getResolutionX(), rasterReference.getResolutionY() });
 		this.resolutionInfo = new ResolutionInfo(sr);
@@ -140,8 +140,8 @@ public abstract class GriddedTileContainer implements TileContainer {
 		this.tileHeight = envelopeHeight / rows;
 		this.rasterReference = RasterGeoReference.create(location, envelope, tileSamplesX * columns,
 				tileSamplesY * rows);
-		LOG.debug("envelope: " + envelope);
-		LOG.debug("raster reference: " + rasterReference);
+		LOG.debug("envelope: {}", envelope);
+		LOG.debug("raster reference: {}", rasterReference);
 	}
 
 	/**

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/container/CachedRasterDataContainer.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/container/CachedRasterDataContainer.java
@@ -110,7 +110,7 @@ public class CachedRasterDataContainer implements RasterDataContainer, RasterDat
 	public synchronized RasterData getRasterData() {
 		// synchronized to prevent multiple reader.read()-calls when
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("accessing: " + this);
+			LOG.debug("accessing: {}", this);
 		}
 		if (!cache.containsKey(identifier)) {
 			RasterData raster = reader.read();
@@ -121,13 +121,13 @@ public class CachedRasterDataContainer implements RasterDataContainer, RasterDat
 					.getTierStatistics()
 					.get("OffHeap")
 					.getOccupiedByteSize();
-				LOG.debug("cache miss: " + this + " #mem: " + occupiedByteSize);
+				LOG.debug("cache miss: {} #mem: {}", this, occupiedByteSize);
 			}
 			return raster;
 		}
 		else {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("cache hit: " + this);
+				LOG.debug("cache hit: {}", this);
 			}
 			return cache.get(identifier);
 		}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/container/LazyRasterDataContainer.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/container/LazyRasterDataContainer.java
@@ -80,7 +80,7 @@ public class LazyRasterDataContainer implements RasterDataContainer, RasterDataC
 	public synchronized RasterData getRasterData() {
 		if (!rasterLoaded) {
 			if (log.isDebugEnabled()) {
-				log.debug("reading: " + this.toString());
+				log.debug("reading: {}", this.toString());
 			}
 			raster = reader.read();
 			rasterLoaded = true;

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/container/RasterDataContainerFactory.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/container/RasterDataContainerFactory.java
@@ -121,8 +121,7 @@ public class RasterDataContainerFactory {
 				return container;
 			}
 		}
-		LOG.error("RasterDataContainer for type " + l
-				+ " not found, returning memory raster data container (the default)");
+		LOG.error("RasterDataContainer for type {} not found, returning memory raster data container (the default)", l);
 		return new MemoryRasterDataContainer();
 	}
 

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/nio/BufferAccess.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/nio/BufferAccess.java
@@ -235,7 +235,7 @@ public class BufferAccess {
 						// lineStride = pixelStride * rect.width;
 					}
 					catch (IOException e) {
-						LOG.debug("No data available: " + e.getLocalizedMessage(), e);
+						LOG.debug("No data available: {}", e.getLocalizedMessage(), e);
 						// the data is no longer available, lets just fill it with no data
 						// values
 						noData = true;

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/nio/ByteBufferRasterData.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/nio/ByteBufferRasterData.java
@@ -677,9 +677,9 @@ public abstract class ByteBufferRasterData implements RasterData {
 				result = getByteBuffer().getShort(pos);
 			}
 			catch (Exception e) {
-				LOG.debug(Thread.currentThread().getName() + "->(x,y)|band->pos: " + x + "," + y + "|" + band + "->"
-						+ pos + "\n-view: " + getView() + "\n-rdi: " + getView().dataInfo + "\n-buffer:"
-						+ getByteBuffer());
+				LOG.debug("{}->(x,y)|band->pos: {},{}|{}->{}\n-view: {}\n-rdi: {}\n-buffer:{}",
+						Thread.currentThread().getName(), x, y, band, pos, getView(), getView().dataInfo,
+						getByteBuffer());
 			}
 			return result;
 		}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/WorldFileAccess.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/WorldFileAccess.java
@@ -188,7 +188,7 @@ public class WorldFileAccess {
 		}
 
 		if (log.isDebugEnabled()) {
-			log.debug("read worldfile for " + filename);
+			log.debug("read worldfile for {}", filename);
 		}
 
 		BufferedReader br = new BufferedReader(new FileReader(worldFile));

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/grid/GridFileReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/grid/GridFileReader.java
@@ -122,7 +122,7 @@ public class GridFileReader extends GridReader {
 		// // set the tiles per blob depend on the gridFile size (if not full etc.)
 		// setTilesPerBlob( (int) ( gridFile.length() / getBytesPerTile() ) );
 		// }
-		LOG.debug("Tiles in grid blob (" + gridFile + "): " + getTilesPerBlob());
+		LOG.debug("Tiles in grid blob ({}): {}", gridFile, getTilesPerBlob());
 	}
 
 	/**
@@ -264,7 +264,7 @@ public class GridFileReader extends GridReader {
 			// rewinding is not an option, buffer.rewind();
 		}
 		catch (IOException e) {
-			LOG.error("Error reading tile data from blob: " + e.getMessage(), e);
+			LOG.error("Error reading tile data from blob: {}", e.getMessage(), e);
 		}
 
 		long elapsed = System.currentTimeMillis() - begin;
@@ -356,10 +356,10 @@ public class GridFileReader extends GridReader {
 		}
 		catch (IOException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("(Stack) Exception occurred: " + e.getLocalizedMessage(), e);
+				LOG.debug("(Stack) Exception occurred: {}", e.getLocalizedMessage(), e);
 			}
 			else {
-				LOG.error("Exception occurred: " + e.getLocalizedMessage());
+				LOG.error("Exception occurred: {}", e.getLocalizedMessage());
 			}
 		}
 

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/grid/SplittedBlobReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/grid/SplittedBlobReader.java
@@ -101,7 +101,7 @@ public class SplittedBlobReader extends GridFileReader {
 			blobNo++;
 			totalSize += blobFile.length();
 		}
-		LOG.debug("Concatenated grid size (of all blob files): " + totalSize);
+		LOG.debug("Concatenated grid size (of all blob files): {}", totalSize);
 
 		blobChannels = new FileChannel[blobFiles.size()];
 		for (int i = 0; i < blobChannels.length; ++i) {
@@ -110,7 +110,7 @@ public class SplittedBlobReader extends GridFileReader {
 			}
 			catch (FileNotFoundException e) {
 				// this should not happen
-				LOG.debug("Could not find file: " + blobFiles.get(i) + ": because: " + e.getLocalizedMessage(), e);
+				LOG.debug("Could not find file: {}: because: {}", blobFiles.get(i), e.getLocalizedMessage(), e);
 			}
 		}
 		setTilesPerBlob((int) (blobFiles.get(0).length() / getBytesPerTile()));
@@ -141,7 +141,7 @@ public class SplittedBlobReader extends GridFileReader {
 
 		}
 		catch (IOException e) {
-			LOG.error("Error reading tile data from blob: " + e.getMessage(), e);
+			LOG.error("Error reading tile data from blob: {}", e.getMessage(), e);
 		}
 
 		if (LOG.isDebugEnabled()) {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/IIORasterDataReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/IIORasterDataReader.java
@@ -172,7 +172,7 @@ public class IIORasterDataReader implements RasterDataReader {
 					return RasterFactory.rasterDataFromImage(result, options);
 				}
 				catch (IOException e) {
-					LOG.error("couldn't open image:" + e.getMessage(), e);
+					LOG.error("couldn't open image:{}", e.getMessage(), e);
 					this.imageReadFailed = true;
 				}
 			}
@@ -211,7 +211,7 @@ public class IIORasterDataReader implements RasterDataReader {
 					width = reader.getWidth(imageIndex);
 				}
 				catch (IOException e) {
-					LOG.debug("couldn't open image for width:" + e.getMessage(), e);
+					LOG.debug("couldn't open image for width:{}", e.getMessage(), e);
 					this.widthReadFailed = true;
 				}
 				resetStream();
@@ -231,7 +231,7 @@ public class IIORasterDataReader implements RasterDataReader {
 					height = reader.getHeight(imageIndex);
 				}
 				catch (IOException e) {
-					LOG.debug("couldn't open image for height:" + e.getMessage(), e);
+					LOG.debug("couldn't open image for height:{}", e.getMessage(), e);
 					this.heightReadFailed = true;
 				}
 				resetStream();
@@ -254,7 +254,7 @@ public class IIORasterDataReader implements RasterDataReader {
 					metaData = reader.getImageMetadata(0);
 				}
 				catch (IOException e) {
-					LOG.debug("couldn't open metadata:" + e.getMessage(), e);
+					LOG.debug("couldn't open metadata:{}", e.getMessage(), e);
 					this.metadataReadFailed = true;
 				}
 				resetStream();
@@ -296,7 +296,7 @@ public class IIORasterDataReader implements RasterDataReader {
 
 				}
 				catch (IOException e) {
-					LOG.debug("couldn't create a raster data info object:" + e.getMessage(), e);
+					LOG.debug("couldn't create a raster data info object:{}", e.getMessage(), e);
 					rdiReadFailed = true;
 				}
 			}
@@ -353,9 +353,9 @@ public class IIORasterDataReader implements RasterDataReader {
 					this.retrievalOfReadersFailed = true;
 				}
 				catch (IOException e) {
-					LOG.debug("Could not open an ImageStream for "
-							+ ((file != null) ? "file: " + file.getAbsolutePath() : "stream ") + ", because: "
-							+ e.getLocalizedMessage(), e);
+					LOG.debug("Could not open an ImageStream for {}, because: {}",
+							((file != null) ? "file: " + file.getAbsolutePath() : "stream "), e.getLocalizedMessage(),
+							e);
 					this.retrievalOfReadersFailed = true;
 				}
 			}
@@ -391,9 +391,8 @@ public class IIORasterDataReader implements RasterDataReader {
 		}
 		catch (IOException e) {
 			LOG.debug(
-					"Could not get easy access information from the imagereader, using configured value for using cache: "
-							+ result,
-					e);
+					"Could not get easy access information from the imagereader, using configured value for using cache: {}",
+					result, e);
 		}
 		return result;
 	}
@@ -435,7 +434,7 @@ public class IIORasterDataReader implements RasterDataReader {
 				}
 			}
 			catch (IOException e) {
-				LOG.debug("Could not read the given rect: " + rect + " because: " + e.getLocalizedMessage(), e);
+				LOG.debug("Could not read the given rect: {} because: {}", rect, e.getLocalizedMessage(), e);
 			}
 		}
 		return result;

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/IIORasterWriter.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/IIORasterWriter.java
@@ -77,7 +77,7 @@ public class IIORasterWriter implements RasterWriter {
 
 	@Override
 	public void write(AbstractRaster raster, File file, RasterIOOptions options) throws IOException {
-		LOG.debug("writing " + file + " with ImageIO");
+		LOG.debug("writing {} with ImageIO", file);
 		String format = options != null ? options.get(RasterIOOptions.OPT_FORMAT) : null;
 		if (format == null) {
 			format = FileUtils.getFileExtension(file);

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/MetaDataReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/MetaDataReader.java
@@ -116,7 +116,7 @@ public class MetaDataReader {
 					crs = CRSManager.lookup("EPSG:" + epsgCode);
 				}
 				catch (UnknownCRSException e) {
-					LOG.error("No coordinate system found for EPSG:" + epsgCode);
+					LOG.error("No coordinate system found for EPSG:{}", epsgCode);
 				}
 			}
 		}
@@ -156,7 +156,7 @@ public class MetaDataReader {
 		if (LOG.isDebugEnabled()) {
 			for (String format : metaData.getMetadataFormatNames()) {
 				// IIOMetadataNode elem = (IIOMetadataNode) metaData.getAsTree( format );
-				LOG.debug("metadata format: " + format);
+				LOG.debug("metadata format: {}", format);
 				LOG.debug("TBD output the xml file here.");
 				// LogUtils.writeTempFile( LOG, "geotiff", ".xml", new XMLFragment( elem
 				// ).toString() );

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/geotiff/GeoTiffWriter.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/geotiff/GeoTiffWriter.java
@@ -250,10 +250,10 @@ public class GeoTiffWriter {
 			CRSType type = srs.getType();
 			switch (type) {
 				case COMPOUND:
-					LOG.warn("Can't save coordinate system. coordinate type " + srs.getType() + " not supported");
+					LOG.warn("Can't save coordinate system. coordinate type {} not supported", srs.getType());
 					break;
 				case GEOCENTRIC:
-					LOG.warn("Can't save coordinate system. coordinate type " + srs.getType() + " not supported");
+					LOG.warn("Can't save coordinate system. coordinate type {} not supported", srs.getType());
 					geoKeyDirectoryTag.put(GTModelTypeGeoKey, new char[] { 0, 1, ModelTypeGeocentric });
 					geoKeyDirectoryTag.put(GeographicTypeGeoKey, keyEntry);
 					if (epsgCode == 32767) {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterDataReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterDataReader.java
@@ -166,8 +166,8 @@ public class JAIRasterDataReader implements RasterDataReader {
 				img = openImageStream(imageStreamFromFileOrStream());
 			}
 			catch (IOException e) {
-				LOG.error("could't open image from " + ((file != null) ? "file: " + file.getAbsolutePath() : "stream ")
-						+ ", because: " + e.getMessage());
+				LOG.error("could't open image from {}, because: {}",
+						((file != null) ? "file: " + file.getAbsolutePath() : "stream "), e.getMessage());
 				// e.printStackTrace();
 				errorOnLoading = true;
 			}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterDataWriter.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterDataWriter.java
@@ -78,7 +78,7 @@ public class JAIRasterDataWriter {
 		try {
 			// jai_imageio registers ImageWrite with support for more formats (eg. JPEG
 			// 2000)
-			LOG.debug("trying to write: " + filename + " with format: " + format);
+			LOG.debug("trying to write: {} with format: {}", filename, format);
 			JAI.create("ImageWrite", result, filename, format, null);
 		}
 		catch (IllegalArgumentException ex) {
@@ -100,7 +100,7 @@ public class JAIRasterDataWriter {
 		try {
 			// jai_imageio registers ImageWrite with support for more formats (eg. JPEG
 			// 2000)
-			LOG.debug("trying to write to stream with format: " + format);
+			LOG.debug("trying to write to stream with format: {}", format);
 			JAI.create("ImageWrite", result, stream, format, null);
 		}
 		catch (IllegalArgumentException ex) {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterReader.java
@@ -80,7 +80,7 @@ public class JAIRasterReader implements RasterReader {
 
 	@Override
 	public AbstractRaster load(File file, RasterIOOptions options) {
-		LOG.debug("reading " + file + " with JAI");
+		LOG.debug("reading {} with JAI", file);
 		reader = new JAIRasterDataReader(file, options);
 
 		return loadFromReader(reader, options);

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterWriter.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/jai/JAIRasterWriter.java
@@ -58,7 +58,7 @@ public class JAIRasterWriter implements RasterWriter {
 
 	@Override
 	public void write(AbstractRaster raster, File file, RasterIOOptions options) throws IOException {
-		LOG.debug("writing " + file + " with JAI");
+		LOG.debug("writing {} with JAI", file);
 		String ext = FileUtils.getFileExtension(file);
 		String format = JAIRasterIOProvider.getJAIFormat(ext);
 		if (format != null) {

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/xyz/XYZReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/xyz/XYZReader.java
@@ -342,7 +342,7 @@ public class XYZReader implements RasterReader {
 					nOpts.setRasterGeoReference(geoRef);
 				}
 				catch (IOException e) {
-					LOG.debug("Could not read xyz world file: " + e.getLocalizedMessage(), e);
+					LOG.debug("Could not read xyz world file: {}", e.getLocalizedMessage(), e);
 				}
 			}
 			result = createSimpleRaster(reader, nOpts);

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/utils/RasterBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/utils/RasterBuilder.java
@@ -150,8 +150,9 @@ public class RasterBuilder {
 					result.add(f);
 				}
 				else {
-					LOG.info("Directory: " + f.getAbsolutePath()
-							+ " can not be added to a Multiresolution raster, because it does not denote a resolution.");
+					LOG.info(
+							"Directory: {} can not be added to a Multiresolution raster, because it does not denote a resolution.",
+							f.getAbsolutePath());
 				}
 			}
 		}
@@ -231,8 +232,9 @@ public class RasterBuilder {
 				result = Double.parseDouble(dirRes);
 			}
 			catch (NumberFormatException e) {
-				LOG.debug("No resolution found in raster datasource defintion, nor in the directory name: " + dirRes
-						+ " returning 0");
+				LOG.debug(
+						"No resolution found in raster datasource defintion, nor in the directory name: {} returning 0",
+						dirRes);
 				result = Double.NaN;
 			}
 		}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/utils/RasterFactory.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/utils/RasterFactory.java
@@ -123,7 +123,7 @@ public class RasterFactory {
 			ResourceMetadata<Coverage> metadata) throws IOException {
 		RasterReader reader = getRasterReader(filename, options);
 		if (reader == null) {
-			log.error("couldn't find raster reader for " + filename);
+			log.error("couldn't find raster reader for {}", filename);
 			throw new IOException("couldn't find raster reader");
 		}
 		AbstractRaster cov = reader.load(filename, options);
@@ -179,7 +179,7 @@ public class RasterFactory {
 		}
 		RasterWriter writer = getRasterWriter(raster, opts);
 		if (writer == null) {
-			log.error("couldn't find raster writer for " + filename);
+			log.error("couldn't find raster writer for {}", filename);
 			throw new IOException("couldn't find raster writer");
 		}
 
@@ -599,9 +599,9 @@ public class RasterFactory {
 			int targetSize = rdi.bands * width * height * rdi.dataSize;
 			if (byteBuffer == null || byteBuffer.capacity() < targetSize) {
 				if (byteBuffer != null) {
-					log.warn("The given bytebuffer's capacity (" + byteBuffer.capacity()
-							+ ") was not too small for the given buffered image (" + targetSize
-							+ "), creating new buffer.");
+					log.warn(
+							"The given bytebuffer's capacity ({}) was not too small for the given buffered image ({}), creating new buffer.",
+							byteBuffer.capacity(), targetSize);
 				}
 				byteBuffer = ByteBufferPool.allocate(rdi.bands * width * height * rdi.dataSize, false);
 			}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/tools/RasterOptionsParser.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/tools/RasterOptionsParser.java
@@ -148,8 +148,8 @@ public class RasterOptionsParser {
 			}
 			else {
 				LOG.warn(
-						"Using default cache dir: " + RasterCache.DEFAULT_CACHE_DIR + " because given cache directory: "
-								+ cacheDir + " does not exist or is a file (and not a directory.)");
+						"Using default cache dir: {} because given cache directory: {} does not exist or is a file (and not a directory.)",
+						RasterCache.DEFAULT_CACHE_DIR, cacheDir);
 			}
 		}
 		return options;

--- a/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/RasterFactoryTest.java
+++ b/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/RasterFactoryTest.java
@@ -137,9 +137,9 @@ public class RasterFactoryTest {
 		RenderedOp tiff = getJAIImage("test_tiled_image_lzw.tif");
 		RenderedOp tiffNone = getJAIImage("test_tiled_image.tif");
 
-		LOG.debug("jpg:  " + jpg.getWidth() + ", " + jpg.getHeight());
-		LOG.debug("tiff:  " + tiff.getWidth() + ", " + tiff.getHeight());
-		LOG.debug("tiffNone:  " + tiffNone.getWidth() + ", " + tiffNone.getHeight());
+		LOG.debug("jpg:  {}, {}", jpg.getWidth(), jpg.getHeight());
+		LOG.debug("tiff:  {}, {}", tiff.getWidth(), tiff.getHeight());
+		LOG.debug("tiffNone:  {}, {}", tiffNone.getWidth(), tiffNone.getHeight());
 
 		// synchronized ( tiff ) {
 		// tiff.wait( 10000 );
@@ -148,12 +148,12 @@ public class RasterFactoryTest {
 
 		long ret = currentTimeMillis();
 		saveSubset(jpg, "jpg", 0, 0, 250, 260);
-		LOG.debug("jpg subset 1: " + (currentTimeMillis() - ret) + "millis");
+		LOG.debug("jpg subset 1: {}millis", (currentTimeMillis() - ret));
 		// jpg.dispose();
 		//
 		ret = currentTimeMillis();
 		saveSubset(jpg, "jpg", 2098, 2000, 1050, 1008);
-		LOG.debug("jpg subset 2: " + (currentTimeMillis() - ret) + "millis");
+		LOG.debug("jpg subset 2: {}millis", (currentTimeMillis() - ret));
 		jpg.dispose();
 
 		gc();
@@ -170,11 +170,11 @@ public class RasterFactoryTest {
 
 		ret = currentTimeMillis();
 		saveSubset(tiff, "jai_tif_1", 0, 0, 250, 260);
-		LOG.debug("compressed tiff subset 1: " + (currentTimeMillis() - ret) + "millis");
+		LOG.debug("compressed tiff subset 1: {}millis", (currentTimeMillis() - ret));
 
 		ret = currentTimeMillis();
 		saveSubset(tiff, "jai_tif_2", 4998, 4900, 10500, 13080);
-		LOG.debug("compressed tiff subset 2: " + (currentTimeMillis() - ret) + "millis");
+		LOG.debug("compressed tiff subset 2: {}millis", (currentTimeMillis() - ret));
 
 		gc();
 		gc();
@@ -189,17 +189,17 @@ public class RasterFactoryTest {
 		}
 		ret = currentTimeMillis();
 		saveSubset(tiffNone, "jai_tif_none_1", 0, 0, 250, 260);
-		LOG.debug("tiff subset 1: " + (currentTimeMillis() - ret) + "millis");
+		LOG.debug("tiff subset 1: {}millis", (currentTimeMillis() - ret));
 		ret = currentTimeMillis();
 		saveSubset(tiffNone, "jai_tif_none_2", 4998, 4900, 10500, 13080);
-		LOG.debug("tiff subset 2: " + (currentTimeMillis() - ret) + "millis");
+		LOG.debug("tiff subset 2: {}millis", (currentTimeMillis() - ret));
 
-		LOG.debug("jai total: " + (currentTimeMillis() - t) + "millis");
+		LOG.debug("jai total: {}millis", (currentTimeMillis() - t));
 		t = System.currentTimeMillis();
 	}
 
 	private void saveSubset(RenderedOp image, String name, int x, int y, int w, int h) {
-		LOG.debug("getting subset: " + name);
+		LOG.debug("getting subset: {}", name);
 		WritableRaster jpgRaster = image.getColorModel()
 			.createCompatibleWritableRaster(w, h)
 			.createWritableTranslatedChild(x, y);
@@ -207,7 +207,7 @@ public class RasterFactoryTest {
 		// BufferedImage img = new BufferedImage( image.getColorModel(),
 		// jpgRaster.getWritableParent(), false, null );
 		// ImageIO.write( img, "png", File.createTempFile( name, ".png" ) );
-		LOG.debug("wrote subset: " + name);
+		LOG.debug("wrote subset: {}", name);
 	}
 
 	private RenderedOp getJAIImage(String file) throws IOException, URISyntaxException {

--- a/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/integration/CenterOuterTest.java
+++ b/deegree-core/deegree-core-coverage/src/test/java/org/deegree/coverage/raster/integration/CenterOuterTest.java
@@ -177,10 +177,10 @@ public abstract class CenterOuterTest implements CompareValues {
 		}
 		catch (IOException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("(Stack) Exception occurred: " + e.getLocalizedMessage(), e);
+				LOG.debug("(Stack) Exception occurred: {}", e.getLocalizedMessage(), e);
 			}
 			else {
-				LOG.error("Exception occurred: " + e.getLocalizedMessage());
+				LOG.error("Exception occurred: {}", e.getLocalizedMessage());
 			}
 		}
 		// System.out.println( sb.toString() );

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/CRSIdentifiable.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/CRSIdentifiable.java
@@ -425,7 +425,7 @@ public class CRSIdentifiable implements CRSResource {
 						}
 					}
 					catch (Exception e) {
-						LOG.debug("Error parsing areaOfUse bbox (ignoring it): '" + e.getMessage() + "'");
+						LOG.debug("Error parsing areaOfUse bbox (ignoring it): '{}'", e.getMessage());
 					}
 				}
 			}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/CRSUtils.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/CRSUtils.java
@@ -132,21 +132,21 @@ public class CRSUtils {
 	public static boolean isAxisAware(final ICRS crs) throws UnknownCRSException {
 		final String alias = crs.getAlias().toLowerCase();
 		if (isUrnEpsgIdentifier(alias) || isOgcCrsIdentifier(alias)) {
-			LOG.debug(alias + " is considered axis aware");
+			LOG.debug("{} is considered axis aware", alias);
 			return true;
 		}
 		for (final String crsString : crs.getOrignalCodeStrings()) {
 			final String lowerCrsString = crsString.toLowerCase();
 			if (isUrnEpsgIdentifier(lowerCrsString)) {
-				LOG.debug(crs.getAlias() + " is considered axis aware");
+				LOG.debug("{} is considered axis aware", crs.getAlias());
 				return true;
 			}
 			if (isOgcCrsIdentifier(lowerCrsString)) {
-				LOG.debug(crs.getAlias() + " is considered axis aware");
+				LOG.debug("{} is considered axis aware", crs.getAlias());
 				return true;
 			}
 		}
-		LOG.debug(crs.getAlias() + " is not considered axis aware");
+		LOG.debug("{} is not considered axis aware", crs.getAlias());
 		return false;
 	}
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/configuration/resources/XMLFileResource.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/configuration/resources/XMLFileResource.java
@@ -75,7 +75,7 @@ public abstract class XMLFileResource extends XMLAdapter implements XMLResource 
 		}
 		InputStream is = null;
 		try {
-			LOG.debug("Trying to load configuration from file: " + file);
+			LOG.debug("Trying to load configuration from file: {}", file);
 			is = file.openStream();
 
 			load(is);

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/coordinatesystems/CRS.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/coordinatesystems/CRS.java
@@ -546,13 +546,13 @@ public abstract class CRS extends CRSIdentifiable implements ICRS {
 					validDomain[3] = axis1Max;
 				}
 				catch (IllegalArgumentException e) {
-					LOG.debug("Exception occurred: " + e.getLocalizedMessage(), e);
-					LOG.debug("Exception occurred: " + e.getLocalizedMessage());
+					LOG.debug("Exception occurred: {}", e.getLocalizedMessage(), e);
+					LOG.debug("Exception occurred: {}", e.getLocalizedMessage());
 
 				}
 				catch (org.deegree.cs.exceptions.TransformationException e) {
-					LOG.debug("Exception occurred: " + e.getLocalizedMessage(), e);
-					LOG.debug("Exception occurred: " + e.getLocalizedMessage());
+					LOG.debug("Exception occurred: {}", e.getLocalizedMessage(), e);
+					LOG.debug("Exception occurred: {}", e.getLocalizedMessage());
 				}
 			}
 		}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/i18n/Messages.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -111,7 +111,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -179,7 +179,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/AbstractCRSStore.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/AbstractCRSStore.java
@@ -112,7 +112,7 @@ public abstract class AbstractCRSStore implements CRSStore {
 			if (result == null) {
 				result = getCRSFromCache(cachedIdentifiables, id, result);
 				if (result == null) {
-					LOG.debug("No crs with id: " + id + " found in cache.");
+					LOG.debug("No crs with id: {} found in cache.", id);
 					result = getCoordinateSystem(id.getOriginal());
 				}
 				if (forceXY && result != null) {
@@ -121,8 +121,9 @@ public abstract class AbstractCRSStore implements CRSStore {
 			}
 		}
 		if (result == null) {
-			LOG.debug("The id: " + id
-					+ " could not be mapped to a valid deegree-crs, currently projectedCRS, geographicCRS, compoundCRS and geocentricCRS are supported.");
+			LOG.debug(
+					"The id: {} could not be mapped to a valid deegree-crs, currently projectedCRS, geographicCRS, compoundCRS and geocentricCRS are supported.",
+					id);
 		}
 		else {
 			/**
@@ -183,16 +184,17 @@ public abstract class AbstractCRSStore implements CRSStore {
 	}
 
 	private ICRS getCRSFromCache(Map<CRSCodeType, CRSResource> cache, CRSCodeType id, ICRS result) {
-		LOG.debug("Trying to load crs with id: " + id + " from cache.");
+		LOG.debug("Trying to load crs with id: {} from cache.", id);
 		if (LOG.isDebugEnabled()) {
 			LOG.debug(cachedIdentifiables.keySet().toString());
 		}
 		if (cache.containsKey(id)) {
 			CRSResource r = cache.get(id);
-			LOG.debug("Found CRSIdentifiable: " + r.getCodeAndName() + " from given id: " + id);
+			LOG.debug("Found CRSIdentifiable: {} from given id: {}", r.getCodeAndName(), id);
 			if (!(r instanceof ICRS)) {
-				LOG.error("Found CRSIdentifiable: " + r.getCodeAndName()
-						+ " but it is not a coordinate system, your db is inconsistent return null.");
+				LOG.error(
+						"Found CRSIdentifiable: {} but it is not a coordinate system, your db is inconsistent return null.",
+						r.getCodeAndName());
 				r = null;
 			}
 			result = (CRS) r;
@@ -233,7 +235,7 @@ public abstract class AbstractCRSStore implements CRSStore {
 			}
 		}
 		catch (Exception e) {
-			LOG.warn("The clearing of the cache could not be forefullfilled because: " + e.getLocalizedMessage());
+			LOG.warn("The clearing of the cache could not be forefullfilled because: {}", e.getLocalizedMessage());
 		}
 	}
 
@@ -270,8 +272,8 @@ public abstract class AbstractCRSStore implements CRSStore {
 		for (int i = 0; i < ids.length && result == null; i++) {
 			result = getCachedIdentifiable(expectedType, ids[i]);
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Searched for id: " + ids[i] + " resulted in: "
-						+ ((result == null) ? "null" : result.getCode()));
+				LOG.debug("Searched for id: {} resulted in: {}", ids[i],
+						((result == null) ? "null" : result.getCode()));
 			}
 		}
 		return result;
@@ -295,8 +297,8 @@ public abstract class AbstractCRSStore implements CRSStore {
 		for (int i = 0; i < ids.length && result == null; i++) {
 			result = getCachedIdentifiable(expectedType, ids[i]);
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Searched for id: " + ids[i] + " resulted in: "
-						+ ((result == null) ? "null" : result.getCode()));
+				LOG.debug("Searched for id: {} resulted in: {}", ids[i],
+						((result == null) ? "null" : result.getCode()));
 			}
 		}
 		return result;
@@ -321,11 +323,11 @@ public abstract class AbstractCRSStore implements CRSStore {
 			result = (V) cachedIdentifiables.get(CRSCodeType.valueOf(id));
 		}
 		catch (ClassCastException cce) {
-			LOG.error("Given id is not of type: " + expectedType.getCanonicalName() + " found following error: "
-					+ cce.getLocalizedMessage());
+			LOG.error("Given id is not of type: {} found following error: {}", expectedType.getCanonicalName(),
+					cce.getLocalizedMessage());
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Searched for id: " + id + " resulted in: " + ((result == null) ? "null" : result.getCode()));
+			LOG.debug("Searched for id: {} resulted in: {}", id, ((result == null) ? "null" : result.getCode()));
 		}
 		return result;
 	}
@@ -348,11 +350,11 @@ public abstract class AbstractCRSStore implements CRSStore {
 			result = (V) cachedIdentifiables.get(id);
 		}
 		catch (ClassCastException cce) {
-			LOG.error("Given id is not of type: " + expectedType.getCanonicalName() + " found following error: "
-					+ cce.getLocalizedMessage());
+			LOG.error("Given id is not of type: {} found following error: {}", expectedType.getCanonicalName(),
+					cce.getLocalizedMessage());
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Searched for id: " + id + " resulted in: " + ((result == null) ? "null" : result.getCode()));
+			LOG.debug("Searched for id: {} resulted in: {}", id, ((result == null) ? "null" : result.getCode()));
 		}
 		return result;
 	}
@@ -372,7 +374,7 @@ public abstract class AbstractCRSStore implements CRSStore {
 		}
 		V result = (V) cachedIdentifiables.get(CRSCodeType.valueOf(id));
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Searched for id: " + id + " resulted in: " + ((result == null) ? "null" : result.getCode()));
+			LOG.debug("Searched for id: {} resulted in: {}", id, ((result == null) ? "null" : result.getCode()));
 		}
 		return result;
 	}
@@ -391,7 +393,7 @@ public abstract class AbstractCRSStore implements CRSStore {
 		}
 		V result = (V) cachedIdentifiables.get(id);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Searched for id: " + id + " resulted in: " + ((result == null) ? "null" : result.getCode()));
+			LOG.debug("Searched for id: {} resulted in: {}", id, ((result == null) ? "null" : result.getCode()));
 		}
 		return result;
 	}
@@ -417,17 +419,17 @@ public abstract class AbstractCRSStore implements CRSStore {
 			if (idString != null) {
 				if (cache.containsKey(idString) && cache.get(idString) != null) {
 					if (update) {
-						LOG.debug("Updating cache with new identifiable: " + idString);
+						LOG.debug("Updating cache with new identifiable: {}", idString);
 						cache.put(idString, identifiable);
 					}
 				}
 				else {
-					LOG.debug("Adding new identifiable to cache: " + idString);
+					LOG.debug("Adding new identifiable to cache: {}", idString);
 					cache.put(idString, identifiable);
 				}
 			}
 			else {
-				LOG.debug("Not adding the null string id to the cache of identifiable: " + identifiable.getCode());
+				LOG.debug("Not adding the null string id to the cache of identifiable: {}", identifiable.getCode());
 			}
 		}
 		return identifiable;

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/CRSManager.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/CRSManager.java
@@ -119,7 +119,7 @@ public class CRSManager implements Initializable, Destroyable {
 				defaultInitialized = true;
 			}
 			catch (Throwable t) {
-				LOG.error("The default configuration could not be loaded: " + t.getMessage());
+				LOG.error("The default configuration could not be loaded: {}", t.getMessage());
 			}
 		}
 	}
@@ -166,18 +166,18 @@ public class CRSManager implements Initializable, Destroyable {
 					if ("default.xml".equals(crsConfigFile.getName())) {
 						prefer = false;
 						remove("default");
-						LOG.info("CRS store " + crsConfigFile + " overwrites internal configuration!");
+						LOG.info("CRS store {} overwrites internal configuration!", crsConfigFile);
 					}
 					handleConfigFile(crsConfigFile.toURI().toURL(), prefer);
 				}
 				catch (Throwable t) {
-					LOG.error("Unable to read config file '" + crsConfigFile + "'.", t);
+					LOG.error("Unable to read config file '{}'.", crsConfigFile, t);
 				}
 			}
 			LOG.info("");
 		}
 		else {
-			LOG.info("Could not set up CRS stores: CRS workspace directory " + crsDir + " is null or does not exist.");
+			LOG.info("Could not set up CRS stores: CRS workspace directory {} is null or does not exist.", crsDir);
 		}
 	}
 
@@ -186,13 +186,13 @@ public class CRSManager implements Initializable, Destroyable {
 		int fileNameStart = fileName.lastIndexOf('/') + 1;
 		// 4 is the length of ".xml"
 		String crsId = fileName.substring(fileNameStart, fileName.length() - 4);
-		LOG.info("Setting up crs store '" + crsId + "' from file '" + fileName + "'..." + "");
+		LOG.info("Setting up crs store '{}' from file '{}'...", crsId, fileName);
 		try {
 			CRSStore crss = create(crsConfigFile.toURI().toURL());
 			registerAndInit(crss, crsId, prefer);
 		}
 		catch (Exception e) {
-			LOG.error("Error creating crs store: " + e.getMessage());
+			LOG.error("Error creating crs store: {}", e.getMessage());
 			LOG.trace("Stack trace:", e);
 		}
 	}
@@ -224,7 +224,7 @@ public class CRSManager implements Initializable, Destroyable {
 			closeQuietly(xmlReader);
 			IOUtils.closeQuietly(urlStream);
 		}
-		LOG.debug("Config namespace: '" + namespace + "'");
+		LOG.debug("Config namespace: '{}'", namespace);
 		CRSStoreProvider provider = getProviders().get(namespace);
 		if (provider == null) {
 			String msg = Messages.get("CRSManager.MISSING_PROVIDER", namespace, configURL);
@@ -250,10 +250,11 @@ public class CRSManager implements Initializable, Destroyable {
 					loaded = ServiceLoader.load(CRSStoreProvider.class);
 				}
 				for (CRSStoreProvider provider : loaded) {
-					LOG.debug("CRS store provider: " + provider + ", namespace: " + provider.getConfigNamespace());
+					LOG.debug("CRS store provider: {}, namespace: {}", provider, provider.getConfigNamespace());
 					if (nsToProvider.containsKey(provider.getConfigNamespace())) {
-						LOG.error("Multiple crs store providers for config namespace: '" + provider.getConfigNamespace()
-								+ "' on classpath -- omitting provider '" + provider.getClass().getName() + "'.");
+						LOG.error(
+								"Multiple crs store providers for config namespace: '{}' on classpath -- omitting provider '{}'.",
+								provider.getConfigNamespace(), provider.getClass().getName());
 						continue;
 					}
 					nsToProvider.put(provider.getConfigNamespace(), provider);
@@ -272,7 +273,7 @@ public class CRSManager implements Initializable, Destroyable {
 			if (idToCRSStore.containsKey(id)) {
 				throw new CRSStoreException(Messages.getMessage("CRSManager.DUPLICATE_ID", id));
 			}
-			LOG.info("Registering global crs store with id '" + id + "', type: '" + crss.getClass().getName() + "'");
+			LOG.info("Registering global crs store with id '{}', type: '{}'", id, crss.getClass().getName());
 			idToTransF.put(id, new TransformationFactory(crss));
 			idToCRSStore.put(id, crss);
 			if (prefer) {
@@ -370,7 +371,7 @@ public class CRSManager implements Initializable, Destroyable {
 					crs = lookup(uri, forceXY);
 				}
 				catch (UnknownCRSException e) {
-					LOG.debug("Could not find CRS with uri " + uri + "; return null.");
+					LOG.debug("Could not find CRS with uri {}; return null.", uri);
 				}
 				return crs;
 			}
@@ -538,7 +539,7 @@ public class CRSManager implements Initializable, Destroyable {
 		}
 		long sT = currentTimeMillis();
 		long eT = currentTimeMillis() - sT;
-		LOG.debug("Getting provider: " + crsStore + " took: " + eT + " ms.");
+		LOG.debug("Getting provider: {} took: {} ms.", crsStore, eT);
 		ICRS realCRS = null;
 		try {
 			sT = currentTimeMillis();
@@ -549,7 +550,7 @@ public class CRSManager implements Initializable, Destroyable {
 				realCRS = crsStore.getCRSByCode(CRSCodeType.valueOf(name.toLowerCase()), forceXY);
 			}
 			eT = currentTimeMillis() - sT;
-			LOG.debug("Getting crs ( " + name + " )from provider: " + crsStore + " took: " + eT + " ms.");
+			LOG.debug("Getting crs ( {} )from provider: {} took: {} ms.", name, crsStore, eT);
 		}
 		catch (CRSConfigurationException e) {
 			String msg = Messages.get("CRSManager.BROKEN_CRS_CONFIG", name, e.getMessage());
@@ -559,7 +560,7 @@ public class CRSManager implements Initializable, Destroyable {
 		if (realCRS == null) {
 			throw new UnknownCRSException(name);
 		}
-		LOG.debug("Successfully created the crs with id: " + name);
+		LOG.debug("Successfully created the crs with id: {}", name);
 		return realCRS;
 	}
 
@@ -589,7 +590,7 @@ public class CRSManager implements Initializable, Destroyable {
 		if (realCRS == null) {
 			throw new UnknownCRSException(crsCodeType.getOriginal());
 		}
-		LOG.debug("Successfully created the crs with id: " + crsCodeType);
+		LOG.debug("Successfully created the crs with id: {}", crsCodeType);
 		return realCRS;
 	}
 
@@ -713,12 +714,12 @@ public class CRSManager implements Initializable, Destroyable {
 			t = crsStore.getDirectTransformation(id);
 		}
 		catch (Throwable e) {
-			LOG.debug("Could not retrieve a transformation for id: " + id);
+			LOG.debug("Could not retrieve a transformation for id: {}", id);
 		}
 		if (t != null) {
 			return (Transformation) t;
 		}
-		LOG.debug("The given id: " + id + " is not of type transformation return null.");
+		LOG.debug("The given id: {} is not of type transformation return null.", id);
 		return null;
 	}
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/DeegreeCRSStore.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/DeegreeCRSStore.java
@@ -255,7 +255,7 @@ public class DeegreeCRSStore extends AbstractCRSStore {
 		// int count = 0;
 		// int percentage = (int) Math.round( total / 100.d );
 		// int number = 0;
-		LOG.info("Trying to create a total of " + total + " coordinate systems.");
+		LOG.info("Trying to create a total of {} coordinate systems.", total);
 		for (CRSCodeType[] crsID : allCRSIDs) {
 			if (crsID != null) {
 				String id = crsID[0].getOriginal();

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/CoordinateSystemParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/CoordinateSystemParser.java
@@ -186,8 +186,9 @@ public class CoordinateSystemParser extends DefinitionParser {
 		}
 
 		if (result == null && LOG.isDebugEnabled()) {
-			LOG.debug("The element with name " + crsType + " could not be mapped to a valid deegreec-crs, currently "
-					+ knownCRS + " are supported.");
+			LOG.debug(
+					"The element with name {} could not be mapped to a valid deegreec-crs, currently {} are supported.",
+					crsType, knownCRS);
 		}
 		return result;
 	}
@@ -453,7 +454,7 @@ public class CoordinateSystemParser extends DefinitionParser {
 		}
 		catch (Exception e) {
 			LOG.debug("Could not get available crs's stack: ", e);
-			LOG.error("Could not get available crs's because: " + e.getLocalizedMessage());
+			LOG.error("Could not get available crs's because: {}", e.getLocalizedMessage());
 		}
 		finally {
 			if (confStream != null) {
@@ -461,7 +462,7 @@ public class CoordinateSystemParser extends DefinitionParser {
 					confStream.close();
 				}
 				catch (IOException e) {
-					LOG.error("Could not close the stream, letting it open because: " + e.getLocalizedMessage());
+					LOG.error("Could not close the stream, letting it open because: {}", e.getLocalizedMessage());
 				}
 			}
 		}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/DefinitionParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/DefinitionParser.java
@@ -127,10 +127,10 @@ public abstract class DefinitionParser {
 							this.configStream.close();
 						}
 						catch (IOException e) {
-							LOG.debug("Unable to close the stream to the configuration: " + this.configURL
-									+ " stack trace.", e);
-							LOG.debug("Unable to close the stream to the configuration: " + this.configURL
-									+ " because: " + e.getLocalizedMessage());
+							LOG.debug("Unable to close the stream to the configuration: {} stack trace.",
+									this.configURL, e);
+							LOG.debug("Unable to close the stream to the configuration: {} because: {}", this.configURL,
+									e.getLocalizedMessage());
 						}
 						this.configReader.close();
 						this.readEntireFile = true;
@@ -199,22 +199,23 @@ public abstract class DefinitionParser {
 				// move from start document.
 				XMLStreamUtils.nextElement(configReader);
 				if (!expectedRootName().equals(configReader.getName())) {
-					LOG.error("The root element of the crs configuration at location: " + configURL
-							+ " is not the expected: " + expectedRootName() + " is your configuration correct?");
+					LOG.error(
+							"The root element of the crs configuration at location: {} is not the expected: {} is your configuration correct?",
+							configURL, expectedRootName());
 				}
 			}
 		}
 		catch (XMLStreamException e) {
-			LOG.debug("Could not read config file from url: " + configURL + ", stack trace.", e);
-			LOG.error("Could not read config file from url: " + configURL + " because: " + e.getLocalizedMessage());
+			LOG.debug("Could not read config file from url: {}, stack trace.", configURL, e);
+			LOG.error("Could not read config file from url: {} because: {}", configURL, e.getLocalizedMessage());
 		}
 		catch (FactoryConfigurationError e) {
-			LOG.debug("Could not read config file from url: " + configURL + ", stack trace.", e);
-			LOG.error("Could not read config file from url: " + configURL + " because: " + e.getLocalizedMessage());
+			LOG.debug("Could not read config file from url: {}, stack trace.", configURL, e);
+			LOG.error("Could not read config file from url: {} because: {}", configURL, e.getLocalizedMessage());
 		}
 		catch (IOException e) {
-			LOG.debug("Could not read config file from url: " + configURL + ", stack trace.", e);
-			LOG.error("Could not read config file from url: " + configURL + " because: " + e.getLocalizedMessage());
+			LOG.debug("Could not read config file from url: {}, stack trace.", configURL, e);
+			LOG.error("Could not read config file from url: {} because: {}", configURL, e.getLocalizedMessage());
 		}
 
 	}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/ProjectionParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/ProjectionParser.java
@@ -134,7 +134,7 @@ public class ProjectionParser extends DefinitionParser {
 			// change schema to let projection be identifiable. fix method geodetic
 			tmercNorthern = XMLStreamUtils.getAttributeValueAsBoolean(reader, null, "northernHemisphere", true);
 		}
-		LOG.debug("At element: " + projectionName);
+		LOG.debug("At element: {}", projectionName);
 		String className = XMLStreamUtils.getAttributeValue(reader, "class");
 
 		CRSResource id = parseIdentifiable(reader);
@@ -210,7 +210,7 @@ public class ProjectionParser extends DefinitionParser {
 	private Projection instantiateConfiguredClass(XMLStreamReader reader, String className, CRSResource id,
 			double falseNorthing, double falseEasting, Point2d naturalOrigin, IUnit units, double scaleFactor) {
 		Projection result = null;
-		LOG.debug("Trying to load user defined projection class: " + className);
+		LOG.debug("Trying to load user defined projection class: {}", className);
 		try {
 			Class<?> t = Class.forName(className);
 			t.asSubclass(Projection.class);
@@ -254,7 +254,7 @@ public class ProjectionParser extends DefinitionParser {
 			LOG.error(e.getMessage(), e);
 		}
 		if (result == null) {
-			LOG.debug("Loading of user defined projection class: " + className + " was not successful");
+			LOG.debug("Loading of user defined projection class: {} was not successful", className);
 		}
 		return result;
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/TransformationParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/deegree/d3/parsers/TransformationParser.java
@@ -128,7 +128,7 @@ public class TransformationParser extends DefinitionParser {
 		if (infoID == null || "".equals(infoID.trim())) {
 			return null;
 		}
-		LOG.debug("Searching for the wgs84 with id: " + infoID);
+		LOG.debug("Searching for the wgs84 with id: {}", infoID);
 		Helmert result = getStore().getCachedIdentifiable(Helmert.class, infoID);
 		if (result == null) {
 			try {
@@ -156,7 +156,7 @@ public class TransformationParser extends DefinitionParser {
 		if (transformId == null || "".equals(transformId.trim())) {
 			return null;
 		}
-		LOG.debug("Searching for the transformation with id: " + transformId);
+		LOG.debug("Searching for the transformation with id: {}", transformId);
 		Transformation result = getStore().getCachedIdentifiable(Transformation.class, transformId);
 		if (result == null) {
 			try {
@@ -195,11 +195,11 @@ public class TransformationParser extends DefinitionParser {
 		ICRS src = getStore().getCRSByCode(new CRSCodeType(sourceCRS));
 		ICRS tar = getStore().getCRSByCode(new CRSCodeType(targetCRS));
 		if (src == null) {
-			LOG.debug(reader.getLocation() + ") could not determine referenced source coordinate system.");
+			LOG.debug("{}) could not determine referenced source coordinate system.", reader.getLocation());
 		}
 
 		if (tar == null) {
-			LOG.debug(reader.getLocation() + ") could not determine referenced target coordinate system.");
+			LOG.debug("{}) could not determine referenced target coordinate system.", reader.getLocation());
 		}
 
 		Transformation result = null;
@@ -244,7 +244,7 @@ public class TransformationParser extends DefinitionParser {
 	private Transformation instantiateConfiguredClass(XMLStreamReader reader, String className, CRSResource id,
 			ICRS sourceCRS, ICRS targetCRS) {
 		Transformation result = null;
-		LOG.debug("Trying to load user defined transformation class: " + className);
+		LOG.debug("Trying to load user defined transformation class: {}", className);
 		try {
 			Class<?> t = Class.forName(className);
 			t.asSubclass(Transformation.class);
@@ -286,7 +286,7 @@ public class TransformationParser extends DefinitionParser {
 			LOG.error(e.getMessage(), e);
 		}
 		if (result == null) {
-			LOG.debug("Loading of user defined transformation class: " + className + " was not successful");
+			LOG.debug("Loading of user defined transformation class: {} was not successful", className);
 		}
 		return result;
 
@@ -342,13 +342,13 @@ public class TransformationParser extends DefinitionParser {
 			scaleX = (float) getElementTextAsDouble(reader, new QName(CRS_NS, "ScaleX"), 1, true);
 		}
 		catch (XMLParsingException e) {
-			LOG.error("Could not parse scaleX from crs:leastsquare, because: " + e.getMessage(), e);
+			LOG.error("Could not parse scaleX from crs:leastsquare, because: {}", e.getMessage(), e);
 		}
 		try {
 			scaleY = (float) getElementTextAsDouble(reader, new QName(CRS_NS, "ScaleY"), 1, true);
 		}
 		catch (XMLParsingException e) {
-			LOG.error("Could not parse scaleY from crs:leastsquare, because: " + e.getMessage(), e);
+			LOG.error("Could not parse scaleY from crs:leastsquare, because: {}", e.getMessage(), e);
 		}
 		return new LeastSquareApproximation(aValues, bValues, sourceCRS, targetCRS, scaleX, scaleY);
 	}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLCRSStore.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLCRSStore.java
@@ -185,8 +185,8 @@ public class GMLCRSStore extends AbstractCRSStore {
 				result = parseVerticalCRS(rootElement);
 			}
 			else {
-				LOG.warn("The given coordinate system:" + localName
-						+ " is currently not supported by the deegree gml provider.");
+				LOG.warn("The given coordinate system:{} is currently not supported by the deegree gml provider.",
+						localName);
 			}
 		}
 		catch (XMLParsingException e) {
@@ -236,7 +236,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of transformation method resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of transformation method resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 		Transformation result = getCachedIdentifiable(Transformation.class, id);
 		ICRS source = sourceCRS;
@@ -372,8 +372,9 @@ public class GMLCRSStore extends AbstractCRSStore {
 									ppm = value;
 									break;
 								default:
-									LOG.warn("The (helmert) transformation parameter: " + paramID.getCodeAndName()
-											+ " could not be mapped to a valid parameter and will not be used.");
+									LOG.warn(
+											"The (helmert) transformation parameter: {} could not be mapped to a valid parameter and will not be used.",
+											paramID.getCodeAndName());
 									break;
 							}
 						}
@@ -407,7 +408,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 					url = new URL(second);
 				}
 				catch (Throwable t) {
-					LOG.debug("Could not load NTv2 file from location: " + second);
+					LOG.debug("Could not load NTv2 file from location: {}", second);
 				}
 				if (url != null) {
 					result = new NTv2Transformation(source, target, id, url);
@@ -436,8 +437,8 @@ public class GMLCRSStore extends AbstractCRSStore {
 			identifier = adapter.getRequiredNodeAsString(rootElement, new XPath(PRE + "identifier", nsContext));
 		}
 		catch (XMLParsingException e) {
-			LOG.error("Could not find the required identifier node for the given gml:identifiable with localname: "
-					+ rootElement.getLocalName());
+			LOG.error("Could not find the required identifier node for the given gml:identifiable with localname: {}",
+					rootElement.getLocalName());
 			return null;
 		}
 		String[] identifiers = { identifier };
@@ -549,7 +550,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of compound crs resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of compound crs resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 
 		List<OMElement> compRefSysProp = adapter.getRequiredElements(rootElement,
@@ -641,7 +642,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of projected crs resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of projected crs resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 
 		OMElement baseGEOCRSElementProperty = adapter.getRequiredElement(rootElement,
@@ -713,7 +714,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of geodetic crs resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of geodetic crs resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 
 		OMElement datumElementProp = adapter.getRequiredElement(rootElement,
@@ -781,7 +782,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of datum resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of datum resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 		IGeodeticDatum result = getCachedIdentifiable(GeodeticDatum.class, id);
 		if (result == null) {
@@ -850,10 +851,10 @@ public class GMLCRSStore extends AbstractCRSStore {
 				throw new XMLParsingException(adapter, rootElement, "An ellipsoidal cs can only have 2 or 3 axis.");
 			}
 			if (axis[0].getUnits() == null) {
-				LOG.debug("Could not check axis [0]: " + axis[0] + " because it has no units.");
+				LOG.debug("Could not check axis [0]: {} because it has no units.", axis[0]);
 			}
 			else if (axis[1].getUnits() == null) {
-				LOG.debug("Could not check axis [1]: " + axis[1] + " because it has no units.");
+				LOG.debug("Could not check axis [1]: {} because it has no units.", axis[1]);
 			}
 			else {
 				if (!(axis[0].getUnits().canConvert(Unit.RADIAN) && axis[1].getUnits().canConvert(Unit.RADIAN))) {
@@ -863,7 +864,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 				}
 				if (axis.length == 3) {
 					if (axis[2].getUnits() == null) {
-						LOG.debug("Could not check axis [2]: " + axis[2] + " because it has no units.");
+						LOG.debug("Could not check axis [2]: {} because it has no units.", axis[2]);
 					}
 					else {
 						if (!axis[2].getUnits().canConvert(Unit.METRE)) {
@@ -931,7 +932,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of ellipsoid resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of ellipsoid resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 		IEllipsoid result = getCachedIdentifiable(Ellipsoid.class, id);
 		if (result == null) {
@@ -1008,7 +1009,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of prime meridian resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of prime meridian resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 		IPrimeMeridian result = getCachedIdentifiable(PrimeMeridian.class, id.getCodes());
 		// if ( cache == null ) {
@@ -1060,7 +1061,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of vertical crs resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of vertical crs resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 		OMElement verticalCSProp = adapter.getRequiredElement(rootElement, new XPath(PRE + "verticalCS", nsContext));
 		OMElement verticalCSType = getRequiredXlinkedElement(verticalCSProp, PRE + "VerticalCS");
@@ -1095,7 +1096,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 		if (result == null) {
 			result = new VerticalDatum(id);
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Parsing id of vertical datum resulted in: " + Arrays.toString(id.getCodes()));
+				LOG.debug("Parsing id of vertical datum resulted in: {}", Arrays.toString(id.getCodes()));
 			}
 		}
 		return addIdToCache(result, false);
@@ -1123,7 +1124,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return null;
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Parsing id of projection method resulted in: " + Arrays.toString(id.getCodes()));
+			LOG.debug("Parsing id of projection method resulted in: {}", Arrays.toString(id.getCodes()));
 		}
 
 		IProjection result = getCachedIdentifiable(Projection.class, id.getCodes());
@@ -1180,8 +1181,9 @@ public class GMLCRSStore extends AbstractCRSStore {
 										trueScaleLatitude = value;
 									case NOT_SUPPORTED:
 									default:
-										LOG.warn("The projection parameter: " + paramID.getCodeAndName()
-												+ " could not be mapped to any projection and will not be used.");
+										LOG.warn(
+												"The projection parameter: {} could not be mapped to any projection and will not be used.",
+												paramID.getCodeAndName());
 										break;
 								}
 							}
@@ -1215,15 +1217,16 @@ public class GMLCRSStore extends AbstractCRSStore {
 					break;
 				case NOT_SUPPORTED:
 				default:
-					LOG.error("The conversion method (Projection): " + conversionMethodID.getCode()
-							+ " is currently not supported by the deegree crs package.");
+					LOG.error(
+							"The conversion method (Projection): {} is currently not supported by the deegree crs package.",
+							conversionMethodID.getCode());
 			}
 
 			String remarks = adapter.getNodeAsString(rootElement, new XPath(PRE + "remarks", nsContext), null);
-			LOG.debug("The remarks fo the conversion are not evaluated: " + remarks);
+			LOG.debug("The remarks fo the conversion are not evaluated: {}", remarks);
 			String accuracy = adapter.getNodeAsString(rootElement,
 					new XPath(PRE + "coordinateOperationAccuracy", nsContext), null);
-			LOG.debug("The coordinateOperationAccuracy for the conversion are not evaluated: " + accuracy);
+			LOG.debug("The coordinateOperationAccuracy for the conversion are not evaluated: {}", accuracy);
 		}
 		return addIdToCache(result, false);
 	}
@@ -1247,7 +1250,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 		List<OMElement> parameterValues = adapter.getElements(rootElement,
 				new XPath(PRE + "parameterValue", nsContext));
 		if (parameterValues == null || parameterValues.size() < 0) {
-			LOG.debug("The root element: " + rootElement.getLocalName() + " does not define any parameters.");
+			LOG.debug("The root element: {} does not define any parameters.", rootElement.getLocalName());
 		}
 		else {
 			for (OMElement paramValueProp : parameterValues) {
@@ -1340,7 +1343,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 		if (result == null) {
 			result = createUnitFromString(uomAttribute);
 			if (result == null) {
-				LOG.debug("Trying to resolve the uri: " + uomAttribute + " from a gml:value/@uom node");
+				LOG.debug("Trying to resolve the uri: {} from a gml:value/@uom node", uomAttribute);
 				OMElement unitElement = null;
 				try {
 					unitElement = getResolver().getURIAsType(uomAttribute);
@@ -1350,8 +1353,8 @@ public class GMLCRSStore extends AbstractCRSStore {
 				}
 				if (unitElement == null) {
 					LOG.error(
-							"Although an uri was determined, the XLinkresolver was not able to retrieve a valid XML-OM representation of the uom-uri. Error while resolving the following uom uri: "
-									+ uomAttribute + ".");
+							"Although an uri was determined, the XLinkresolver was not able to retrieve a valid XML-OM representation of the uom-uri. Error while resolving the following uom uri: {}.",
+							uomAttribute);
 				}
 				else {
 					CRSResource unitID = parseIdentifiedObject(unitElement);
@@ -1410,17 +1413,17 @@ public class GMLCRSStore extends AbstractCRSStore {
 		String xlink = retrieveXLink(rootElement);
 		OMElement result = null;
 		if (null != xlink && !"".equals(xlink)) {
-			LOG.debug("Found an xlink: " + xlink);
+			LOG.debug("Found an xlink: {}", xlink);
 			// The conversion is given by a link, so resolve it.
 			result = getResolver().getURIAsType(xlink);
 			if (result == null) {
 				LOG.error(
-						"Although an xlink was given, the XLInkresolver was not able to retrieve a valid XML-OM representation of the uri it denotes. Error while resolving the following uri from rootElement: "
-								+ rootElement.getLocalName() + ": " + xlink + ". No further evaluation can be done.");
+						"Although an xlink was given, the XLInkresolver was not able to retrieve a valid XML-OM representation of the uri it denotes. Error while resolving the following uri from rootElement: {}: {}. No further evaluation can be done.",
+						rootElement.getLocalName(), xlink);
 			}
 		}
 		else {
-			LOG.debug("No xlink found in: " + rootElement.getLocalName());
+			LOG.debug("No xlink found in: {}", rootElement.getLocalName());
 		}
 		return result;
 	}
@@ -1453,7 +1456,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 				idRes = getResolver().getURIAsType(id.getOriginal());
 			}
 			catch (IOException e) {
-				LOG.debug("Exception occurred: " + e.getLocalizedMessage(), e);
+				LOG.debug("Exception occurred: {}", e.getLocalizedMessage(), e);
 			}
 			if (idRes != null) {
 				String localName = idRes.getLocalName();
@@ -1471,12 +1474,12 @@ public class GMLCRSStore extends AbstractCRSStore {
 						}
 					}
 					catch (XMLParsingException e) {
-						LOG.debug("Could not get an identifiable for id: " + id.getOriginal() + " because: "
-								+ e.getLocalizedMessage(), e);
+						LOG.debug("Could not get an identifiable for id: {} because: {}", id.getOriginal(),
+								e.getLocalizedMessage(), e);
 					}
 					catch (IOException e) {
-						LOG.debug("Could not get an identifiable for id: " + id.getOriginal() + " because: "
-								+ e.getLocalizedMessage(), e);
+						LOG.debug("Could not get an identifiable for id: {} because: {}", id.getOriginal(),
+								e.getLocalizedMessage(), e);
 					}
 
 				}
@@ -1511,7 +1514,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			idRes = getResolver().getURIAsType(id);
 		}
 		catch (IOException e) {
-			LOG.debug("Exception occurred: " + e.getLocalizedMessage(), e);
+			LOG.debug("Exception occurred: {}", e.getLocalizedMessage(), e);
 		}
 		if (idRes != null) {
 			String localName = idRes.getLocalName();
@@ -1520,8 +1523,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 					return parseCoordinateSystem(idRes);
 				}
 				catch (XMLParsingException e) {
-					LOG.debug("Could not get an identifiable for id: " + id + " because: " + e.getLocalizedMessage(),
-							e);
+					LOG.debug("Could not get an identifiable for id: {} because: {}", id, e.getLocalizedMessage(), e);
 				}
 			}
 		}
@@ -1534,7 +1536,7 @@ public class GMLCRSStore extends AbstractCRSStore {
 			return parseGMLTransformation(getResolver().getURIAsType(uri), null, null);
 		}
 		catch (Exception e) {
-			LOG.debug("Could not parse transformation with uri: " + uri, e);
+			LOG.debug("Could not parse transformation with uri: {}", uri, e);
 		}
 		return null;
 	}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLCRSStoreProvider.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLCRSStoreProvider.java
@@ -107,15 +107,16 @@ public class GMLCRSStoreProvider implements CRSStoreProvider {
 						t = Class.forName(resourceClassName);
 					}
 					catch (Exception e) {
-						LOG.debug("Could not find class from classname '" + resourceClassName
-								+ "'. Search in the additional modules in the workspace.");
+						LOG.debug(
+								"Could not find class from classname '{}'. Search in the additional modules in the workspace.",
+								resourceClassName);
 						t = Class.forName(resourceClassName, false, workspace.getModuleClassLoader());
 					}
-					LOG.debug("Trying to load configured CRS provider from classname: " + resourceClassName);
+					LOG.debug("Trying to load configured CRS provider from classname: {}", resourceClassName);
 					Constructor<?> constructor = t.getConstructor(GMLCRSStore.class, Map.class);
 					if (constructor == null) {
-						LOG.error("No constructor ( " + this.getClass() + ", Properties.class) found in class:"
-								+ resourceClassName);
+						LOG.error("No constructor ( {}, Properties.class) found in class:{}", this.getClass(),
+								resourceClassName);
 					}
 					else {
 						resource = (GMLResource) constructor.newInstance(crsStore, params);
@@ -125,7 +126,7 @@ public class GMLCRSStoreProvider implements CRSStoreProvider {
 					LOG.error(Messages.getMessage("CRS_CONFIG_INSTANTIATION_ERROR", resourceClassName, t.getMessage()),
 							t);
 				}
-				LOG.info("The configured class: " + resourceClassName + " was instantiated.");
+				LOG.info("The configured class: {} was instantiated.", resourceClassName);
 			}
 			if (resource == null) {
 				LOG.info("Trying to instantiate the default GMLFileResource");

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLFileResource.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/gml/GMLFileResource.java
@@ -126,7 +126,7 @@ public class GMLFileResource extends XMLFileResource implements GMLResource {
 		}
 
 		if (result == null) {
-			LOG.info("No helmert transformation found for the given crs: " + sourceCRS.getCodeAndName());
+			LOG.info("No helmert transformation found for the given crs: {}", sourceCRS.getCodeAndName());
 		}
 		return result;
 	}
@@ -176,8 +176,8 @@ public class GMLFileResource extends XMLFileResource implements GMLResource {
 		}
 
 		if (transformations.isEmpty()) {
-			LOG.debug("Apparently no transformations were found for the given CoordinateSystem: "
-					+ sourceCRS.getCode().getOriginal());
+			LOG.debug("Apparently no transformations were found for the given CoordinateSystem: {}",
+					sourceCRS.getCode().getOriginal());
 			return null;
 		}
 		Transformation result = null;
@@ -191,8 +191,8 @@ public class GMLFileResource extends XMLFileResource implements GMLResource {
 					}
 				}
 				catch (XMLParsingException e) {
-					LOG.debug("Transformation with id: " + transElem.getLocalName() + " could not be used because:  "
-							+ e.getMessage());
+					LOG.debug("Transformation with id: {} could not be used because:  {}", transElem.getLocalName(),
+							e.getMessage());
 				}
 			}
 		}
@@ -226,17 +226,17 @@ public class GMLFileResource extends XMLFileResource implements GMLResource {
 		else {
 			String transformTargetID = getTargetTransformID(transformationElement);
 			if (!targetIDs.contains(transformTargetID)) {
-				LOG.debug("Found a transformation with gml:id: "
-						+ transformationElement.getAttributeValue(new QName(CommonNamespaces.GML3_2_NS, "id"))
-						+ ", but the target does not match the source crs, trying to build transformation chain.");
+				LOG.debug(
+						"Found a transformation with gml:id: {}, but the target does not match the source crs, trying to build transformation chain.",
+						transformationElement.getAttributeValue(new QName(CommonNamespaces.GML3_2_NS, "id")));
 				Transformation second = getTransformation(result.getTargetCRS(), targetCRS);
 				if (second != null) {
 					result = new ConcatenatedTransform(result, second);
 				}
 				else {
-					LOG.debug("The transformation with gml:id: "
-							+ transformationElement.getAttributeValue(new QName(CommonNamespaces.GML3_2_NS, "id"))
-							+ " is not the start of transformation chain, discarding it. ");
+					LOG.debug(
+							"The transformation with gml:id: {} is not the start of transformation chain, discarding it. ",
+							transformationElement.getAttributeValue(new QName(CommonNamespaces.GML3_2_NS, "id")));
 					result = null;
 				}
 			}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/PROJ4CRSStore.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/PROJ4CRSStore.java
@@ -132,7 +132,7 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 	public List<ICRS> getAvailableCRSs() throws CRSConfigurationException {
 		Set<CRSCodeType> keys = getResolver().getAvailableCodes();
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Found following keys: " + keys);
+			LOG.debug("Found following keys: {}", keys);
 		}
 		List<ICRS> allSystems = new LinkedList<ICRS>();
 		for (CRSCodeType key : keys) {
@@ -421,7 +421,7 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 		// Get the ellipsoid
 		String tmpValue = params.remove("ellps");
 		if (tmpValue != null && !"".equals(tmpValue.trim())) {
-			LOG.debug("Creating predefined ellipsoid: " + tmpValue);
+			LOG.debug("Creating predefined ellipsoid: {}", tmpValue);
 			result = getPredefinedEllipsoid(tmpValue);
 		}
 		else {
@@ -458,8 +458,9 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 									inverseFlattening = 1 / flattening;
 								}
 								else {
-									LOG.debug("The given flattening: " + flattening
-											+ " can not be inverted (divide by zero) using a sphere as ellipsoid");
+									LOG.debug(
+											"The given flattening: {} can not be inverted (divide by zero) using a sphere as ellipsoid",
+											flattening);
 								}
 							}
 							else {
@@ -1605,7 +1606,7 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 
 		String crsType = crsDefinition.remove("proj");
 		if (crsType == null || "".equals(crsType.trim())) {
-			LOG.debug("The given params contain: " + crsDefinition);
+			LOG.debug("The given params contain: {}", crsDefinition);
 			throw new CRSConfigurationException(
 					Messages.getMessage("CRS_CONFIG_PROJ4_NO_PROJ_PARAM", crsDefinition.get(EPSG_PRE + "identifier")));
 		}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/ProjFileResource.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/ProjFileResource.java
@@ -84,15 +84,15 @@ public class ProjFileResource implements CRSResource<Map<String, String>> {
 				if (line.startsWith("#")) {
 					// remove the '#' from the String.
 					if (kvp.get("comment") != null) {
-						LOG.debug("(Line: " + lineNumber + ") Multiple comments found, removing previous: "
-								+ kvp.get("comment"));
+						LOG.debug("(Line: {}) Multiple comments found, removing previous: {}", lineNumber,
+								kvp.get("comment"));
 					}
 					kvp.put("comment", line.substring(1).trim());
 				}
 				else {
 					String code = parseConfigString(line, Integer.toString(lineNumber), kvp);
 					if (code != null && !"".equals(code.trim())) {
-						LOG.debug("Found code: " + CRSCodeType.valueOf(code) + " with following params: " + kvp);
+						LOG.debug("Found code: {} with following params: {}", CRSCodeType.valueOf(code), kvp);
 						idToParams.put(CRSCodeType.valueOf(code), kvp);
 					}
 					kvp = new HashMap<String, String>(15);
@@ -104,11 +104,11 @@ public class ProjFileResource implements CRSResource<Map<String, String>> {
 
 		}
 		catch (FileNotFoundException e) {
-			LOG.error("Could not create ProjFileResource: " + e.getMessage(), e);
+			LOG.error("Could not create ProjFileResource: {}", e.getMessage(), e);
 			throw new CRSConfigurationException(e);
 		}
 		catch (IOException e) {
-			LOG.error("Could not open file: " + file, e);
+			LOG.error("Could not open file: {}", file, e);
 			throw new CRSConfigurationException(e);
 			// e.printStackTrace();
 		}
@@ -144,7 +144,7 @@ public class ProjFileResource implements CRSResource<Map<String, String>> {
 	public Map<String, String> getURIAsType(String uri) throws IOException {
 		String tmpID = getIDCode(uri);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Given id: " + uri + " converted into: " + tmpID);
+			LOG.debug("Given id: {} converted into: {}", uri, tmpID);
 		}
 		Map<String, String> result = idToParams.get(new CRSCodeType(tmpID));
 		if (result != null) {
@@ -288,7 +288,7 @@ public class ProjFileResource implements CRSResource<Map<String, String>> {
 									lineNumber, "A Value", "=", getTokenizerSymbolToString(t.ttype)));
 						}
 						String value = t.sval;
-						LOG.debug("Putting key: " + key + " with value: " + value);
+						LOG.debug("Putting key: {} with value: {}", key, value);
 						kvp.put(key, value);
 						// take the next token.
 						t.nextToken();

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/projections/cylindric/Mercator.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/projections/cylindric/Mercator.java
@@ -106,7 +106,7 @@ public class Mercator extends CylindricalProjection implements IMercator {
 	public synchronized Point2d doInverseProjection(IGeographicCRS geographicCRS, double x, double y)
 			throws ProjectionException {
 		Point2d result = new Point2d(0, 0);
-		LOG.debug("InverseProjection, incoming points x: " + x + " y: " + y);
+		LOG.debug("InverseProjection, incoming points x: {} y: {}", x, y);
 		x -= getFalseEasting();
 		y -= getFalseNorthing();
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/projections/cylindric/TransverseMercator.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/projections/cylindric/TransverseMercator.java
@@ -191,7 +191,7 @@ public class TransverseMercator extends CylindricalProjection implements ITransv
 	public synchronized Point2d doInverseProjection(IGeographicCRS geographicCRS, double x, double y)
 			throws ProjectionException {
 		Point2d result = new Point2d(0, 0);
-		LOG.debug("InverseProjection, incoming points x: " + x + " y: " + y);
+		LOG.debug("InverseProjection, incoming points x: {} y: {}", x, y);
 		x = (x - getFalseEasting()) / getScaleFactor(geographicCRS);
 		y = (y - getFalseNorthing()) / getScaleFactor(geographicCRS);
 		y *= hemisphere;
@@ -280,7 +280,7 @@ public class TransverseMercator extends CylindricalProjection implements ITransv
 	public synchronized Point2d doProjection(IGeographicCRS geographicCRS, double lambda, double phi)
 			throws ProjectionException {
 		// LOG.debug( "Projection, incoming points lambda: " + lambda + " phi: " + phi );
-		LOG.debug("Projection, incoming points lambda: " + Math.toDegrees(lambda) + " phi: " + Math.toDegrees(phi));
+		LOG.debug("Projection, incoming points lambda: {} phi: {}", Math.toDegrees(lambda), Math.toDegrees(phi));
 		Point2d result = new Point2d(0, 0);
 		lambda -= getProjectionLongitude();
 		// phi -= getProjectionLatitude();

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/TransformationFactory.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/TransformationFactory.java
@@ -278,8 +278,8 @@ public class TransformationFactory {
 				if (sourceCRS.hasDirectTransformation(targetCRS)) {
 					Transformation direct = sourceCRS.getDirectTransformation(targetCRS);
 					if (direct != null) {
-						LOG.debug("Using direct (polynomial) transformation instead of a helmert transformation: "
-								+ direct.getImplementationName());
+						LOG.debug("Using direct (polynomial) transformation instead of a helmert transformation: {}",
+								direct.getImplementationName());
 						result = direct;
 					}
 				}
@@ -327,7 +327,7 @@ public class TransformationFactory {
 			LOG.debug(output.toString());
 
 			if (result instanceof MatrixTransform) {
-				LOG.debug("Resulting matrix transform:\n" + ((MatrixTransform) result).getMatrix());
+				LOG.debug("Resulting matrix transform:\n{}", ((MatrixTransform) result).getMatrix());
 			}
 
 		}
@@ -405,7 +405,7 @@ public class TransformationFactory {
 						h.getTargetCRS(), h.getScaleX(), h.getScaleY(), h);
 			}
 			else {
-				LOG.warn("The transformation with implementation name: " + implName + " could not be copied.");
+				LOG.warn("The transformation with implementation name: {} could not be copied.", implName);
 			}
 		}
 		return result;
@@ -645,9 +645,9 @@ public class TransformationFactory {
 		sourceCRS = ((CompoundCRS) resolve(sourceCRS));
 		targetCRS = ((CompoundCRS) resolve(targetCRS));
 
-		LOG.debug("Creating compound( " + sourceCRS.getUnderlyingCRS().getCode() + ") ->compound transformation( "
-				+ targetCRS.getUnderlyingCRS().getCode() + "): from (source): " + sourceCRS.getCode() + " to(target): "
-				+ targetCRS.getCode());
+		LOG.debug("Creating compound( {}) ->compound transformation( {}): from (source): {} to(target): {}",
+				sourceCRS.getUnderlyingCRS().getCode(), targetCRS.getUnderlyingCRS().getCode(), sourceCRS.getCode(),
+				targetCRS.getCode());
 		final CRSType sourceType = sourceCRS.getUnderlyingCRS().getType();
 		final CRSType targetType = targetCRS.getUnderlyingCRS().getType();
 		Transformation result = null;
@@ -828,8 +828,9 @@ public class TransformationFactory {
 		// prepare the found transformation if it is a helmert transfomation
 		if (result != null && !isIdentity(result) && "Helmert".equalsIgnoreCase(result.getImplementationName())
 				&& this.preferredDSTransform.isPreferred(result)) {
-			LOG.debug("Creating geographic -> geographic transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode() + " based on a given Helmert transformation");
+			LOG.debug(
+					"Creating geographic -> geographic transformation: from (source): {} to(target): {} based on a given Helmert transformation",
+					sourceCRS.getCode(), targetCRS.getCode());
 
 			final IGeodeticDatum sourceDatum = sourceCRS.getGeodeticDatum();
 			final IGeodeticDatum targetDatum = targetCRS.getGeodeticDatum();
@@ -856,8 +857,8 @@ public class TransformationFactory {
 		}
 		else if (result == null || "Helmert".equalsIgnoreCase(result.getImplementationName())
 				|| !this.preferredDSTransform.isPreferred(result)) {
-			LOG.debug("Creating geographic ->geographic transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode());
+			LOG.debug("Creating geographic ->geographic transformation: from (source): {} to(target): {}",
+					sourceCRS.getCode(), targetCRS.getCode());
 			// if a conversion needs to take place
 			if (isEllipsoidTransformNeeded(sourceCRS, targetCRS)) {
 				Transformation sourceT = getToWGSTransformation(sourceCRS);
@@ -948,8 +949,8 @@ public class TransformationFactory {
 
 		Transformation result = getTransformation(sourceCRS, targetCRS);
 		if (isIdentity(result)) {
-			LOG.debug("Creating geographic->projected transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode());
+			LOG.debug("Creating geographic->projected transformation: from (source): {} to(target): {}",
+					sourceCRS.getCode(), targetCRS.getCode());
 			final IGeographicCRS stepGeoCS = targetCRS.getGeographicCRS();
 
 			final Transformation geo2geo = createTransformation(sourceCRS, stepGeoCS);
@@ -976,8 +977,8 @@ public class TransformationFactory {
 	 */
 	private Transformation createTransformation(final IGeographicCRS sourceCRS, final IGeocentricCRS targetCRS)
 			throws TransformationException {
-		LOG.debug("Creating geographic -> geocentric transformation: from (source): " + sourceCRS.getCode()
-				+ " to (target): " + targetCRS.getCode());
+		LOG.debug("Creating geographic -> geocentric transformation: from (source): {} to (target): {}",
+				sourceCRS.getCode(), targetCRS.getCode());
 		Transformation result = getTransformation(sourceCRS, targetCRS);
 		if (isIdentity(result)) {
 			IGeocentricCRS sourceGeocentric = new GeocentricCRS(sourceCRS.getGeodeticDatum(),
@@ -1105,8 +1106,8 @@ public class TransformationFactory {
 			throws TransformationException {
 		Transformation result = getTransformation(sourceCRS, targetCRS);
 		if (isIdentity(result)) {
-			LOG.debug("Creating projected -> projected transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode());
+			LOG.debug("Creating projected -> projected transformation: from (source): {} to(target): {}",
+					sourceCRS.getCode(), targetCRS.getCode());
 			if (sourceCRS.getProjection().equals(targetCRS.getProjection())) {
 				/*
 				 * Swap axis order, and rotate the longitude coordinate if prime meridians
@@ -1140,8 +1141,8 @@ public class TransformationFactory {
 			throws TransformationException {
 		Transformation result = getTransformation(sourceCRS, targetCRS);
 		if (isIdentity(result)) {
-			LOG.debug("Creating projected -> geocentric transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode());
+			LOG.debug("Creating projected -> geocentric transformation: from (source): {} to(target): {}",
+					sourceCRS.getCode(), targetCRS.getCode());
 			final IGeographicCRS sourceGCS = sourceCRS.getGeographicCRS();
 
 			final Transformation inverseProjection = createTransformation(sourceCRS, sourceGCS);
@@ -1168,8 +1169,8 @@ public class TransformationFactory {
 			throws TransformationException {
 		Transformation result = getTransformation(sourceCRS, targetCRS);
 		if (isIdentity(result)) {
-			LOG.debug("Creating projected->geographic transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode());
+			LOG.debug("Creating projected->geographic transformation: from (source): {} to(target): {}",
+					sourceCRS.getCode(), targetCRS.getCode());
 			result = createTransformation(targetCRS, sourceCRS);
 			if (result != null) {
 				result.inverse();
@@ -1195,8 +1196,8 @@ public class TransformationFactory {
 			throws TransformationException {
 		Transformation result = getTransformation(sourceCRS, targetCRS);
 		if (isIdentity(result)) {
-			LOG.debug("Creating geocentric->geocetric transformation: from (source): " + sourceCRS.getCode()
-					+ " to(target): " + targetCRS.getCode());
+			LOG.debug("Creating geocentric->geocetric transformation: from (source): {} to(target): {}",
+					sourceCRS.getCode(), targetCRS.getCode());
 
 			if (isEllipsoidTransformNeeded(sourceCRS, targetCRS)) {
 				final IGeodeticDatum sourceDatum = sourceCRS.getGeodeticDatum();
@@ -1204,8 +1205,8 @@ public class TransformationFactory {
 				// convert from the source to target ellipsoid through the
 				// geocentric coordinate system.
 				if (!isIdentity(sourceDatum.getWGS84Conversion()) || !isIdentity(targetDatum.getWGS84Conversion())) {
-					LOG.debug("Creating helmert transformation: source(" + sourceCRS.getCode() + ")->target("
-							+ targetCRS.getCode() + ").");
+					LOG.debug("Creating helmert transformation: source({})->target({}).", sourceCRS.getCode(),
+							targetCRS.getCode());
 					result = transformUsingPivot(sourceCRS, targetCRS, sourceDatum.getWGS84Conversion(),
 							targetDatum.getWGS84Conversion());
 				}
@@ -1268,22 +1269,22 @@ public class TransformationFactory {
 			resultMatrix.setIdentity();
 		}
 		else {
-			LOG.debug("step1 matrix: \n " + forwardAxisAlign);
-			LOG.debug("step2 matrix: \n " + forwardToWGS);
-			LOG.debug("step3 matrix: \n " + inverseToWGS);
-			LOG.debug("step4 matrix: \n " + resultMatrix);
+			LOG.debug("step1 matrix: \n {}", forwardAxisAlign);
+			LOG.debug("step2 matrix: \n {}", forwardToWGS);
+			LOG.debug("step3 matrix: \n {}", inverseToWGS);
+			LOG.debug("step4 matrix: \n {}", resultMatrix);
 			if (inverseToWGS != null) {
 				inverseToWGS.invert(); // Invert in place.
-				LOG.debug("inverseToWGS inverted matrix: \n " + inverseToWGS);
+				LOG.debug("inverseToWGS inverted matrix: \n {}", inverseToWGS);
 			}
 			if (resultMatrix != null) {
 				if (inverseToWGS != null) {
 					resultMatrix.mul(inverseToWGS); // step4 = step4*step3
-					LOG.debug("resultMatrix (after mul with inverseToWGS): \n " + resultMatrix);
+					LOG.debug("resultMatrix (after mul with inverseToWGS): \n {}", resultMatrix);
 				}
 				if (forwardToWGS != null) {
 					resultMatrix.mul(forwardToWGS); // step4 = step4*step3*step2
-					LOG.debug("resultMatrix (after mul with forwardToWGS2): \n " + resultMatrix);
+					LOG.debug("resultMatrix (after mul with forwardToWGS2): \n {}", resultMatrix);
 				}
 				if (forwardAxisAlign != null) {
 					resultMatrix.mul(forwardAxisAlign); // step4 =
@@ -1294,7 +1295,7 @@ public class TransformationFactory {
 				resultMatrix = inverseToWGS;
 				if (forwardToWGS != null) {
 					resultMatrix.mul(forwardToWGS); // step4 = step3*step2*step1
-					LOG.debug("resultMatrix (after mul with forwardToWGS2): \n " + resultMatrix);
+					LOG.debug("resultMatrix (after mul with forwardToWGS2): \n {}", resultMatrix);
 				}
 				if (forwardAxisAlign != null) {
 					resultMatrix.mul(forwardAxisAlign); // step4 =
@@ -1312,8 +1313,8 @@ public class TransformationFactory {
 			}
 		}
 
-		LOG.debug("The resulting helmert transformation matrix: from( " + sourceCRS.getCode() + ") to("
-				+ targetCRS.getCode() + ")\n " + resultMatrix);
+		LOG.debug("The resulting helmert transformation matrix: from( {}) to({})\n {}", sourceCRS.getCode(),
+				targetCRS.getCode(), resultMatrix);
 		return new MatrixTransform(sourceCRS, targetCRS, resultMatrix, "Helmert-Transformation");
 
 	}

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/coordinate/ConcatenatedTransform.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/coordinate/ConcatenatedTransform.java
@@ -223,7 +223,7 @@ public class ConcatenatedTransform extends Transformation {
 			m2.mul(m1);
 
 			// m1.mul( m2 );
-			LOG.debug("Concatenate: both transforms are matrices, resulting multiply:\n" + m2);
+			LOG.debug("Concatenate: both transforms are matrices, resulting multiply:\n{}", m2);
 			MatrixTransform result = new MatrixTransform(first.getSourceCRS(), second.getTargetCRS(), m2);
 			// if ( result.isIdentity() ) {
 			// return null;

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/coordinate/ProjectionTransform.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/coordinate/ProjectionTransform.java
@@ -94,19 +94,20 @@ public class ProjectionTransform extends Transformation {
 		else {
 			IAxis first = axis[0];
 			IAxis second = axis[1];
-			LOG.debug("First projected crs Axis: " + first);
-			LOG.debug("Second projected crs Axis: " + second);
+			LOG.debug("First projected crs Axis: {}", first);
+			LOG.debug("Second projected crs Axis: {}", second);
 			if (first != null && second != null) {
 				if (Axis.AO_WEST == Math.abs(second.getOrientation())) {
 					result = true;
 					if (Axis.AO_NORTH != Math.abs(first.getOrientation())) {
-						LOG.warn("The given projection uses a second axis which is not mappable (  " + second
-								+ ") please check your configuration, assuming y, x axis-order.");
+						LOG.warn(
+								"The given projection uses a second axis which is not mappable (  {}) please check your configuration, assuming y, x axis-order.",
+								second);
 					}
 				}
 			}
 		}
-		LOG.debug("Incoming ordinates will" + ((result) ? " " : " not ") + "be swapped.");
+		LOG.debug("Incoming ordinates will{}be swapped.", ((result) ? " " : " not "));
 		return result;
 	}
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/ntv2/NTv2Transformation.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/transformations/ntv2/NTv2Transformation.java
@@ -133,12 +133,12 @@ public class NTv2Transformation extends Transformation {
 		}
 		catch (FileNotFoundException e) {
 			LOG.debug("Could not find the gridshift file stack trace.", e);
-			LOG.error("Could not find the gridshift file because: " + e.getLocalizedMessage());
+			LOG.error("Could not find the gridshift file because: {}", e.getLocalizedMessage());
 			throw new IllegalArgumentException("Could not load the gridshift file: " + gridURL, e);
 		}
 		catch (IOException e) {
 			LOG.debug("Could not read the gridshift file stack trace.", e);
-			LOG.error("Could not read the gridshift file because: " + e.getLocalizedMessage());
+			LOG.error("Could not read the gridshift file because: {}", e.getLocalizedMessage());
 			throw new IllegalArgumentException("Could not load the gridshift file: " + gridURL, e);
 		}
 
@@ -150,14 +150,16 @@ public class NTv2Transformation extends Transformation {
 
 		if (Math.abs(sourceEl.getSemiMajorAxis() - gsf.getFromSemiMajorAxis()) > 0.001
 				|| Math.abs(sourceEl.getSemiMinorAxis() - gsf.getFromSemiMinorAxis()) > 0.001) {
-			LOG.warn("The given source CRS' ellipsoid (" + sourceEl.getCode().getOriginal()
-					+ ") does not match the 'from' ellipsoid (" + fromEllips + ") defined in the gridfile: " + gridURL);
+			LOG.warn(
+					"The given source CRS' ellipsoid ({}) does not match the 'from' ellipsoid ({}) defined in the gridfile: {}",
+					sourceEl.getCode().getOriginal(), fromEllips, gridURL);
 		}
 
 		if (Math.abs(targetEl.getSemiMajorAxis() - gsf.getToSemiMajorAxis()) > 0.001
 				|| Math.abs(targetEl.getSemiMinorAxis() - gsf.getToSemiMinorAxis()) > 0.001) {
-			LOG.warn("The given target CRS' ellipsoid (" + targetEl.getCode().getOriginal()
-					+ ") does not match the 'to' ellipsoid (" + toEllips + ") defined in the gridfile: " + gridURL);
+			LOG.warn(
+					"The given target CRS' ellipsoid ({}) does not match the 'to' ellipsoid ({}) defined in the gridfile: {}",
+					targetEl.getCode().getOriginal(), toEllips, gridURL);
 		}
 
 		isIdentity = (Math.abs(gsf.getFromSemiMajorAxis() - gsf.getToSemiMajorAxis()) < 0.001)
@@ -181,14 +183,16 @@ public class NTv2Transformation extends Transformation {
 
 		if (Math.abs(sourceEl.getSemiMajorAxis() - gsf.getFromSemiMajorAxis()) > 0.001
 				|| Math.abs(sourceEl.getSemiMinorAxis() - gsf.getFromSemiMinorAxis()) > 0.001) {
-			LOG.warn("The given source CRS' ellipsoid (" + sourceEl.getCode().getOriginal()
-					+ ") does not match the 'from' ellipsoid (" + fromEllips + ") defined in the gridfile: " + gridURL);
+			LOG.warn(
+					"The given source CRS' ellipsoid ({}) does not match the 'from' ellipsoid ({}) defined in the gridfile: {}",
+					sourceEl.getCode().getOriginal(), fromEllips, gridURL);
 		}
 
 		if (Math.abs(targetEl.getSemiMajorAxis() - gsf.getToSemiMajorAxis()) > 0.001
 				|| Math.abs(targetEl.getSemiMinorAxis() - gsf.getToSemiMinorAxis()) > 0.001) {
-			LOG.warn("The given target CRS' ellipsoid (" + targetEl.getCode().getOriginal()
-					+ ") does not match the 'to' ellipsoid (" + toEllips + ") defined in the gridfile: " + gridURL);
+			LOG.warn(
+					"The given target CRS' ellipsoid ({}) does not match the 'to' ellipsoid ({}) defined in the gridfile: {}",
+					targetEl.getCode().getOriginal(), toEllips, gridURL);
 		}
 
 		isIdentity = (Math.abs(gsf.getFromSemiMajorAxis() - gsf.getToSemiMajorAxis()) < 0.001)
@@ -207,19 +211,20 @@ public class NTv2Transformation extends Transformation {
 		else {
 			IAxis first = axis[0];
 			IAxis second = axis[1];
-			LOG.debug("First crs Axis: " + first);
-			LOG.debug("Second crs Axis: " + second);
+			LOG.debug("First crs Axis: {}", first);
+			LOG.debug("Second crs Axis: {}", second);
 			if (first != null && second != null) {
 				if (Axis.AO_WEST == Math.abs(second.getOrientation())) {
 					result = true;
 					if (Axis.AO_NORTH != Math.abs(first.getOrientation())) {
-						LOG.warn("The given projection uses a second axis which is not mappable (  " + second
-								+ ") please check your configuration, assuming y, x axis-order.");
+						LOG.warn(
+								"The given projection uses a second axis which is not mappable (  {}) please check your configuration, assuming y, x axis-order.",
+								second);
 					}
 				}
 			}
 		}
-		LOG.debug("Incoming ordinates will" + ((result) ? " " : " not ") + "be swapped.");
+		LOG.debug("Incoming ordinates will{}be swapped.", ((result) ? " " : " not "));
 		return result;
 	}
 
@@ -241,8 +246,8 @@ public class NTv2Transformation extends Transformation {
 				}
 			}
 			catch (IOException e) {
-				LOG.debug("Exception occurred: " + e.getLocalizedMessage(), e);
-				LOG.error("Exception occurred: " + e.getLocalizedMessage());
+				LOG.debug("Exception occurred: {}", e.getLocalizedMessage(), e);
+				LOG.error("Exception occurred: {}", e.getLocalizedMessage());
 			}
 			if (!shift) {
 				StringBuilder sb = new StringBuilder("Could not do ");

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/utilities/MappingUtils.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/utilities/MappingUtils.java
@@ -149,13 +149,14 @@ public class MappingUtils {
 				return reorganizeConcatenate((ConcatenatedTransform) originalChain, tbu);
 			}
 			// rb: what kind of transformation could this probably be???
-			LOG.warn("Could not handle transformation replacement of type:" + originalChain.getImplementationName()
-					+ " ignoring requested transformation: " + tbu.getCodeAndName());
+			LOG.warn("Could not handle transformation replacement of type:{} ignoring requested transformation: {}",
+					originalChain.getImplementationName(), tbu.getCodeAndName());
 
 		}
 		else {
-			LOG.debug("Found no matching (requested) transformation: " + tbu.getCodeAndName()
-					+ " in resulting transform, transformation chain will not be altered.");
+			LOG.debug(
+					"Found no matching (requested) transformation: {} in resulting transform, transformation chain will not be altered.",
+					tbu.getCodeAndName());
 		}
 		// none of the above match.
 		return originalChain;
@@ -174,20 +175,23 @@ public class MappingUtils {
 		Deque<Transformation> chain = new LinkedList<Transformation>();
 		obtainChain(ct, tbu.getSourceCRS(), tbu.getTargetCRS(), chain);
 		if (chain.isEmpty()) {
-			LOG.debug("Found no matching (requested) transformation: " + tbu.getCodeAndName()
-					+ " in concatenated transform, transformation chain will not be altered.");
+			LOG.debug(
+					"Found no matching (requested) transformation: {} in concatenated transform, transformation chain will not be altered.",
+					tbu.getCodeAndName());
 			return ct;
 		}
 		Transformation first = chain.peekFirst();
 		if (first == null || !first.getSourceCRS().equals(tbu.getSourceCRS())) {
-			LOG.debug("Found no matching (requested) transformation: " + tbu.getCodeAndName()
-					+ " in concatenated transform, transformation chain will not be altered.");
+			LOG.debug(
+					"Found no matching (requested) transformation: {} in concatenated transform, transformation chain will not be altered.",
+					tbu.getCodeAndName());
 			return ct;
 		}
 		Transformation last = chain.peekLast();
 		if (last == null || !last.getTargetCRS().equals(tbu.getTargetCRS())) {
-			LOG.debug("Found no matching (requested) transformation: " + tbu.getCodeAndName()
-					+ " in concatenated transform, transformation chain will not be altered.");
+			LOG.debug(
+					"Found no matching (requested) transformation: {} in concatenated transform, transformation chain will not be altered.",
+					tbu.getCodeAndName());
 			return ct;
 		}
 		Queue<Transformation> resultChain = new LinkedList<Transformation>();

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/utilities/Matrix.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/utilities/Matrix.java
@@ -264,9 +264,9 @@ public class Matrix extends GMatrix {
 	 */
 	public static Matrix swapAxis(final ICRS sourceCRS, final ICRS targetCRS) throws TransformationException {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Creating swap matrix from: " + sourceCRS.getCode() + " to: " + targetCRS.getCode());
-			LOG.debug("Source Axis:\n" + Arrays.toString(sourceCRS.getAxis()));
-			LOG.debug("Target Axis:\n" + Arrays.toString(targetCRS.getAxis()));
+			LOG.debug("Creating swap matrix from: {} to: {}", sourceCRS.getCode(), targetCRS.getCode());
+			LOG.debug("Source Axis:\n{}", Arrays.toString(sourceCRS.getAxis()));
+			LOG.debug("Target Axis:\n{}", Arrays.toString(targetCRS.getAxis()));
 		}
 		final Matrix matrix;
 		try {
@@ -290,7 +290,7 @@ public class Matrix extends GMatrix {
 	public static Matrix swapAndRotateGeoAxis(final IGeographicCRS sourceCRS, final IGeographicCRS targetCRS)
 			throws TransformationException {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Creating geo swap/rotate matrix from: " + sourceCRS.getCode() + " to: " + targetCRS.getCode());
+			LOG.debug("Creating geo swap/rotate matrix from: {} to: {}", sourceCRS.getCode(), targetCRS.getCode());
 		}
 		Matrix matrix = swapAxis(sourceCRS, targetCRS);
 		if (!sourceCRS.getGeodeticDatum().getPrimeMeridian().equals(targetCRS.getGeodeticDatum().getPrimeMeridian())) {
@@ -304,7 +304,7 @@ public class Matrix extends GMatrix {
 				// different.
 				final int orientation = targetAxis[i].getOrientation();
 				if (Axis.AO_WEST == Math.abs(orientation)) {
-					LOG.debug("Adding prime-meridian translation to axis:" + targetAxis[i]);
+					LOG.debug("Adding prime-meridian translation to axis:{}", targetAxis[i]);
 					final double sourceLongitude = sourceCRS.getGeodeticDatum()
 						.getPrimeMeridian()
 						.getLongitudeAsRadian();

--- a/deegree-core/deegree-core-cs/src/test/java/org/deegree/cs/transformations/TransformationETRS89RDTest.java
+++ b/deegree-core/deegree-core-cs/src/test/java/org/deegree/cs/transformations/TransformationETRS89RDTest.java
@@ -155,7 +155,7 @@ public class TransformationETRS89RDTest extends TransformationAccuracy {
 		ICRS sourceCRS = CRSManager.lookup("epsg:4258");
 		ICRS targetCRS = CRSManager.lookup("epsg:28992");
 		for (String station : refPoints.keySet()) {
-			LOG.info("\n refence point from station " + station);
+			LOG.info("\n refence point from station {}", station);
 			Pair<Point3d, Point3d> points = refPoints.get(station);
 			doForwardAndInverse(sourceCRS, targetCRS, points.first, points.second, EPSILON_M, EPSILON_M);
 		}

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/lang/MapCall.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/lang/MapCall.java
@@ -101,8 +101,7 @@ public class MapCall {
 					}
 					catch (UnsupportedOperationException e) {
 						LOG.error(
-								"The error '{}' occurred while converting a property to a string, "
-										+ "probably the WKT writer cannot convert a geometry.",
+								"The error '{}' occurred while converting a property to a string, probably the WKT writer cannot convert a geometry.",
 								e.getLocalizedMessage());
 						LOG.debug("Stack trace:", e);
 					}

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/lang/Value.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/lang/Value.java
@@ -59,8 +59,9 @@ public class Value {
 				sb.append(((Property) o).getValue());
 			}
 			catch (UnsupportedOperationException e) {
-				LOG.error("The error '{}' occurred while converting a property to a string, "
-						+ "probably the WKT writer cannot convert a geometry.", e.getLocalizedMessage());
+				LOG.error(
+						"The error '{}' occurred while converting a property to a string, probably the WKT writer cannot convert a geometry.",
+						e.getLocalizedMessage());
 				LOG.debug("Stack trace:", e);
 			}
 		}

--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalDataset.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalDataset.java
@@ -301,9 +301,9 @@ public class GdalDataset implements KeyedResource {
 				byte[] bandBytes = bands[i];
 				if (band.ReadRaster(regionMinX, regionMinY, regionPixelsX, regionPixelsY, targetWidth, targetHeight,
 						GDT_Byte, bandBytes, 0, 0) != CE_None) {
-					LOG.error("GDAL ReadRaster failed: " + regionMinX + "," + regionMinY + "," + regionPixelsX + ","
-							+ regionPixelsY + "," + targetWidth + "," + targetHeight + "," + bandBytes.length + ","
-							+ datasetPixelsX + "," + datasetPixelsY);
+					LOG.error("GDAL ReadRaster failed: {},{},{},{},{},{},{},{},{}", regionMinX, regionMinY,
+							regionPixelsX, regionPixelsY, targetWidth, targetHeight, bandBytes.length, datasetPixelsX,
+							datasetPixelsY);
 					return bands;
 				}
 			}

--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalDatasetPool.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalDatasetPool.java
@@ -101,7 +101,7 @@ public class GdalDatasetPool {
 			pool.close();
 		}
 		catch (Exception e) {
-			LOG.error("Error closing KeyedObjectPool: " + e.getMessage());
+			LOG.error("Error closing KeyedObjectPool: {}", e.getMessage());
 		}
 	}
 

--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalSettings.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/GdalSettings.java
@@ -87,7 +87,7 @@ public class GdalSettings implements Initializable, Destroyable {
 		LOG.info("--------------------------------------------------------------------------------");
 		GDALSettings settings = getGdalConfigOptions(workspace);
 		if (settings == null) {
-			LOG.info("No " + configFileName + " in workspace. Not initializing GDAL JNI adapter.");
+			LOG.info("No {} in workspace. Not initializing GDAL JNI adapter.", configFileName);
 			return;
 		}
 		else {
@@ -99,11 +99,11 @@ public class GdalSettings implements Initializable, Destroyable {
 	private void registerGdal(GDALSettings settings) {
 		if (registerOnceQuietly()) {
 			for (GDALOption gdalConfigOption : settings.getGDALOption()) {
-				LOG.info("GDAL: " + gdalConfigOption.getName() + "=" + gdalConfigOption.getValue().trim());
+				LOG.info("GDAL: {}={}", gdalConfigOption.getName(), gdalConfigOption.getValue().trim());
 				gdal.SetConfigOption(gdalConfigOption.getName(), gdalConfigOption.getValue().trim());
 			}
 			int activeDatasets = settings.getOpenDatasets().intValue();
-			LOG.info("Max number of open GDAL datasets: " + activeDatasets);
+			LOG.info("Max number of open GDAL datasets: {}", activeDatasets);
 			pool = new GdalDatasetPool(activeDatasets);
 		}
 	}
@@ -118,7 +118,7 @@ public class GdalSettings implements Initializable, Destroyable {
 			return true;
 		}
 		catch (Exception e) {
-			LOG.error("Registration of GDAL JNI adapter failed: " + e.getMessage(), e);
+			LOG.error("Registration of GDAL JNI adapter failed: {}", e.getMessage(), e);
 		}
 		return false;
 	}
@@ -130,12 +130,12 @@ public class GdalSettings implements Initializable, Destroyable {
 	private GDALSettings getGdalConfigOptions(final Workspace ws) {
 		File configFile = new File(((DefaultWorkspace) ws).getLocation(), configFileName);
 		if (configFile.exists()) {
-			LOG.info("Using '" + configFileName + "' from workspace for GDAL settings.");
+			LOG.info("Using '{}' from workspace for GDAL settings.", configFileName);
 			try {
 				return readGdalConfigOptions(configFile, ws);
 			}
 			catch (Exception e) {
-				LOG.error("Error reading GDALSettings file: " + e.getMessage());
+				LOG.error("Error reading GDALSettings file: {}", e.getMessage());
 			}
 		}
 		return null;

--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/pool/LimitedKeyedResourcePool.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/pool/LimitedKeyedResourcePool.java
@@ -75,7 +75,7 @@ public class LimitedKeyedResourcePool<T extends KeyedResource> implements Closea
 
 	public T borrow(final String key) throws InterruptedException, IOException {
 
-		LOG.debug("Borrowing resource, key: " + key + ". Total resource count: " + keyTracker);
+		LOG.debug("Borrowing resource, key: {}. Total resource count: {}", key, keyTracker);
 		needResource.lock();
 		T resource = checkForIdleResource(key);
 		if (resource != null) {
@@ -93,7 +93,7 @@ public class LimitedKeyedResourcePool<T extends KeyedResource> implements Closea
 				resource = trashResourceAndAddNew(key, resource);
 			}
 		}
-		LOG.debug("Borrowed resource, key: " + key + ". Total resource count: " + keyTracker);
+		LOG.debug("Borrowed resource, key: {}. Total resource count: {}", key, keyTracker);
 		return resource;
 	}
 
@@ -103,7 +103,7 @@ public class LimitedKeyedResourcePool<T extends KeyedResource> implements Closea
 	}
 
 	private void recycleResource(final T resource) {
-		LOG.debug("Got recycled resource, key: " + resource.getKey());
+		LOG.debug("Got recycled resource, key: {}", resource.getKey());
 		keyTracker.renew(resource.getKey());
 		needResource.unlock();
 	}
@@ -112,18 +112,18 @@ public class LimitedKeyedResourcePool<T extends KeyedResource> implements Closea
 		LOG.debug("Got empty resource slot");
 		keyTracker.add(key);
 		needResource.unlock();
-		LOG.debug("Creating resource, key: " + key);
+		LOG.debug("Creating resource, key: {}", key);
 		return factory.create(key);
 	}
 
 	private T trashResourceAndAddNew(final String key, final T resource) throws IOException {
-		LOG.debug("Got resource to trash, key: " + resource.getKey());
+		LOG.debug("Got resource to trash, key: {}", resource.getKey());
 		keyTracker.remove(resource.getKey());
 		keyTracker.add(key);
 		needResource.unlock();
-		LOG.debug("Destroying resource, key: " + resource.getKey());
+		LOG.debug("Destroying resource, key: {}", resource.getKey());
 		resource.close();
-		LOG.debug("Creating resource, key: " + key);
+		LOG.debug("Creating resource, key: {}", key);
 		return factory.create(key);
 	}
 
@@ -133,7 +133,7 @@ public class LimitedKeyedResourcePool<T extends KeyedResource> implements Closea
 	}
 
 	public void returnObject(final T resource) {
-		LOG.debug("Returning resource, key: " + resource.getKey() + ". Total resource count: " + keyTracker);
+		LOG.debug("Returning resource, key: {}. Total resource count: {}", resource.getKey(), keyTracker);
 		final String key = resource.getKey();
 		final BlockingQueue<T> queue = getQueue(key);
 		queue.add(resource);

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/GeometryTransformer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/GeometryTransformer.java
@@ -446,17 +446,17 @@ public class GeometryTransformer extends Transformer {
 				}
 				catch (IllegalArgumentException e) {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug("No valid domain checking available: " + e.getMessage(), e);
+						LOG.debug("No valid domain checking available: {}", e.getMessage(), e);
 					}
 				}
 				catch (TransformationException e) {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug("No valid domain checking available: " + e.getMessage(), e);
+						LOG.debug("No valid domain checking available: {}", e.getMessage(), e);
 					}
 				}
 				catch (UnknownCRSException e) {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug("No valid domain checking available: " + e.getMessage(), e);
+						LOG.debug("No valid domain checking available: {}", e.getMessage(), e);
 					}
 				}
 			}
@@ -464,15 +464,15 @@ public class GeometryTransformer extends Transformer {
 				result = validDomain.contains(inSource);
 			}
 			catch (UnsupportedOperationException e) {
-				LOG.info("Could not determine valid domain because it is not supported: " + e.getMessage(), e);
+				LOG.info("Could not determine valid domain because it is not supported: {}", e.getMessage(), e);
 				result = true;
 			}
 			catch (IllegalArgumentException e) {
-				LOG.info("Could not determine valid domain because it is not supported: " + e.getMessage(), e);
+				LOG.info("Could not determine valid domain because it is not supported: {}", e.getMessage(), e);
 				result = true;
 			}
 			catch (Throwable t) {
-				LOG.info("No valid domain checking available: " + t.getMessage(), t);
+				LOG.info("No valid domain checking available: {}", t.getMessage(), t);
 				result = false;
 			}
 		}

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/i18n/Messages.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -111,7 +111,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -179,7 +179,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKTWriter.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/io/WKTWriter.java
@@ -1359,7 +1359,7 @@ public class WKTWriter {
 			write(geom, writer);
 		}
 		catch (IOException e) {
-			LOG.error("Error while exporting geometry becauese: " + e.getLocalizedMessage(), e);
+			LOG.error("Error while exporting geometry becauese: {}", e.getLocalizedMessage(), e);
 		}
 		return writer.toString();
 	}

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/SurfaceLinearizer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/linearization/SurfaceLinearizer.java
@@ -130,8 +130,8 @@ public class SurfaceLinearizer {
 			}
 			default: {
 				// TODO
-				LOG.warn("The surface type " + surface.getSurfaceType()
-						+ " currently cannot be linearized. It's being returned as it is.");
+				LOG.warn("The surface type {} currently cannot be linearized. It's being returned as it is.",
+						surface.getSurfaceType());
 				linearizedSurface = surface;
 			}
 		}

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/GeometryFixer.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/GeometryFixer.java
@@ -116,7 +116,7 @@ public class GeometryFixer {
 					fixedSegments.set(fixedSegments.size() - 1, fixedSegment);
 				}
 				else {
-					LOG.warn("Cannot fix " + lastSegment.getSegmentType() + " segments.");
+					LOG.warn("Cannot fix {} segments.", lastSegment.getSegmentType());
 				}
 				fixedCurve = new DefaultCurve(curve.getId(), curve.getCoordinateSystem(), curve.getPrecision(),
 						fixedSegments);
@@ -252,8 +252,9 @@ public class GeometryFixer {
 						points = ((LineStringSegment) curveSegment).getControlPoints();
 						break;
 					default:
-						LOG.warn("Calculating orientation of " + segmentType.name()
-								+ " segments is not implemented yet. Ring orientation remains unchanged.");
+						LOG.warn(
+								"Calculating orientation of {} segments is not implemented yet. Ring orientation remains unchanged.",
+								segmentType.name());
 						return ring;
 				}
 
@@ -310,7 +311,7 @@ public class GeometryFixer {
 				break;
 			}
 			case ARC_BY_BULGE: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
@@ -326,47 +327,47 @@ public class GeometryFixer {
 				break;
 			}
 			case ARC_STRING_BY_BULGE: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case BEZIER: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case BSPLINE: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case CIRCLE: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case CIRCLE_BY_CENTER_POINT: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case CLOTHOID: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case CUBIC_SPLINE: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case GEODESIC: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
 			case GEODESIC_STRING: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}
@@ -376,7 +377,7 @@ public class GeometryFixer {
 				break;
 			}
 			case OFFSET_CURVE: {
-				LOG.warn("Inverting of " + segment.getSegmentType().name() + " segments is not implemented yet.");
+				LOG.warn("Inverting of {} segments is not implemented yet.", segment.getSegmentType().name());
 				fixedSegment = segment;
 				break;
 			}

--- a/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/GeometryValidator.java
+++ b/deegree-core/deegree-core-geometry/src/main/java/org/deegree/geometry/validation/GeometryValidator.java
@@ -429,7 +429,7 @@ public class GeometryValidator {
 			}
 		}
 		catch (Exception e) {
-			LOG.debug("Validation interrupted: " + e.getMessage());
+			LOG.debug("Validation interrupted: {}", e.getMessage());
 		}
 
 		return isValid;

--- a/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization/SurfaceLinearizerTest.java
+++ b/deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization/SurfaceLinearizerTest.java
@@ -92,13 +92,13 @@ public class SurfaceLinearizerTest {
 		LOG.debug("exterior ring:");
 		for (Curve curve : res.getExteriorRing().getMembers()) {
 			for (Point p : curve.getControlPoints()) {
-				LOG.debug(p.get0() + ", " + p.get1());
+				LOG.debug("{}, {}", p.get0(), p.get1());
 			}
 		}
 		for (Points pts : res.getInteriorRingsCoordinates()) {
 			LOG.debug("interior ring:");
 			for (int i = 0; i < pts.size(); i++)
-				LOG.debug(pts.get(i).get0() + ", " + pts.get(i).get1());
+				LOG.debug("{}, {}", pts.get(i).get0(), pts.get(i).get1());
 		}
 	}
 

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/DimensionConfigBuilder.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/config/DimensionConfigBuilder.java
@@ -105,8 +105,7 @@ public class DimensionConfigBuilder {
 			}
 			catch (Exception e) {
 				LOG.warn(
-						"The dimension '{}' has not been added for layer '{}' because the error"
-								+ " '{}' occurred while parsing the extent/default values.",
+						"The dimension '{}' has not been added for layer '{}' because the error '{}' occurred while parsing the extent/default values.",
 						new Object[] { type.getName(), layerName, e.getLocalizedMessage() });
 				continue;
 			}

--- a/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/MetadataRecordFactory.java
+++ b/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/MetadataRecordFactory.java
@@ -173,7 +173,7 @@ public class MetadataRecordFactory {
 				case RegistryPackage:
 					return new RegistryPackage(rootEl);
 				default:
-					LOG.warn("Treating registry object '" + type + "' as generic registry object.");
+					LOG.warn("Treating registry object '{}' as generic registry object.", type);
 					return new RegistryObject(rootEl);
 			}
 		}

--- a/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/i18n/Messages.java
+++ b/deegree-core/deegree-core-metadata/src/main/java/org/deegree/metadata/i18n/Messages.java
@@ -89,8 +89,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -112,7 +112,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -180,7 +180,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/i18n/Messages.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			else {
 				defaultProps.load(is);
@@ -111,7 +111,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeQuietly(is);
@@ -179,7 +179,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/capabilities/AbstractOWSCommonCapabilitiesAdapter.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/capabilities/AbstractOWSCommonCapabilitiesAdapter.java
@@ -372,7 +372,7 @@ abstract class AbstractOWSCommonCapabilitiesAdapter extends XMLAdapter implement
 					values.add(new Value(childEl.getText()));
 				}
 				else {
-					LOG.warn("Unrecognized child element in 'ows:Range': '" + childEl.getQName() + "'.");
+					LOG.warn("Unrecognized child element in 'ows:Range': '{}'.", childEl.getQName());
 				}
 			}
 			possibleValues = new AllowedValues(values);
@@ -435,7 +435,7 @@ abstract class AbstractOWSCommonCapabilitiesAdapter extends XMLAdapter implement
 				closure = CLOSED_OPEN;
 			}
 			else {
-				LOG.warn("Unrecognized range closure: '" + rangeClosureStr + "'.");
+				LOG.warn("Unrecognized range closure: '{}'.", rangeClosureStr);
 			}
 		}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/client/AbstractOWSClient.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/client/AbstractOWSClient.java
@@ -185,19 +185,19 @@ public abstract class AbstractOWSClient<T extends OWSCapabilitiesAdapter> {
 			identification = capaDoc.parseServiceIdentification();
 		}
 		catch (Throwable t) {
-			LOG.warn("Error parsing service identification section: " + t.getMessage());
+			LOG.warn("Error parsing service identification section: {}", t.getMessage());
 		}
 		try {
 			provider = capaDoc.parseServiceProvider();
 		}
 		catch (Throwable t) {
-			LOG.warn("Error parsing service provider section: " + t.getMessage());
+			LOG.warn("Error parsing service provider section: {}", t.getMessage());
 		}
 		try {
 			metadata = capaDoc.parseOperationsMetadata();
 		}
 		catch (Throwable t) {
-			LOG.warn("Error parsing metadata section: " + t.getMessage());
+			LOG.warn("Error parsing metadata section: {}", t.getMessage());
 		}
 	}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpClientImpl.java
@@ -141,7 +141,7 @@ public class OwsHttpClientImpl implements OwsHttpClient {
 			query = new URI(sb.toString());
 			HttpGet httpGet = new HttpGet(query);
 			DefaultHttpClient httpClient = getInitializedHttpClient(endPoint);
-			LOG.debug("Performing GET request: " + query);
+			LOG.debug("Performing GET request: {}", query);
 			HttpResponse httpResponse = httpClient.execute(httpGet);
 			response = new OwsHttpResponseImpl(httpResponse, httpClient.getConnectionManager(), sb.toString());
 		}
@@ -161,8 +161,8 @@ public class OwsHttpClientImpl implements OwsHttpClient {
 		try {
 			HttpPost httpPost = new HttpPost(endPoint.toURI());
 			DefaultHttpClient httpClient = getInitializedHttpClient(endPoint);
-			LOG.debug("Performing POST request on " + endPoint);
-			LOG.debug("post size: " + body.size());
+			LOG.debug("Performing POST request on {}", endPoint);
+			LOG.debug("post size: {}", body.size());
 			InputStreamEntity entity = new InputStreamEntity(body.getInputStream(), (long) body.size());
 			entity.setContentType(contentType);
 			httpPost.setEntity(entity);

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpResponseImpl.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/ows/http/OwsHttpResponseImpl.java
@@ -114,9 +114,9 @@ public class OwsHttpResponseImpl implements OwsHttpResponse {
 	public XMLStreamReader getAsXMLStream() throws OWSExceptionReport, XMLStreamException {
 		XMLStreamReader xmlStream = xmlFac.createXMLStreamReader(url, is);
 		assertNoExceptionReport(xmlStream);
-		LOG.debug("Response root element: " + xmlStream.getName());
+		LOG.debug("Response root element: {}", xmlStream.getName());
 		String version = xmlStream.getAttributeValue(null, "version");
-		LOG.trace("Response version attribute: " + version);
+		LOG.trace("Response version attribute: {}", version);
 		return xmlStream;
 	}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/Process.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/Process.java
@@ -210,9 +210,9 @@ public class Process implements Serializable {
 			URL url = client.getDescribeProcessURL(false);
 
 			if (processInfo.getId().getCodeSpace() != null) {
-				LOG.warn("Performing DescribeProcess using GET, but process identifier ('" + processInfo.getId()
-						+ "') has a code space (which cannot be expressed using the GET binding). "
-						+ "Omitting the code space and hoping for the best...");
+				LOG.warn(
+						"Performing DescribeProcess using GET, but process identifier ('{}') has a code space (which cannot be expressed using the GET binding). Omitting the code space and hoping for the best...",
+						processInfo.getId());
 			}
 
 			String finalURLStr = url.toExternalForm() + "?service=WPS&version="

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessExecution.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/ProcessExecution.java
@@ -202,7 +202,7 @@ public class ProcessExecution extends AbstractProcessExecution {
 			if (statusLocation == null) {
 				throw new RuntimeException("Cannot update status. No statusLocation provided.");
 			}
-			LOG.debug("Polling response document from status location: " + statusLocation);
+			LOG.debug("Polling response document from status location: {}", statusLocation);
 			XMLInputFactory inFactory = XMLInputFactory.newInstance();
 			InputStream is = statusLocation.openStream();
 			XMLStreamReader xmlReader = inFactory.createXMLStreamReader(is);
@@ -309,7 +309,7 @@ public class ProcessExecution extends AbstractProcessExecution {
 			ExecuteRequest100Writer executer = new ExecuteRequest100Writer(logWriter);
 			executer.write100(process.getId(), inputs, responseFormat);
 			logWriter.close();
-			LOG.debug("WPS request can be found at " + logFile);
+			LOG.debug("WPS request can be found at {}", logFile);
 
 			InputStream is = new FileInputStream(logFile);
 			byte[] buffer = new byte[1024];
@@ -361,7 +361,7 @@ public class ProcessExecution extends AbstractProcessExecution {
 			logStream.close();
 
 			responseStream = new FileInputStream(logFile);
-			LOG.debug("WPS response can be found at " + logFile);
+			LOG.debug("WPS response can be found at {}", logFile);
 		}
 
 		// String outputContent = conn.getContentType();

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/RawProcessExecution.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/RawProcessExecution.java
@@ -134,7 +134,7 @@ public class RawProcessExecution extends AbstractProcessExecution {
 			ExecuteRequest100Writer executer = new ExecuteRequest100Writer(logWriter);
 			executer.write100(process.getId(), inputs, responseFormat);
 			logWriter.close();
-			LOG.debug("WPS request can be found at " + logFile);
+			LOG.debug("WPS request can be found at {}", logFile);
 
 			InputStream is = new FileInputStream(logFile);
 			byte[] buffer = new byte[1024];
@@ -166,7 +166,7 @@ public class RawProcessExecution extends AbstractProcessExecution {
 			logStream.close();
 
 			responseStream = new FileInputStream(logFile);
-			LOG.debug("WPS response can be found at " + logFile);
+			LOG.debug("WPS response can be found at {}", logFile);
 		}
 
 		String outputContent = conn.getContentType();

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/execute/ExecutionOutputs.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/process/execute/ExecutionOutputs.java
@@ -63,7 +63,7 @@ public class ExecutionOutputs {
 	 */
 	public ExecutionOutputs(ExecutionOutput[] outputs) {
 		for (ExecutionOutput output : outputs) {
-			LOG.debug("Output: " + output.getId() + ": " + output);
+			LOG.debug("Output: {}: {}", output.getId(), output);
 			paramIdToOutput.put(output.getId(), output);
 		}
 	}

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/wps100/ExecuteResponse100Reader.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wps/client/wps100/ExecuteResponse100Reader.java
@@ -102,7 +102,7 @@ public class ExecuteResponse100Reader {
 		List<ExecutionOutput> outputs = null;
 
 		String statusLocationXMLEncoded = reader.getAttributeValue(null, "statusLocation");
-		LOG.debug("Status location: " + statusLocationXMLEncoded);
+		LOG.debug("Status location: {}", statusLocationXMLEncoded);
 		URL statusLocation = null;
 		if (statusLocationXMLEncoded != null) {
 			statusLocation = new URL(statusLocationXMLEncoded);
@@ -295,7 +295,7 @@ public class ExecuteResponse100Reader {
 					XMLStreamUtils.nextElement(reader);
 				}
 				else {
-					LOG.debug("Response document contains empty complex data output '" + id + "'");
+					LOG.debug("Response document contains empty complex data output '{}'", id);
 				}
 				xmlWriter.writeEndDocument();
 				xmlWriter.close();
@@ -308,8 +308,9 @@ public class ExecuteResponse100Reader {
 					tmpSink.write(bytes);
 				}
 				else {
-					LOG.warn("The encoding of binary data (found at response location " + reader.getLocation()
-							+ ") is not base64. Currently only for this format the decoding can be performed. Skipping the data.");
+					LOG.warn(
+							"The encoding of binary data (found at response location {}) is not base64. Currently only for this format the decoding can be performed. Skipping the data.",
+							reader.getLocation());
 				}
 			}
 			tmpSink.close();

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wpvs/client/WPVSClient.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/src/main/java/org/deegree/protocol/wpvs/client/WPVSClient.java
@@ -110,7 +110,7 @@ public class WPVSClient {
 				String name = capabilities.getNodeAsString(node, xpName, null);
 				if (name != null) {
 					res.add(name);
-					LOG.info("dataset found in GetCapabilities: " + name);
+					LOG.info("dataset found in GetCapabilities: {}", name);
 				}
 			}
 			else

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/client/WFSFeatureCollection.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/main/java/org/deegree/protocol/wfs/client/WFSFeatureCollection.java
@@ -139,8 +139,9 @@ public class WFSFeatureCollection<T> {
 					numberMatched = new BigInteger(numberMatchedAttr);
 				}
 				catch (NumberFormatException e) {
-					LOG.warn("Unable to parse value of 'numberMatched' attribute (='" + numberMatchedAttr
-							+ "'). Neither 'unknown' nor an integer value.");
+					LOG.warn(
+							"Unable to parse value of 'numberMatched' attribute (='{}'). Neither 'unknown' nor an integer value.",
+							numberMatchedAttr);
 				}
 			}
 
@@ -155,8 +156,9 @@ public class WFSFeatureCollection<T> {
 					numberReturned = new BigInteger(numberReturnedAttr);
 				}
 				catch (NumberFormatException e) {
-					LOG.warn("Unable to parse value of 'numberReturned' attribute (='" + numberReturnedAttr
-							+ "'). Neither 'unknown' nor an integer value.");
+					LOG.warn(
+							"Unable to parse value of 'numberReturned' attribute (='{}'). Neither 'unknown' nor an integer value.",
+							numberReturnedAttr);
 				}
 			}
 
@@ -200,8 +202,8 @@ public class WFSFeatureCollection<T> {
 					numberMatched = new BigInteger(numberOfFeaturesAttr);
 				}
 				catch (NumberFormatException e) {
-					LOG.warn("Unable to parse value of 'numberOfFeatures' attribute (='" + numberOfFeaturesAttr
-							+ "'). Not an integer value.");
+					LOG.warn("Unable to parse value of 'numberOfFeatures' attribute (='{}'). Not an integer value.",
+							numberOfFeaturesAttr);
 				}
 			}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/client/WFSClientTest.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/src/test/java/org/deegree/protocol/wfs/client/WFSClientTest.java
@@ -84,7 +84,7 @@ public class WFSClientTest {
 
 		String wfsUtahDemo100Url = TestProperties.getProperty(WFS_UTAH_DEMO_100_URL);
 		if (wfsUtahDemo100Url == null) {
-			LOG.warn("Skipping test, property '" + WFS_UTAH_DEMO_100_URL + "' not found in ~/.deegree-test.properties");
+			LOG.warn("Skipping test, property '{}' not found in ~/.deegree-test.properties", WFS_UTAH_DEMO_100_URL);
 			return;
 		}
 
@@ -115,7 +115,7 @@ public class WFSClientTest {
 
 		String wfsUtahDemo110Url = TestProperties.getProperty(WFS_UTAH_DEMO_110_URL);
 		if (wfsUtahDemo110Url == null) {
-			LOG.warn("Skipping test, property '" + WFS_UTAH_DEMO_110_URL + "' not found in ~/.deegree-test.properties");
+			LOG.warn("Skipping test, property '{}' not found in ~/.deegree-test.properties", WFS_UTAH_DEMO_110_URL);
 			return;
 		}
 
@@ -164,7 +164,7 @@ public class WFSClientTest {
 
 		String wfsUtahDemo110Url = TestProperties.getProperty(WFS_UTAH_DEMO_100_URL);
 		if (wfsUtahDemo110Url == null) {
-			LOG.warn("Skipping test, property '" + WFS_UTAH_DEMO_100_URL + "' not found in ~/.deegree-test.properties");
+			LOG.warn("Skipping test, property '{}' not found in ~/.deegree-test.properties", WFS_UTAH_DEMO_100_URL);
 			return;
 		}
 
@@ -183,7 +183,7 @@ public class WFSClientTest {
 
 		String wfsUtahDemo110Url = TestProperties.getProperty(WFS_UTAH_DEMO_110_URL);
 		if (wfsUtahDemo110Url == null) {
-			LOG.warn("Skipping test, property '" + WFS_UTAH_DEMO_110_URL + "' not found in ~/.deegree-test.properties");
+			LOG.warn("Skipping test, property '{}' not found in ~/.deegree-test.properties", WFS_UTAH_DEMO_110_URL);
 			return;
 		}
 
@@ -201,7 +201,7 @@ public class WFSClientTest {
 
 		String wfsUtahDemo110Url = TestProperties.getProperty(WFS_UTAH_DEMO_110_URL);
 		if (wfsUtahDemo110Url == null) {
-			LOG.warn("Skipping test, property '" + WFS_UTAH_DEMO_110_URL + "' not found in ~/.deegree-test.properties");
+			LOG.warn("Skipping test, property '{}' not found in ~/.deegree-test.properties", WFS_UTAH_DEMO_110_URL);
 			return;
 		}
 
@@ -232,7 +232,7 @@ public class WFSClientTest {
 
 		String wfsUtahDemo110Url = TestProperties.getProperty(WFS_UTAH_DEMO_110_URL);
 		if (wfsUtahDemo110Url == null) {
-			LOG.warn("Skipping test, property '" + WFS_UTAH_DEMO_110_URL + "' not found in ~/.deegree-test.properties");
+			LOG.warn("Skipping test, property '{}' not found in ~/.deegree-test.properties", WFS_UTAH_DEMO_110_URL);
 			return;
 		}
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/client/WMSClient.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/client/WMSClient.java
@@ -607,7 +607,7 @@ public class WMSClient extends AbstractOWSClient<WMSCapabilitiesAdapter> {
 				LOG.debug("Received response.");
 			}
 			catch (Throwable e) {
-				LOG.info("Error performing GetMap request: " + e.getMessage());
+				LOG.info("Error performing GetMap request: {}", e.getMessage());
 				LOG.trace("Stack trace:", e);
 				res.second = e.getMessage();
 			}
@@ -671,7 +671,7 @@ public class WMSClient extends AbstractOWSClient<WMSCapabilitiesAdapter> {
 				throws Exception {
 			url += toQueryString(map);
 			URL theUrl = new URL(url);
-			LOG.debug("Connecting to URL " + theUrl);
+			LOG.debug("Connecting to URL {}", theUrl);
 			URLConnection conn = ProxySettings.openURLConnection(theUrl, ProxySettings.getHttpProxyUser(true),
 					ProxySettings.getHttpProxyPassword(true), httpBasicUser, httpBasicPass);
 			conn.setConnectTimeout(connectionTimeout * 1000);
@@ -679,9 +679,9 @@ public class WMSClient extends AbstractOWSClient<WMSCapabilitiesAdapter> {
 			conn.connect();
 			LOG.debug("Connected.");
 			if (LOG.isTraceEnabled()) {
-				LOG.trace("Requesting from " + theUrl);
-				LOG.trace("Content type is " + conn.getContentType());
-				LOG.trace("Content encoding is " + conn.getContentEncoding());
+				LOG.trace("Requesting from {}", theUrl);
+				LOG.trace("Content type is {}", conn.getContentType());
+				LOG.trace("Content encoding is {}", conn.getContentEncoding());
 			}
 			if (conn.getContentType() != null && conn.getContentType().startsWith(format)) {
 				res.first = IMAGE.work(conn.getInputStream());
@@ -844,7 +844,7 @@ public class WMSClient extends AbstractOWSClient<WMSCapabilitiesAdapter> {
 		String query = url + toQueryString(map);
 
 		URL theUrl = new URL(query);
-		LOG.debug("Connecting to URL " + theUrl);
+		LOG.debug("Connecting to URL {}", theUrl);
 		URLConnection conn = ProxySettings.openURLConnection(theUrl, getHttpProxyUser(true), getHttpProxyPassword(true),
 				httpBasicUser, httpBasicPass);
 		conn.setConnectTimeout(connectionTimeout * 1000);

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetMap.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetMap.java
@@ -802,7 +802,7 @@ public class GetMap extends RequestBase {
 			crsRef = CRSUtils.getAxisAwareCrs(crsRef);
 		}
 		catch (Exception e) {
-			LOG.warn("Unable to determine axis-aware variant of '" + crs + "'. Continuing.");
+			LOG.warn("Unable to determine axis-aware variant of '{}'. Continuing.", crs);
 		}
 		return new GeometryFactory().createEnvelope(bbox[0], bbox[1], bbox[2], bbox[3], crsRef);
 	}

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DTileRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DTileRenderer.java
@@ -97,7 +97,7 @@ public class Java2DTileRenderer implements TileRenderer {
 			graphics.drawImage(tile.getAsImage(), minx, miny, maxx - minx, maxy - miny, null);
 		}
 		catch (TileIOException e) {
-			LOG.debug("Error retrieving tile image: " + e.getMessage());
+			LOG.debug("Error retrieving tile image: {}", e.getMessage());
 			graphics.setColor(RED);
 			graphics.fillRect(minx, miny, maxx - minx, maxy - miny);
 		}

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/labelplacement/AutoLabelPlacement.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/labelplacement/AutoLabelPlacement.java
@@ -88,7 +88,7 @@ public class AutoLabelPlacement {
 				labelPositionsList.add(new PointLabelPositionOptions(l, uomCalculator));
 		}
 
-		LOG.debug("Added " + labelPositionsList.size() + " Labels of " + labelList.size() + " to auto placement");
+		LOG.debug("Added {} Labels of {} to auto placement", labelPositionsList.size(), labelList.size());
 
 		if (labelPositionsList.size() > 1) {
 			buildCollisionMatrix();
@@ -124,7 +124,7 @@ public class AutoLabelPlacement {
 
 		int n = labelPositionsList.size();
 
-		LOG.debug("Starting Annealing with value: " + currentQuality + ", trying to reach: " + (n + 0.8 * 40));
+		LOG.debug("Starting Annealing with value: {}, trying to reach: {}", currentQuality, (n + 0.8 * 40));
 		long now = System.currentTimeMillis();
 
 		while (counter <= 2500 && currentQuality > (n + 0.8 * 40)) {
@@ -173,9 +173,9 @@ public class AutoLabelPlacement {
 
 		long duration = System.currentTimeMillis() - now;
 
-		LOG.debug("Final value: " + currentQuality + ", needed " + counter + " iterations");
-		LOG.debug("Annealing took: " + duration + " ms, ( " + (int) ((double) duration / (double) counter * 1000)
-				+ " µs per iteration  )");
+		LOG.debug("Final value: {}, needed {} iterations", currentQuality, counter);
+		LOG.debug("Annealing took: {} ms, ( {} µs per iteration  )", duration,
+				(int) ((double) duration / (double) counter * 1000));
 	}
 
 	/**
@@ -196,7 +196,7 @@ public class AutoLabelPlacement {
 
 		}
 
-		LOG.debug("Building of collision matrix took: " + (System.currentTimeMillis() - now) + " millis.");
+		LOG.debug("Building of collision matrix took: {} millis.", (System.currentTimeMillis() - now));
 	}
 
 	/**

--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/TextStroke.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/strokes/TextStroke.java
@@ -151,7 +151,7 @@ public class TextStroke implements Stroke {
 			return null;
 		}
 
-		LOG.trace("Rendering the word/gap list: " + wordsToRender);
+		LOG.trace("Rendering the word/gap list: {}", wordsToRender);
 
 		// prepare for second run - now actually doing something
 		// this just iterates over the path and creates the final shape to render.
@@ -477,7 +477,7 @@ public class TextStroke implements Stroke {
 			GeneralPath path = tryWordWise(shape, initialGap);
 			if (path != null) {
 				if (LOG.isDebugEnabled()) {
-					LOG.debug("Rendered text '" + text + "' word wise.");
+					LOG.debug("Rendered text '{}' word wise.", text);
 				}
 				return path;
 			}
@@ -536,7 +536,7 @@ public class TextStroke implements Stroke {
 		}
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Rendered text '" + text + "' character wise.");
+			LOG.debug("Rendered text '{}' character wise.", text);
 		}
 
 		return result;

--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/RasterRendererApplet.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/RasterRendererApplet.java
@@ -105,7 +105,7 @@ public class RasterRendererApplet extends JApplet {
 		try {
 			// LOG.debug( "Loading SE XML..." );
 			URI uri = RasterRendererApplet.class.getResource(fname).toURI();
-			LOG.debug("Loading resource: " + uri);
+			LOG.debug("Loading resource: {}", uri);
 			File f = new File(uri);
 			final XMLInputFactory fac = XMLInputFactory.newInstance();
 			XMLStreamReader in = fac.createXMLStreamReader(f.toString(), new FileInputStream(f));

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -340,8 +340,8 @@ public abstract class AbstractWhereBuilder {
 		SQLOperation sqlOper = null;
 
 		if (op.getMatchAction() != null && op.getMatchAction() != MatchAction.ANY) {
-			LOG.warn("Mapping of operators with matchAction=" + op.getMatchAction()
-					+ " to SQL is not implemented (and probably not possible).");
+			LOG.warn("Mapping of operators with matchAction={} to SQL is not implemented (and probably not possible).",
+					op.getMatchAction());
 		}
 
 		switch (op.getSubType()) {
@@ -509,7 +509,7 @@ public abstract class AbstractWhereBuilder {
 		}
 		else if (pt1 != null && pt2 != null) {
 			if (pt1.getBaseType() != pt2.getBaseType()) {
-				LOG.warn("Comparison on different types (" + pt1 + "/" + pt2 + "). Relying on db type conversion.");
+				LOG.warn("Comparison on different types ({}/{}). Relying on db type conversion.", pt1, pt2);
 			}
 		}
 	}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/function/SQLFunctionManager.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/function/SQLFunctionManager.java
@@ -68,11 +68,11 @@ public class SQLFunctionManager implements Initializable, Destroyable {
 			nameToFunction = new HashMap<String, SQLFunctionProvider>();
 			try {
 				for (SQLFunctionProvider function : functionLoader) {
-					LOG.debug("SQLFunction: " + function + ", name: " + function.getName());
+					LOG.debug("SQLFunction: {}, name: {}", function, function.getName());
 					String name = function.getName().toLowerCase();
 					if (nameToFunction.containsKey(name)) {
-						LOG.error("Multiple SQLFunction instances for name: '" + name + "' on classpath -- omitting '"
-								+ function.getClass().getName() + "'.");
+						LOG.error("Multiple SQLFunction instances for name: '{}' on classpath -- omitting '{}'.", name,
+								function.getClass().getName());
 						continue;
 					}
 					nameToFunction.put(name, function);
@@ -105,7 +105,7 @@ public class SQLFunctionManager implements Initializable, Destroyable {
 				fp.destroy();
 			}
 			catch (Throwable t) {
-				LOG.error("Destroying of SQLFunctionProvider " + fp.getName() + " failed: " + t.getMessage());
+				LOG.error("Destroying of SQLFunctionProvider {} failed: {}", fp.getName(), t.getMessage());
 			}
 		}
 		functionLoader = null;
@@ -123,7 +123,7 @@ public class SQLFunctionManager implements Initializable, Destroyable {
 				fp.init(ws);
 			}
 			catch (Exception t) {
-				LOG.error("Initialization of SQLFunctionProvider " + fp.getName() + " failed: " + t.getMessage());
+				LOG.error("Initialization of SQLFunctionProvider {} failed: {}", fp.getName(), t.getMessage());
 			}
 		}
 	}

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLGeometryConverter.java
@@ -156,8 +156,8 @@ public class MSSQLGeometryConverter implements GeometryParticleConverter {
 		if (literal != null) {
 			ICRS literalCRS = literal.getCoordinateSystem();
 			if (literalCRS != null && !(crs.equals(literalCRS))) {
-				LOG.debug("Need transformed literal geometry for evaluation: " + literalCRS.getAlias() + " -> "
-						+ crs.getAlias());
+				LOG.debug("Need transformed literal geometry for evaluation: {} -> {}", literalCRS.getAlias(),
+						crs.getAlias());
 				try {
 					GeometryTransformer transformer = new GeometryTransformer(crs);
 					transformedLiteral = transformer.transform(literal);

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
@@ -174,8 +174,8 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
 		if (literal != null) {
 			ICRS literalCRS = literal.getCoordinateSystem();
 			if (literalCRS != null && !(crs.equals(literalCRS))) {
-				LOG.debug("Need transformed literal geometry for evaluation: " + literalCRS.getAlias() + " -> "
-						+ crs.getAlias());
+				LOG.debug("Need transformed literal geometry for evaluation: {} -> {}", literalCRS.getAlias(),
+						crs.getAlias());
 				try {
 					GeometryTransformer transformer = new GeometryTransformer(crs);
 					transformedLiteral = transformer.transform(literal);

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
@@ -452,9 +452,8 @@ public class SDOGeometryConverter {
 		}
 
 		if (!ringu.isEmpty()) {
-			LOG.warn("SDO_Geometry with rings of unknown type detected. "
-					+ "Please consider upgrading to the current format using "
-					+ "the SDO_MIGRATE.TO_CURRENT procedure.");
+			LOG.warn(
+					"SDO_Geometry with rings of unknown type detected. Please consider upgrading to the current format using the SDO_MIGRATE.TO_CURRENT procedure.");
 
 			// maps to store spatial relations between rings
 			Map<Ring, Set<Ring>> contained = new HashMap<Ring, Set<Ring>>();

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISDialect.java
@@ -110,20 +110,20 @@ public class PostGISDialect extends AbstractSQLDialect implements SQLDialect {
 
 	private String getUndefinedSrid(String version) {
 		if (version == null || version.startsWith("0.") || version.startsWith("1.")) {
-			LOG.debug("PostGIS version is " + version + " -- SRID identifier for undefined: -1");
+			LOG.debug("PostGIS version is {} -- SRID identifier for undefined: -1", version);
 			return "-1";
 		}
-		LOG.debug("PostGIS version is " + version + " -- SRID identifier for undefined: 0");
+		LOG.debug("PostGIS version is {} -- SRID identifier for undefined: 0", version);
 		return "0";
 	}
 
 	private boolean determineUseLegacyPredicates(String version) {
 		if (version == null || version.startsWith("0.") || version.startsWith("1.0") || version.startsWith("1.1")
 				|| version.startsWith("1.2")) {
-			LOG.debug("PostGIS version is " + version + " -- using legacy (pre-SQL-MM) predicates.");
+			LOG.debug("PostGIS version is {} -- using legacy (pre-SQL-MM) predicates.", version);
 			return true;
 		}
-		LOG.debug("PostGIS version is " + version + " -- using modern (SQL-MM) predicates.");
+		LOG.debug("PostGIS version is {} -- using modern (SQL-MM) predicates.", version);
 		return false;
 	}
 

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISGeometryConverter.java
@@ -141,8 +141,8 @@ public class PostGISGeometryConverter implements GeometryParticleConverter {
 		if (literal != null) {
 			ICRS literalCRS = literal.getCoordinateSystem();
 			if (literalCRS != null && !(crs.equals(literalCRS))) {
-				LOG.debug("Need transformed literal geometry for evaluation: " + literalCRS.getAlias() + " -> "
-						+ crs.getAlias());
+				LOG.debug("Need transformed literal geometry for evaluation: {} -> {}", literalCRS.getAlias(),
+						crs.getAlias());
 				try {
 					GeometryTransformer transformer = new GeometryTransformer(crs);
 					transformedLiteral = transformer.transform(literal);

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/unevaluated/Symbolizer.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/unevaluated/Symbolizer.java
@@ -152,8 +152,9 @@ public class Symbolizer<T extends Styling<T>> {
 		if (n instanceof GenericXMLElement) {
 			GenericXMLElement elem = (GenericXMLElement) n;
 			if (elem.getChildren().isEmpty()) {
-				LOG.warn("The geometry expression in file '{}', line {}, column {} evaluated"
-						+ " to a custom property with no children.", new Object[] { file, line, col });
+				LOG.warn(
+						"The geometry expression in file '{}', line {}, column {} evaluated to a custom property with no children.",
+						new Object[] { file, line, col });
 				return null;
 			}
 			TypedObjectNode maybeGeom = elem.getChildren().get(0);
@@ -195,15 +196,14 @@ public class Symbolizer<T extends Styling<T>> {
 						}
 						else {
 							LOG.warn(
-									"The geometry expression in file '{}', line {}, column {} "
-											+ "evaluated to something where no geometry"
-											+ " could be found. Actual type was '{}'.",
+									"The geometry expression in file '{}', line {}, column {} evaluated to something where no geometry could be found. Actual type was '{}'.",
 									new Object[] { file, line, col, node.getClass() });
 						}
 					}
 					if (geoms.isEmpty()) {
-						LOG.warn("The geometry expression in file '{}', line {}, column {} "
-								+ "evaluated to no geometry could be found.", new Object[] { file, line, col });
+						LOG.warn(
+								"The geometry expression in file '{}', line {}, column {} evaluated to no geometry could be found.",
+								new Object[] { file, line, col });
 					}
 				}
 			}

--- a/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/standard/DefaultWorkspace.java
+++ b/deegree-core/deegree-core-workspace/src/main/java/org/deegree/workspace/standard/DefaultWorkspace.java
@@ -146,7 +146,7 @@ public class DefaultWorkspace implements Workspace {
 				if (states.getState(dep) != Initialized) {
 					states.setState(md.getIdentifier(), Error);
 					String msg = "Dependent resource " + dep + " failed to initialize.";
-					LOG.error("Unable to build resource {}: " + msg, md.getIdentifier());
+					LOG.error("Unable to build resource {}: {}", msg, md.getIdentifier());
 					errors.registerError(md.getIdentifier(), msg);
 					continue outer;
 				}
@@ -250,11 +250,11 @@ public class DefaultWorkspace implements Workspace {
 								urls.add(url);
 								ModuleInfo moduleInfo = ModuleInfo.extractModuleInfo(url);
 								if (moduleInfo != null) {
-									LOG.info(" - " + moduleInfo);
+									LOG.info(" - {}", moduleInfo);
 									wsModules.add(moduleInfo);
 								}
 								else {
-									LOG.info(" - " + fs[i] + " (non-deegree)");
+									LOG.info(" - {} (non-deegree)", fs[i]);
 								}
 							}
 						}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/BBoxTracker.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/BBoxTracker.java
@@ -76,7 +76,7 @@ public class BBoxTracker {
 				bbox = f.getEnvelope();
 			}
 			catch (Exception e) {
-				LOG.warn("Unable to determine bbox of feature with id " + f.getId() + ": " + e.getMessage());
+				LOG.warn("Unable to determine bbox of feature with id {}: {}", f.getId(), e.getMessage());
 			}
 			if (bbox != null) {
 				try {
@@ -94,8 +94,8 @@ public class BBoxTracker {
 					increaseBBoxes.put(f.getName(), bbox);
 				}
 				catch (Throwable t) {
-					LOG.error("Tracking bbox increase failed. Falling back to full recalculation. Error: "
-							+ t.getMessage());
+					LOG.error("Tracking bbox increase failed. Falling back to full recalculation. Error: {}",
+							t.getMessage());
 					recalcFts.add(f.getName());
 				}
 			}
@@ -107,7 +107,7 @@ public class BBoxTracker {
 	 * @param ft feature type to be updated, must not be <code>null</code>
 	 */
 	public void update(QName ft) {
-		LOG.debug("Update on feature type '" + ft + "'. Full bbox recalculation required on commit.");
+		LOG.debug("Update on feature type '{}'. Full bbox recalculation required on commit.", ft);
 		recalcFts.add(ft);
 	}
 
@@ -116,7 +116,7 @@ public class BBoxTracker {
 	 * @param ft feature type to be deleted, must not be <code>null</code>
 	 */
 	public void delete(QName ft) {
-		LOG.debug("Delete on feature type '" + ft + "'. Full bbox recalculation required on commit.");
+		LOG.debug("Delete on feature type '{}'. Full bbox recalculation required on commit.", ft);
 		recalcFts.add(ft);
 	}
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/cache/BBoxPropertiesCache.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/cache/BBoxPropertiesCache.java
@@ -81,11 +81,11 @@ public class BBoxPropertiesCache implements BBoxCache {
 	public BBoxPropertiesCache(File propsFile) throws IOException {
 		this.propsFile = propsFile;
 		if (!propsFile.exists()) {
-			LOG.info("File '" + propsFile.getCanonicalPath() + "' does not exist. Will be created as needed.");
+			LOG.info("File '{}' does not exist. Will be created as needed.", propsFile.getCanonicalPath());
 			return;
 		}
 		if (!propsFile.isFile()) {
-			LOG.error("File '" + propsFile.getCanonicalPath() + "' does not denote a standard file.");
+			LOG.error("File '{}' does not denote a standard file.", propsFile.getCanonicalPath());
 			return;
 		}
 
@@ -149,7 +149,7 @@ public class BBoxPropertiesCache implements BBoxCache {
 			props.store(out, null);
 		}
 		catch (Throwable t) {
-			LOG.warn("Unable to store cached envelopes in file '" + propsFile + "': " + t.getMessage());
+			LOG.warn("Unable to store cached envelopes in file '{}': {}", propsFile, t.getMessage());
 		}
 		finally {
 			IOUtils.closeQuietly(out);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/DefaultLockManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/DefaultLockManager.java
@@ -273,7 +273,7 @@ public class DefaultLockManager implements LockManager {
 					}
 				}
 				catch (SQLException e1) {
-					LOG.warn("Error performing rollback on lock db: " + e.getMessage(), e);
+					LOG.warn("Error performing rollback on lock db: {}", e.getMessage(), e);
 				}
 				throw new FeatureStoreException(e.getMessage(), e);
 			}
@@ -288,7 +288,7 @@ public class DefaultLockManager implements LockManager {
 					}
 				}
 				catch (SQLException e) {
-					LOG.warn("Error resetting auto commit on lock db connection: " + e.getMessage(), e);
+					LOG.warn("Error resetting auto commit on lock db connection: {}", e.getMessage(), e);
 				}
 				close(rs, insertLockstmt, conn, LOG);
 				if (checkStmt != null) {
@@ -296,7 +296,7 @@ public class DefaultLockManager implements LockManager {
 						checkStmt.close();
 					}
 					catch (SQLException e) {
-						LOG.error("Unable to close Statement: " + e.getMessage());
+						LOG.error("Unable to close Statement: {}", e.getMessage());
 					}
 				}
 				if (lockedStmt != null) {
@@ -304,7 +304,7 @@ public class DefaultLockManager implements LockManager {
 						lockedStmt.close();
 					}
 					catch (SQLException e) {
-						LOG.error("Unable to close Statement: " + e.getMessage());
+						LOG.error("Unable to close Statement: {}", e.getMessage());
 					}
 				}
 				if (failedToLockStmt != null) {
@@ -312,7 +312,7 @@ public class DefaultLockManager implements LockManager {
 						failedToLockStmt.close();
 					}
 					catch (SQLException e) {
-						LOG.error("Unable to close Statement: " + e.getMessage());
+						LOG.error("Unable to close Statement: {}", e.getMessage());
 					}
 				}
 			}
@@ -333,7 +333,7 @@ public class DefaultLockManager implements LockManager {
 			final DefaultLockManager manager = this;
 			try {
 				conn = connection.getConnection();
-				LOG.debug("Using connection: " + conn);
+				LOG.debug("Using connection: {}", conn);
 				stmt = conn.createStatement();
 				rs = stmt.executeQuery("SELECT ID,ACQUIRED,EXPIRES FROM LOCKS");
 				lockIter = new ResultSetIterator<Lock>(rs, conn, stmt) {
@@ -492,7 +492,7 @@ public class DefaultLockManager implements LockManager {
 	void releaseExpiredLocks() {
 
 		Timestamp now = new Timestamp(new Date().getTime());
-		LOG.debug("Checking for and removing all locks expired until '" + now + "'");
+		LOG.debug("Checking for and removing all locks expired until '{}'", now);
 		synchronized (this) {
 			Connection conn = null;
 			PreparedStatement stmt = null;
@@ -503,20 +503,20 @@ public class DefaultLockManager implements LockManager {
 						"DELETE FROM LOCKED_FIDS WHERE LOCK_ID IN (SELECT ID FROM LOCKS WHERE EXPIRES <=?)");
 				stmt.setTimestamp(1, now);
 				int deleted = stmt.executeUpdate();
-				LOG.debug("Deleted " + deleted + " row(s) from table LOCKED_FIDS.");
+				LOG.debug("Deleted {} row(s) from table LOCKED_FIDS.", deleted);
 				stmt.close();
 
 				stmt = conn.prepareStatement(
 						"DELETE FROM LOCK_FAILED_FIDS WHERE LOCK_ID IN (SELECT ID FROM LOCKS WHERE EXPIRES <=?)");
 				stmt.setTimestamp(1, now);
 				deleted = stmt.executeUpdate();
-				LOG.debug("Deleted " + deleted + " row(s) from table LOCK_FAILED_FIDS.");
+				LOG.debug("Deleted {} row(s) from table LOCK_FAILED_FIDS.", deleted);
 				stmt.close();
 
 				stmt = conn.prepareStatement("DELETE FROM LOCKS WHERE EXPIRES <=?");
 				stmt.setTimestamp(1, now);
 				deleted = stmt.executeUpdate();
-				LOG.debug("Deleted " + deleted + " row(s) from table LOCKS.");
+				LOG.debug("Deleted {} row(s) from table LOCKS.", deleted);
 			}
 			catch (SQLException e) {
 				String msg = "Could not determine expired locks: " + e.getMessage();

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/LockDbProviderProvider.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/src/main/java/org/deegree/feature/persistence/lock/LockDbProviderProvider.java
@@ -87,7 +87,7 @@ public class LockDbProviderProvider extends ConnectionProviderProvider {
 		List<ResourceMetadata<ConnectionProvider>> list = new ArrayList<ResourceMetadata<ConnectionProvider>>();
 
 		String lockDb = new File(TempFileManager.getBaseDir(), "lockdb").getAbsolutePath();
-		LOG.info("Using '" + lockDb + "' for h2 lock database.");
+		LOG.info("Using '{}' for h2 lock database.", lockDb);
 		String url = "jdbc:h2:" + lockDb;
 
 		ResourceLocation<ConnectionProvider> location = getSyntheticProvider("LOCK_DB", url, "SA", "");

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreBuilder.java
@@ -149,13 +149,13 @@ public class MemoryFeatureStoreBuilder implements ResourceBuilder<FeatureStore> 
 					URL docURL = metadata.getLocation().resolveToFile(datasetFile.getValue().trim()).toURI().toURL();
 					GMLStreamReader gmlStream = GMLInputFactory.createGMLStreamReader(version, docURL);
 					gmlStream.setApplicationSchema(schema);
-					LOG.info("Populating feature store with features from file '" + docURL + "'...");
+					LOG.info("Populating feature store with features from file '{}'...", docURL);
 					FeatureCollection fc = (FeatureCollection) gmlStream.readFeature();
 					gmlStream.getIdContext().resolveLocalRefs();
 
 					FeatureStoreTransaction ta = fs.acquireTransaction();
 					int fids = ta.performInsert(fc, USE_EXISTING).size();
-					LOG.info("Inserted " + fids + " features.");
+					LOG.info("Inserted {} features.", fids);
 					ta.commit();
 				}
 				catch (Exception e) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/main/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTransaction.java
@@ -213,7 +213,7 @@ class MemoryFeatureStoreTransaction implements FeatureStoreTransaction {
 
 		long begin = System.currentTimeMillis();
 		if (fs.getStorageCrs() != null) {
-			LOG.debug("Transforming incoming feature collection to '" + fs.getStorageCrs() + "'");
+			LOG.debug("Transforming incoming feature collection to '{}'", fs.getStorageCrs());
 			try {
 				fc = transformGeometries(fc);
 			}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/DBFReader.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/DBFReader.java
@@ -124,27 +124,27 @@ public class DBFReader {
 
 		int version = getUnsigned(buffer);
 		if (version < 3 || version > 5) {
-			LOG.warn("DBase file is of unsupported version " + version + ". Trying to continue anyway...");
+			LOG.warn("DBase file is of unsupported version {}. Trying to continue anyway...", version);
 		}
 		if (LOG.isTraceEnabled()) {
-			LOG.trace("Version number: " + version);
+			LOG.trace("Version number: {}", version);
 			int year = 1900 + getUnsigned(buffer);
 			int month = getUnsigned(buffer);
 			int day = getUnsigned(buffer);
-			LOG.trace("Last modified: " + year + "/" + month + "/" + day);
+			LOG.trace("Last modified: {}/{}/{}", year, month, day);
 		}
 		else {
 			skipBytes(buffer, 3);
 		}
 
 		noOfRecords = buffer.getInt();
-		LOG.trace("Number of records: " + noOfRecords);
+		LOG.trace("Number of records: {}", noOfRecords);
 
 		headerLength = buffer.getShort();
-		LOG.trace("Length of header: " + headerLength);
+		LOG.trace("Length of header: {}", headerLength);
 
 		recordLength = buffer.getShort();
-		LOG.trace("Record length: " + recordLength);
+		LOG.trace("Record length: {}", recordLength);
 		buffer.position(14);
 		int dirty = getUnsigned(buffer);
 		if (dirty == 1) {
@@ -157,7 +157,7 @@ public class DBFReader {
 
 		if (LOG.isTraceEnabled()) {
 			buffer.position(29);
-			LOG.trace("Language driver code is " + getUnsigned(buffer));
+			LOG.trace("Language driver code is {}", getUnsigned(buffer));
 			skipBytes(buffer, 2);
 		}
 		else {
@@ -203,7 +203,7 @@ public class DBFReader {
 
 			int fieldLength = getUnsigned(buffer);
 			int fieldPrecision = getUnsigned(buffer);
-			LOG.trace("Field length is " + fieldLength + ", type is " + type);
+			LOG.trace("Field length is {}, type is {}", fieldLength, type);
 
 			// using the prefix here is vital for repairing of unqualified property names
 			// in WFS...
@@ -219,7 +219,7 @@ public class DBFReader {
 				case 'C':
 					if (fieldPrecision > 0) {
 						fieldLength += fieldPrecision << 8;
-						LOG.trace("Field length is changed to " + fieldLength + " for text field.");
+						LOG.trace("Field length is changed to {} for text field.", fieldLength);
 					}
 					pt = new SimplePropertyType(ptName, 0, 1, BaseType.STRING, null, null);
 					break;
@@ -250,12 +250,13 @@ public class DBFReader {
 							"Double fields are not supported. Please send the file to the devs, so they can implement it.");
 					break;
 				default:
-					LOG.warn("Exotic field encountered: '" + type
-							+ "'. Please send the file to the devs, so they can have a look.");
+					LOG.warn(
+							"Exotic field encountered: '{}'. Please send the file to the devs, so they can have a look.",
+							type);
 			}
 
-			LOG.trace("Found field with name '" + name + "' and type "
-					+ (pt != null ? pt.getPrimitiveType() : " no supported type."));
+			LOG.trace("Found field with name '{}' and type {}", name,
+					(pt != null ? pt.getPrimitiveType() : " no supported type."));
 
 			fields.put(name, new Field(type, pt, fieldLength));
 			fieldOrder.add(name);
@@ -329,7 +330,7 @@ public class DBFReader {
 			pos = headerLength + (num + 1) * recordLength;
 		}
 		if (getUnsigned(buffer) == 42) {
-			LOG.warn("The record with number " + num + " is marked as deleted.");
+			LOG.warn("The record with number {} is marked as deleted.", num);
 		}
 
 		for (String name : fieldOrder) {
@@ -409,7 +410,7 @@ public class DBFReader {
 				case 'T':
 				case 'O':
 				default:
-					LOG.trace("Skipping unsupported field " + field.propertyType.getName());
+					LOG.trace("Skipping unsupported field {}", field.propertyType.getName());
 			}
 
 			map.put(field.propertyType, property);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/SHPReader.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/SHPReader.java
@@ -315,8 +315,8 @@ public class SHPReader {
 		bbox = fac.createEnvelope(envelope[0], envelope[2], envelope[1], envelope[3], crs);
 
 		if (LOG.isTraceEnabled()) {
-			LOG.trace("Envelope: " + envelope[0] + "," + envelope[1] + " " + envelope[2] + "," + envelope[3] + " "
-					+ envelope[4] + "," + envelope[5] + " " + envelope[6] + "," + envelope[7]);
+			LOG.trace("Envelope: {},{} {},{} {},{} {},{}", envelope[0], envelope[1], envelope[2], envelope[3],
+					envelope[4], envelope[5], envelope[6], envelope[7]);
 		}
 
 	}
@@ -847,7 +847,7 @@ public class SHPReader {
 		int numPoints = buffer.getInt();
 
 		if (LOG.isTraceEnabled()) {
-			LOG.trace("Reading multipatch with " + numParts + " parts and " + numPoints + " points.");
+			LOG.trace("Reading multipatch with {} parts and {} points.", numParts, numPoints);
 		}
 
 		int[] partTypes = new int[numParts];

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/ShapeFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/ShapeFeatureStore.java
@@ -336,7 +336,7 @@ public class ShapeFeatureStore implements FeatureStore {
 				bbox = transformer.transform(bbox);
 			}
 			catch (Exception e) {
-				LOG.error("Transformation of bbox failed: " + e.getMessage(), e);
+				LOG.error("Transformation of bbox failed: {}", e.getMessage(), e);
 			}
 		}
 		return bbox;

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/MappedAppSchema.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/MappedAppSchema.java
@@ -142,7 +142,7 @@ public class MappedAppSchema extends GenericAppSchema {
 		this.blobMapping = blobMapping;
 		this.keyDependencies = new TableDependencies(ftMappings, deleteCascadingByDB);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Key dependencies: " + keyDependencies);
+			LOG.debug("Key dependencies: {}", keyDependencies);
 		}
 		this.relationalModel = relationalModel;
 	}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -219,10 +219,10 @@ public class SQLFeatureStore implements FeatureStore {
 		this.allowInMemoryFiltering = config.getDisablePostFiltering() == null;
 		fetchSize = config.getJDBCConnId().getFetchSize() != null ? config.getJDBCConnId().getFetchSize().intValue()
 				: DEFAULT_FETCH_SIZE;
-		LOG.debug("Fetch size: " + fetchSize);
+		LOG.debug("Fetch size: {}", fetchSize);
 		readAutoCommit = config.getJDBCConnId().isReadAutoCommit() != null ? config.getJDBCConnId().isReadAutoCommit()
 				: !dialect.requiresTransactionForCursorMode();
-		LOG.debug("Read auto commit: " + readAutoCommit);
+		LOG.debug("Read auto commit: {}", readAutoCommit);
 
 		if (config.getFeatureCache() != null) {
 			cache = new SimpleFeatureStoreCache(DEFAULT_CACHE_SIZE);
@@ -512,7 +512,7 @@ public class SQLFeatureStore implements FeatureStore {
 		ResultSet rs = null;
 		try {
 			stmt = conn.createStatement();
-			LOG.debug("Executing envelope SELECT: " + sql);
+			LOG.debug("Executing envelope SELECT: {}", sql);
 			rs = stmt.executeQuery(sql.toString());
 			rs.next();
 			ICRS crs = propMapping.second.getCRS();
@@ -615,7 +615,7 @@ public class SQLFeatureStore implements FeatureStore {
 			stmt.setString(1, id);
 			rs = stmt.executeQuery();
 			if (rs.next()) {
-				LOG.debug("Recreating object '" + id + "' from bytea.");
+				LOG.debug("Recreating object '{}' from bytea.", id);
 				BlobCodec codec = blobMapping.getCodec();
 				geomOrFeature = codec.decode(rs.getBinaryStream(1), getNamespaceContext(), getSchema(),
 						blobMapping.getCRS(), resolver);
@@ -683,7 +683,7 @@ public class SQLFeatureStore implements FeatureStore {
 			transaction.get().getConnection().close();
 		}
 		catch (final SQLException e) {
-			LOG.error("Error closing connection/removing it from the pool: " + e.getMessage());
+			LOG.error("Error closing connection/removing it from the pool: {}", e.getMessage());
 		}
 		finally {
 			transaction.remove();
@@ -833,7 +833,7 @@ public class SQLFeatureStore implements FeatureStore {
 						}
 					}
 
-					LOG.debug("WHERE clause: " + wb.getWhere());
+					LOG.debug("WHERE clause: {}", wb.getWhere());
 					if (wb.getWhere() != null) {
 						sql.append(" WHERE ");
 						sql.append(wb.getWhere().getSQL());
@@ -893,7 +893,7 @@ public class SQLFeatureStore implements FeatureStore {
 			if (query.getPrefilterBBox() != null) {
 				OperatorFilter bboxFilter = new OperatorFilter(query.getPrefilterBBox());
 				wb = getWhereBuilderBlob(bboxFilter, conn);
-				LOG.debug("WHERE clause: " + wb.getWhere());
+				LOG.debug("WHERE clause: {}", wb.getWhere());
 			}
 			String alias = wb != null ? wb.getAliasManager().getRootTableAlias() : "X1";
 
@@ -977,8 +977,8 @@ public class SQLFeatureStore implements FeatureStore {
 		if (literal != null) {
 			ICRS literalCRS = literal.getCoordinateSystem();
 			if (literalCRS != null && !(crs.equals(literalCRS))) {
-				LOG.debug("Need transformed literal geometry for evaluation: " + literalCRS.getAlias() + " -> "
-						+ crs.getAlias());
+				LOG.debug("Need transformed literal geometry for evaluation: {} -> {}", literalCRS.getAlias(),
+						crs.getAlias());
 				try {
 					GeometryTransformer transformer = new GeometryTransformer(crs);
 					transformedLiteral = transformer.transform(literal);
@@ -1152,8 +1152,8 @@ public class SQLFeatureStore implements FeatureStore {
 			}
 		}
 		catch (IllegalArgumentException e) {
-			LOG.warn("No features are returned, as an error occurred during mapping of feature name to id: "
-					+ e.getMessage());
+			LOG.warn("No features are returned, as an error occurred during mapping of feature name to id: {}",
+					e.getMessage());
 			LOG.trace(e.getMessage(), e);
 			return new EmptyFeatureInputStream();
 		}
@@ -1285,7 +1285,7 @@ public class SQLFeatureStore implements FeatureStore {
 			if (query.getPrefilterBBox() != null) {
 				OperatorFilter bboxFilter = new OperatorFilter(query.getPrefilterBBox());
 				wb = getWhereBuilderBlob(bboxFilter, conn);
-				LOG.debug("WHERE clause: " + wb.getWhere());
+				LOG.debug("WHERE clause: {}", wb.getWhere());
 			}
 			String alias = wb != null ? wb.getAliasManager().getRootTableAlias() : "X1";
 
@@ -1442,8 +1442,8 @@ public class SQLFeatureStore implements FeatureStore {
 			wb = getWhereBuilder(featureTypeAndMappings.values(), filter, query.getSortProperties(),
 					query.isHandleStrict());
 			TableAliasManager aliasManager = wb.getAliasManager();
-			LOG.debug("WHERE clause: " + wb.getWhere());
-			LOG.debug("ORDER BY clause: " + wb.getOrderBy());
+			LOG.debug("WHERE clause: {}", wb.getWhere());
+			LOG.debug("ORDER BY clause: {}", wb.getOrderBy());
 
 			FeatureBuilder builder = new FeatureBuilderRelational(this, featureTypeAndMappings, conn, aliasManager,
 					nullEscalation);
@@ -1807,7 +1807,7 @@ public class SQLFeatureStore implements FeatureStore {
 		if (config.getInspectors() != null) {
 			for (CustomInspector inspectorConfig : config.getInspectors().getCustomInspector()) {
 				String className = inspectorConfig.getClazz();
-				LOG.info("Adding custom feature inspector '" + className + "' to inspector chain.");
+				LOG.info("Adding custom feature inspector '{}' to inspector chain.", className);
 				try {
 					@SuppressWarnings("unchecked")
 					Class<FeatureInspector> inspectorClass = (Class<FeatureInspector>) workspace.getModuleClassLoader()

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/BlobCodec.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/BlobCodec.java
@@ -152,7 +152,7 @@ public class BlobCodec {
 			gmlWriter.write(object);
 			gmlWriter.close();
 			os.close();
-			LOG.debug("Wrote encoded feature to '" + file.getAbsolutePath() + "'");
+			LOG.debug("Wrote encoded feature to '{}'", file.getAbsolutePath());
 		}
 		LOG.debug("Encoding feature (compression: {}) took {} [ms]", compression, System.currentTimeMillis() - begin);
 	}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/FeatureBuilderBlob.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/FeatureBuilderBlob.java
@@ -107,7 +107,7 @@ public class FeatureBuilderBlob implements FeatureBuilder {
 				feature = (Feature) fs.getCache().get(gmlId);
 			}
 			if (feature == null) {
-				LOG.debug("Recreating object '" + gmlId + "' from db (BLOB/hybrid mode).");
+				LOG.debug("Recreating object '{}' from db (BLOB/hybrid mode).", gmlId);
 				feature = (Feature) codec.decode(rs.getBinaryStream(2), fs.getNamespaceContext(), fs.getSchema(), crs,
 						fs.getResolver());
 				if (fs.getCache() != null) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/AbstractMappedSchemaBuilder.java
@@ -194,7 +194,7 @@ public abstract class AbstractMappedSchemaBuilder {
 		else if ("GEOMETRYCOLLECTION".equals(pgType)) {
 			return MULTI_GEOMETRY;
 		}
-		LOG.warn("Unknown PostGIS geometry type '" + pgType + "'. Interpreting as generic geometry.");
+		LOG.warn("Unknown PostGIS geometry type '{}'. Interpreting as generic geometry.", pgType);
 		return GEOMETRY;
 	}
 
@@ -209,7 +209,7 @@ public abstract class AbstractMappedSchemaBuilder {
 				mapping = parser.mappingExpr().value;
 			}
 			catch (RecognitionException e) {
-				LOG.warn("Unable to parse mapping expression '" + s + "': treating as SQL expression");
+				LOG.warn("Unable to parse mapping expression '{}': treating as SQL expression", s);
 				return new Function(s);
 			}
 		}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderGML.java
@@ -184,7 +184,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 			String prefix = userHint.getPrefix();
 			String oldPrefix = nsBindings.getPrefix(nsUri);
 			if (oldPrefix != null && !oldPrefix.equals(prefix)) {
-				LOG.warn("Multiple prefices for namespace '" + nsUri + "': " + prefix + " / " + oldPrefix);
+				LOG.warn("Multiple prefices for namespace '{}': {} / {}", nsUri, prefix, oldPrefix);
 			}
 			else {
 				nsBindings.addNamespace(prefix, nsUri);
@@ -194,7 +194,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 		// Namespace bindings from config file
 		InputStream is = null;
 		try {
-			LOG.debug("Scanning config file '" + componentLocation + "' for namespace bindings");
+			LOG.debug("Scanning config file '{}' for namespace bindings", componentLocation);
 			is = new URL(componentLocation).openStream();
 			XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader(is);
 			while (xmlStream.next() != END_DOCUMENT) {
@@ -205,8 +205,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 							String nsUri = xmlStream.getNamespaceURI(i);
 							String oldPrefix = nsBindings.getPrefix(nsUri);
 							if (oldPrefix != null && !oldPrefix.equals(prefix)) {
-								LOG.debug("Multiple prefices for namespace '" + nsUri + "': " + prefix + " / "
-										+ oldPrefix);
+								LOG.debug("Multiple prefices for namespace '{}': {} / {}", nsUri, prefix, oldPrefix);
 							}
 							else {
 								nsBindings.addNamespace(prefix, nsUri);
@@ -217,7 +216,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 			}
 		}
 		catch (Exception e) {
-			LOG.error("Error determining namespaces from config file '" + componentLocation + "': " + e.getMessage());
+			LOG.error("Error determining namespaces from config file '{}': {}", componentLocation, e.getMessage());
 		}
 		finally {
 			if (is != null) {
@@ -236,7 +235,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 			String nsUri = schemaNSBindings.get(prefix);
 			String oldPrefix = nsBindings.getPrefix(nsUri);
 			if (oldPrefix != null && !oldPrefix.equals(prefix)) {
-				LOG.warn("Multiple prefices for namespace '" + nsUri + "': " + prefix + " / " + oldPrefix);
+				LOG.warn("Multiple prefices for namespace '{}': {} / {}", nsUri, prefix, oldPrefix);
 			}
 			else {
 				nsBindings.addNamespace(prefix, nsUri);
@@ -250,7 +249,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 			String nsUri = schemaNSBindings.get(prefix);
 			String oldPrefix = nsBindings.getPrefix(nsUri);
 			if (oldPrefix != null && !oldPrefix.equals(prefix)) {
-				LOG.warn("Multiple prefices for namespace '" + nsUri + "': " + prefix + " / " + oldPrefix);
+				LOG.warn("Multiple prefices for namespace '{}': {} / {}", nsUri, prefix, oldPrefix);
 			}
 			else {
 				nsBindings.addNamespace(prefix, nsUri);
@@ -310,7 +309,7 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 			String msg = "Error building GML application schema: " + t.getMessage();
 			throw new FeatureStoreException(msg);
 		}
-		LOG.debug("GML version: " + appSchema.getGMLSchema().getVersion());
+		LOG.debug("GML version: {}", appSchema.getGMLSchema().getVersion());
 		return appSchema;
 	}
 
@@ -401,14 +400,13 @@ public class MappedSchemaBuilderGML extends AbstractMappedSchemaBuilder {
 
 		if (config.getType() != null) {
 			PrimitiveType forcedType = new PrimitiveType(getPrimitiveType(config.getType()));
-			LOG.debug(
-					"Overriding schema-derived primitive type '" + pt.getFirst() + "'. Forcing '" + forcedType + "'.");
+			LOG.debug("Overriding schema-derived primitive type '{}'. Forcing '{}'.", pt.getFirst(), forcedType);
 			pt.first = forcedType;
 		}
 
 		MappingExpression me = parseMappingExpression(config.getMapping());
 		List<TableJoin> joinedTable = buildJoinTable(currentTable, config.getJoin());
-		LOG.debug("Targeted primitive type: " + pt);
+		LOG.debug("Targeted primitive type: {}", pt);
 		boolean escalateVoid = determineParticleVoidability(pt.second, config.getNullEscalation());
 		return new PrimitiveMapping(path, escalateVoid, me, pt.first, joinedTable, config.getCustomConverter());
 	}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTable.java
@@ -177,7 +177,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 		}
 
 		TableName table = new TableName(ftDecl.getTable());
-		LOG.debug("Processing feature type mapping for table '" + table + "'.");
+		LOG.debug("Processing feature type mapping for table '{}'.", table);
 		if (getColumnMetadataFromDb(table).isEmpty()) {
 			throw new FeatureStoreException("No table with name '" + table + "' exists (or no columns defined).");
 		}
@@ -188,7 +188,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 			ftName = new QName(table.getTable());
 		}
 		ftName = makeFullyQualified(ftName, "app", "http://www.deegree.org/app");
-		LOG.debug("Feature type name: '" + ftName + "'.");
+		LOG.debug("Feature type name: '{}'.", ftName);
 
 		FIDMapping fidMapping = buildFIDMapping(table, ftName, ftDecl.getFIDMapping());
 
@@ -205,7 +205,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 	private void buildFeatureTypeAndMapping(TableName table, QName ftName, FIDMapping fidMapping,
 			List<SortCriterion> sortCriteria) throws SQLException {
 
-		LOG.debug("Deriving properties and mapping for feature type '" + ftName + "' from table '" + table + "'");
+		LOG.debug("Deriving properties and mapping for feature type '{}' from table '{}'", ftName, table);
 
 		List<PropertyType> pts = new ArrayList<PropertyType>();
 		List<Mapping> mappings = new ArrayList<Mapping>();
@@ -217,7 +217,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 
 		for (ColumnMetadata md : getColumnMetadataFromDb(table).values()) {
 			if (fidColumnNames.contains(new SQLIdentifier(md.column.toLowerCase()))) {
-				LOG.debug("Omitting column '" + md.column + "' from properties. Used in FIDMapping.");
+				LOG.debug("Omitting column '{}' from properties. Used in FIDMapping.", md.column);
 				continue;
 			}
 
@@ -235,8 +235,8 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 					mappings.add(mapping);
 				}
 				catch (IllegalArgumentException e) {
-					LOG.warn("Skipping column with type code '" + md.sqlType + "' from list of properties:"
-							+ e.getMessage());
+					LOG.warn("Skipping column with type code '{}' from list of properties:{}", md.sqlType,
+							e.getMessage());
 				}
 			}
 			else {
@@ -384,7 +384,7 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 			m = new GeometryMapping(path, minOccurs == 0, mapping, type, new GeometryStorageParams(crs, srid, dim), jc);
 		}
 		else {
-			LOG.warn("Unhandled property declaration '" + propDecl.getClass() + "'. Skipping it.");
+			LOG.warn("Unhandled property declaration '{}'. Skipping it.", propDecl.getClass());
 		}
 		return new Pair<PropertyType, Mapping>(pt, m);
 	}
@@ -506,8 +506,9 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 					catch (Throwable t) {
 						// thanks to Larry E. for this
 					}
-					LOG.debug("Found column '" + column + "', typeName: '" + sqlTypeName + "', typeCode: '" + sqlType
-							+ "', isNullable: '" + isNullable + "', isAutoincrement:' " + isAutoincrement + "'");
+					LOG.debug(
+							"Found column '{}', typeName: '{}', typeCode: '{}', isNullable: '{}', isAutoincrement:' {}'",
+							column, sqlTypeName, sqlType, isNullable, isAutoincrement);
 
 					// type name ("geometry") works for PostGIS, MSSQL and Oracle
 					if (sqlTypeName.toLowerCase().contains("geometry")) {
@@ -531,17 +532,16 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 									dim = DIM_3;
 								}
 								geomType = getGeometryType(rs2.getString(3));
-								LOG.debug("Derived geometry type: " + geomType + ", srid: " + srid + ", dim: " + dim
-										+ "");
+								LOG.debug("Derived geometry type: {}, srid: {}, dim: {}", geomType, srid, dim);
 							}
 							else {
-								LOG.debug("No metadata for geometry column '" + column
-										+ "' available in DB. Using defaults.");
+								LOG.debug("No metadata for geometry column '{}' available in DB. Using defaults.",
+										column);
 							}
 						}
 						catch (Exception e) {
-							LOG.warn("Unable to determine geometry column details: " + e.getMessage()
-									+ ". Using defaults.", e);
+							LOG.warn("Unable to determine geometry column details: {}. Using defaults.", e.getMessage(),
+									e);
 						}
 						finally {
 							JDBCUtils.close(rs2, stmt, null, LOG);
@@ -573,17 +573,17 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 									dim = DIM_3;
 								}
 								geomType = getGeometryType(rs2.getString(3).toUpperCase());
-								LOG.debug("Derived geometry type (geography): " + geomType + ", srid: " + srid
-										+ ", dim: " + dim + "");
+								LOG.debug("Derived geometry type (geography): {}, srid: {}, dim: {}", geomType, srid,
+										dim);
 							}
 							else {
-								LOG.warn("No metadata for geography column '" + column
-										+ "' available in DB. Using defaults.");
+								LOG.warn("No metadata for geography column '{}' available in DB. Using defaults.",
+										column);
 							}
 						}
 						catch (Exception e) {
-							LOG.warn("Unable to determine geography column details: " + e.getMessage()
-									+ ". Using defaults.", e);
+							LOG.warn("Unable to determine geography column details: {}. Using defaults.",
+									e.getMessage(), e);
 						}
 						finally {
 							JDBCUtils.close(rs2, stmt, null, LOG);
@@ -609,13 +609,14 @@ public class MappedSchemaBuilderTable extends AbstractMappedSchemaBuilder {
 	}
 
 	private ICRS deriveCrs(String srid) {
-		LOG.debug("Deriving CRS from database SRID ('" + srid + "').");
+		LOG.debug("Deriving CRS from database SRID ('{}').", srid);
 		try {
 			return lookup("EPSG:" + srid, true);
 		}
 		catch (UnknownCRSException e) {
-			LOG.error("Deriving CRS from database SRID ('" + srid
-					+ "') failed. Use StorageCRS option to configure CRS explicitly.");
+			LOG.error(
+					"Deriving CRS from database SRID ('{}') failed. Use StorageCRS option to configure CRS explicitly.",
+					srid);
 		}
 		try {
 			LOG.warn("Defaulting to EPSG:4326.");

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTableOld.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/MappedSchemaBuilderTableOld.java
@@ -180,7 +180,7 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 		}
 
 		TableName table = new TableName(ftDecl.getTable());
-		LOG.debug("Processing feature type mapping for table '" + table + "'.");
+		LOG.debug("Processing feature type mapping for table '{}'.", table);
 		if (getColumns(table).isEmpty()) {
 			throw new FeatureStoreException("No table with name '" + table + "' exists (or no columns defined).");
 		}
@@ -191,7 +191,7 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 			ftName = new QName(table.getTable());
 		}
 		ftName = makeFullyQualified(ftName, "app", "http://www.deegree.org/app");
-		LOG.debug("Feature type name: '" + ftName + "'.");
+		LOG.debug("Feature type name: '{}'.", ftName);
 
 		FIDMapping fidMapping = buildFIDMapping(table, ftName, ftDecl.getFIDMapping());
 
@@ -206,7 +206,7 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 
 	private void process(TableName table, QName ftName, FIDMapping fidMapping) throws SQLException {
 
-		LOG.debug("Deriving properties and mapping for feature type '" + ftName + "' from table '" + table + "'");
+		LOG.debug("Deriving properties and mapping for feature type '{}' from table '{}'", ftName, table);
 
 		List<PropertyType> pts = new ArrayList<PropertyType>();
 		List<Mapping> mappings = new ArrayList<Mapping>();
@@ -218,7 +218,7 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 
 		for (ColumnMetadataOld md : getColumns(table).values()) {
 			if (fidColumnNames.contains(new SQLIdentifier(md.column.toLowerCase()))) {
-				LOG.debug("Omitting column '" + md.column + "' from properties. Used in FIDMapping.");
+				LOG.debug("Omitting column '{}' from properties. Used in FIDMapping.", md.column);
 				continue;
 			}
 
@@ -236,8 +236,8 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 					mappings.add(mapping);
 				}
 				catch (IllegalArgumentException e) {
-					LOG.warn("Skipping column with type code '" + md.sqlType + "' from list of properties:"
-							+ e.getMessage());
+					LOG.warn("Skipping column with type code '{}' from list of properties:{}", md.sqlType,
+							e.getMessage());
 				}
 			}
 			else {
@@ -365,7 +365,7 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 			m = new GeometryMapping(path, minOccurs == 0, mapping, type, new GeometryStorageParams(crs, srid, dim), jc);
 		}
 		else {
-			LOG.warn("Unhandled property declaration '" + propDecl.getClass() + "'. Skipping it.");
+			LOG.warn("Unhandled property declaration '{}'. Skipping it.", propDecl.getClass());
 		}
 		return new Pair<PropertyType, Mapping>(pt, m);
 	}
@@ -473,8 +473,9 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 					catch (Throwable t) {
 						// thanks to Larry E. for this
 					}
-					LOG.debug("Found column '" + column + "', typeName: '" + sqlTypeName + "', typeCode: '" + sqlType
-							+ "', isNullable: '" + isNullable + "', isAutoincrement:' " + isAutoincrement + "'");
+					LOG.debug(
+							"Found column '{}', typeName: '{}', typeCode: '{}', isNullable: '{}', isAutoincrement:' {}'",
+							column, sqlTypeName, sqlType, isNullable, isAutoincrement);
 
 					// type name works for PostGIS, MSSQL and Oracle
 					if (sqlTypeName.toLowerCase().contains("geometry")) {
@@ -500,17 +501,17 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 									dim = DIM_3;
 								}
 								geomType = getGeometryType(rs2.getString(3));
-								LOG.debug("Derived geometry type: " + geomType + ", crs: " + crs + ", srid: " + srid
-										+ ", dim: " + dim + "");
+								LOG.debug("Derived geometry type: {}, crs: {}, srid: {}, dim: {}", geomType, crs, srid,
+										dim);
 							}
 							else {
-								LOG.warn("No metadata for geometry column '" + column
-										+ "' available in DB. Using defaults.");
+								LOG.warn("No metadata for geometry column '{}' available in DB. Using defaults.",
+										column);
 							}
 						}
 						catch (Exception e) {
-							LOG.warn("Unable to determine geometry column details: " + e.getMessage()
-									+ ". Using defaults.", e);
+							LOG.warn("Unable to determine geometry column details: {}. Using defaults.", e.getMessage(),
+									e);
 						}
 						finally {
 							JDBCUtils.close(rs2, stmt, null, LOG);
@@ -544,17 +545,17 @@ public class MappedSchemaBuilderTableOld extends AbstractMappedSchemaBuilder {
 									dim = DIM_3;
 								}
 								geomType = getGeometryType(rs2.getString(3).toUpperCase());
-								LOG.debug("Derived geometry type (geography): " + geomType + ", crs: " + crs
-										+ ", srid: " + srid + ", dim: " + dim + "");
+								LOG.debug("Derived geometry type (geography): {}, crs: {}, srid: {}, dim: {}", geomType,
+										crs, srid, dim);
 							}
 							else {
-								LOG.warn("No metadata for geography column '" + column
-										+ "' available in DB. Using defaults.");
+								LOG.warn("No metadata for geography column '{}' available in DB. Using defaults.",
+										column);
 							}
 						}
 						catch (Exception e) {
-							LOG.warn("Unable to determine geography column details: " + e.getMessage()
-									+ ". Using defaults.", e);
+							LOG.warn("Unable to determine geography column details: {}. Using defaults.",
+									e.getMessage(), e);
 						}
 						finally {
 							JDBCUtils.close(rs2, stmt, null, LOG);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/config/SQLFeatureStoreConfigWriter.java
@@ -189,7 +189,7 @@ public class SQLFeatureStoreConfigWriter {
 
 	private void writeFeatureTypeMapping(XMLStreamWriter writer, FeatureType ft) throws XMLStreamException {
 
-		LOG.debug("Feature type '" + ft.getName() + "'");
+		LOG.debug("Feature type '{}'", ft.getName());
 		FeatureTypeMapping ftMapping = schema.getFtMapping(ft.getName());
 
 		writer.writeStartElement(CONFIG_NS, "FeatureTypeMapping");
@@ -302,7 +302,7 @@ public class SQLFeatureStoreConfigWriter {
 			writer.writeEndElement();
 		}
 		else {
-			LOG.warn("Unhandled mapping particle " + particle.getClass().getName());
+			LOG.warn("Unhandled mapping particle {}", particle.getClass().getName());
 		}
 	}
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/IdAnalyzer.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/IdAnalyzer.java
@@ -76,7 +76,7 @@ public class IdAnalyzer {
 				if (ftMapping != null) {
 					FIDMapping fidMapping = ftMapping.getFidMapping();
 					if (fidMapping != null) {
-						LOG.debug(fidMapping.getPrefix() + " -> " + ft.getName());
+						LOG.debug("{} -> {}", fidMapping.getPrefix(), ft.getName());
 						prefixToFt.put(fidMapping.getPrefix(), ft);
 					}
 				}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/TableDependencies.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/id/TableDependencies.java
@@ -142,7 +142,7 @@ public class TableDependencies {
 		Set<SQLIdentifier> generatedColumns = tableToGenerators.get(currentTable);
 		if (generatedColumns != null && generatedColumns.containsAll(fromColumns)) {
 			KeyPropagation prop = new KeyPropagation(join.getFromTable(), fromColumns, joinTable, toColumns);
-			LOG.debug("Found key propagation (to join table): " + prop);
+			LOG.debug("Found key propagation (to join table): {}", prop);
 			addChild(currentTable, prop);
 			addParent(joinTable, prop);
 			found = true;
@@ -158,7 +158,7 @@ public class TableDependencies {
 			}
 			if (generatedColumnsJoinTable.containsAll(toColumns)) {
 				KeyPropagation prop = new KeyPropagation(joinTable, toColumns, join.getFromTable(), fromColumns);
-				LOG.debug("Found key propagation (from join table): " + prop);
+				LOG.debug("Found key propagation (from join table): {}", prop);
 				addChild(joinTable, prop);
 				addParent(currentTable, prop);
 				found = true;
@@ -176,7 +176,7 @@ public class TableDependencies {
 		List<SQLIdentifier> toColumns = join.getToColumns();
 		TableName joinTable = join.getToTable();
 		KeyPropagation prop = new KeyPropagation(join.getFromTable(), fromColumns, joinTable, toColumns);
-		LOG.debug("Found key propagation (to join table): " + prop);
+		LOG.debug("Found key propagation (to join table): {}", prop);
 		addChild(currentTable, prop);
 		addParent(joinTable, prop);
 		for (SQLIdentifier fromColumn : fromColumns) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRow.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRow.java
@@ -92,19 +92,19 @@ public abstract class InsertRow extends TransactionRow {
 				IDGenerator idGenerator = keyColumnToGenerator.get(autoKeyColumn);
 				if (idGenerator instanceof SequenceIDGenerator) {
 					int seqVal = getSequenceNextVal(((SequenceIDGenerator) idGenerator).getSequence());
-					LOG.debug("Got key value for column '" + autoKeyColumn.getName() + "' from sequence: " + seqVal);
+					LOG.debug("Got key value for column '{}' from sequence: {}", autoKeyColumn.getName(), seqVal);
 					addPreparedArgument(autoKeyColumn, seqVal);
 				}
 				else if (idGenerator instanceof UUIDGenerator) {
 					String uuid = UUID.randomUUID().toString();
-					LOG.debug("Got key value for column '" + autoKeyColumn.getName() + "' from UUID: " + uuid);
+					LOG.debug("Got key value for column '{}' from UUID: {}", autoKeyColumn.getName(), uuid);
 					addPreparedArgument(autoKeyColumn, uuid);
 				}
 				else if (idGenerator instanceof AutoIDGenerator) {
-					LOG.debug("Key for column '" + autoKeyColumn.getName() + "' will be generated on insert by DB.");
+					LOG.debug("Key for column '{}' will be generated on insert by DB.", autoKeyColumn.getName());
 				}
 				else {
-					LOG.warn("Unhandled ID generator: " + idGenerator.getClass().getName());
+					LOG.warn("Unhandled ID generator: {}", idGenerator.getClass().getName());
 				}
 			}
 		}
@@ -116,7 +116,7 @@ public abstract class InsertRow extends TransactionRow {
 		ResultSet rs = null;
 		try {
 			stmt = mgr.getConnection().createStatement();
-			LOG.debug("Determing feature ID from db sequence: " + sql);
+			LOG.debug("Determing feature ID from db sequence: {}", sql);
 			rs = stmt.executeQuery(sql);
 			if (rs.next()) {
 				return rs.getInt(1);
@@ -189,7 +189,7 @@ public abstract class InsertRow extends TransactionRow {
 			throws SQLException, FeatureStoreException {
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Inserting row: " + this);
+			LOG.debug("Inserting row: {}", this);
 		}
 
 		String sql = getSql();
@@ -215,8 +215,7 @@ public abstract class InsertRow extends TransactionRow {
 		int columnId = 1;
 		for (Entry<SQLIdentifier, Object> entry : columnToObject.entrySet()) {
 			if (entry.getValue() != null) {
-				LOG.debug("- Argument " + entry.getKey() + " = " + entry.getValue() + " (" + entry.getValue().getClass()
-						+ ")");
+				LOG.debug("- Argument {} = {} ({})", entry.getKey(), entry.getValue(), entry.getValue().getClass());
 				if (entry.getValue() instanceof ParticleConversion<?>) {
 					ParticleConversion<?> conversion = (ParticleConversion<?>) entry.getValue();
 					conversion.setParticle(stmt, columnId++);
@@ -226,7 +225,7 @@ public abstract class InsertRow extends TransactionRow {
 				}
 			}
 			else {
-				LOG.debug("- Argument " + entry.getKey() + " = NULL");
+				LOG.debug("- Argument {} = NULL", entry.getKey());
 				stmt.setObject(columnId++, null);
 			}
 		}
@@ -241,7 +240,7 @@ public abstract class InsertRow extends TransactionRow {
 					for (SQLIdentifier autoGenCol : autoGenColumns) {
 						Object keyValue = rs.getObject(i++);
 						columnToObject.put(autoGenCol, keyValue);
-						LOG.debug("Retrieved auto generated key: " + autoGenCol + "=" + keyValue);
+						LOG.debug("Retrieved auto generated key: {}={}", autoGenCol, keyValue);
 					}
 				}
 				else {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/insert/InsertRowManager.java
@@ -164,7 +164,7 @@ public class InsertRowManager {
 				buildInsertRows(feature, particleMapping, featureRow, allRows);
 			}
 
-			LOG.debug("Built rows for feature '" + feature.getId() + "': " + allRows.size());
+			LOG.debug("Built rows for feature '{}': {}", feature.getId(), allRows.size());
 
 			for (InsertRow insertRow : allRows) {
 				if (!insertRow.hasParents()) {
@@ -172,9 +172,9 @@ public class InsertRowManager {
 				}
 			}
 
-			LOG.debug("Before heap run: uninserted rows: " + delayedRows.size() + ", root rows: " + rootRows.size());
+			LOG.debug("Before heap run: uninserted rows: {}, root rows: {}", delayedRows.size(), rootRows.size());
 			processHeap();
-			LOG.debug("After heap run: uninserted rows: " + delayedRows.size() + ", root rows: " + rootRows.size());
+			LOG.debug("After heap run: uninserted rows: {}, root rows: {}", delayedRows.size(), rootRows.size());
 
 		}
 		catch (Throwable t) {
@@ -217,7 +217,7 @@ public class InsertRowManager {
 
 			buildInsertRows(feature, mapping, featureRow, allRows);
 
-			LOG.debug("Built rows for feature '" + feature.getId() + "': " + allRows.size());
+			LOG.debug("Built rows for feature '{}': {}", feature.getId(), allRows.size());
 
 			for (InsertRow insertRow : allRows) {
 				if (!insertRow.hasParents()) {
@@ -225,9 +225,9 @@ public class InsertRowManager {
 				}
 			}
 
-			LOG.debug("Before heap run: uninserted rows: " + delayedRows.size() + ", root rows: " + rootRows.size());
+			LOG.debug("Before heap run: uninserted rows: {}, root rows: {}", delayedRows.size(), rootRows.size());
 			processHeap();
-			LOG.debug("After heap run: uninserted rows: " + delayedRows.size() + ", root rows: " + rootRows.size());
+			LOG.debug("After heap run: uninserted rows: {}, root rows: {}", delayedRows.size(), rootRows.size());
 
 		}
 		catch (Throwable t) {
@@ -406,7 +406,7 @@ public class InsertRowManager {
 				// nothing to do
 			}
 			else {
-				LOG.warn("Unhandled mapping type '" + mapping.getClass() + "'.");
+				LOG.warn("Unhandled mapping type '{}'.", mapping.getClass());
 			}
 
 			// add index column value if the join uses a numbered order column
@@ -522,7 +522,7 @@ public class InsertRowManager {
 			List<InsertRow> rootRemoves = new ArrayList<InsertRow>();
 			List<InsertRow> rootAdds = new ArrayList<InsertRow>();
 			for (InsertRow row : rootRows) {
-				LOG.debug("Inserting row " + row);
+				LOG.debug("Inserting row {}", row);
 				row.performInsert(conn, rowToChildRows.get(row) != null);
 				delayedRows.remove(row);
 				rootRemoves.add(row);
@@ -531,7 +531,7 @@ public class InsertRowManager {
 				List<InsertRow> childRows = rowToChildRows.get(row);
 				if (childRows != null) {
 					for (InsertRow childRow : childRows) {
-						LOG.debug("Child row: " + childRow);
+						LOG.debug("Child row: {}", childRow);
 						childRow.removeParent(row);
 						if (!childRow.hasParents()) {
 							rootAdds.add(childRow);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
@@ -282,7 +282,7 @@ public class AppSchemaMapper {
 
 	private FeatureTypeMapping generateFtMapping(FeatureType ft) {
 		CycleAnalyser cycleAnalyser = new CycleAnalyser(allowedCycleDepth, ft.getName());
-		LOG.info("Mapping feature type '" + ft.getName() + "'");
+		LOG.info("Mapping feature type '{}'", ft.getName());
 		MappingContext mc = mcManager.newContext(ft.getName(), detectPrimaryKeyColumnName());
 
 		// TODO
@@ -322,7 +322,7 @@ public class AppSchemaMapper {
 	}
 
 	private List<Mapping> generatePropMapping(PropertyType pt, MappingContext mc, CycleAnalyser cycleAnalyser) {
-		LOG.debug("Mapping property '" + pt.getName() + "'");
+		LOG.debug("Mapping property '{}'", pt.getName());
 		List<Mapping> mappings = new ArrayList<>();
 		XSElementDeclaration elDecl = pt.getElementDecl();
 		int before = mcManager.getContextCount();
@@ -365,9 +365,9 @@ public class AppSchemaMapper {
 						}
 
 						int complexity = mcManager.getContextCount() - before;
-						LOG.info("Mapping complexity index of property type '" + eName + "': " + complexity);
+						LOG.info("Mapping complexity index of property type '{}': {}", eName, complexity);
 						if (complexity > maxComplexityIndex) {
-							LOG.warn("Mapping property type '" + eName + "' exceeds complexity limit: " + complexity);
+							LOG.warn("Mapping property type '{}' exceeds complexity limit: {}", eName, complexity);
 							mappings.clear();
 						}
 						else {
@@ -375,8 +375,8 @@ public class AppSchemaMapper {
 						}
 					}
 					catch (Throwable t) {
-						LOG.warn("Unable to create relational mapping for property type '" + pt.getName() + "': "
-								+ t.getMessage());
+						LOG.warn("Unable to create relational mapping for property type '{}': {}", pt.getName(),
+								t.getMessage());
 					}
 				}
 				return mappings;
@@ -398,20 +398,20 @@ public class AppSchemaMapper {
 				generatedMapping = generatePropMapping((CodePropertyType) pt, mc);
 			}
 			else {
-				LOG.warn("Unhandled property type '" + pt.getName() + "': " + pt.getClass().getName());
+				LOG.warn("Unhandled property type '{}': {}", pt.getName(), pt.getClass().getName());
 			}
 			if (generatedMapping != null) {
 				mappings.add(generatedMapping);
 			}
 		}
 		catch (Throwable t) {
-			LOG.warn("Unable to create relational mapping for property type '" + pt.getName() + "': " + t.getMessage());
+			LOG.warn("Unable to create relational mapping for property type '{}': {}", pt.getName(), t.getMessage());
 		}
 
 		int complexity = mcManager.getContextCount() - before;
-		LOG.debug("Mapping complexity index of property type '" + pt.getName() + "': " + complexity);
+		LOG.debug("Mapping complexity index of property type '{}': {}", pt.getName(), complexity);
 		if (complexity > maxComplexityIndex) {
-			LOG.warn("Mapping property type '" + pt.getName() + "' exceeds complexity limit: " + complexity);
+			LOG.warn("Mapping property type '{}' exceeds complexity limit: {}", pt.getName(), complexity);
 			mappings.clear();
 		}
 
@@ -420,7 +420,7 @@ public class AppSchemaMapper {
 
 	private PrimitiveMapping generatePropMapping(SimplePropertyType pt, MappingContext mc,
 			CycleAnalyser cycleAnalyser) {
-		LOG.debug("Mapping simple property '" + pt.getName() + "'");
+		LOG.debug("Mapping simple property '{}'", pt.getName());
 		ValueReference path = getPropName(pt.getName());
 		MappingContext propMc = null;
 		List<TableJoin> jc = null;
@@ -441,7 +441,7 @@ public class AppSchemaMapper {
 	}
 
 	private GeometryMapping generatePropMapping(GeometryPropertyType pt, MappingContext mc) {
-		LOG.debug("Mapping geometry property '" + pt.getName() + "'");
+		LOG.debug("Mapping geometry property '{}'", pt.getName());
 		ValueReference path = getPropName(pt.getName());
 		MappingContext propMc = null;
 		List<TableJoin> jc = null;
@@ -459,7 +459,7 @@ public class AppSchemaMapper {
 	}
 
 	private Mapping generatePropMapping(FeaturePropertyType pt, MappingContext mc) {
-		LOG.debug("Mapping feature property '" + pt.getName() + "'");
+		LOG.debug("Mapping feature property '{}'", pt.getName());
 		ValueReference path = getPropName(pt.getName());
 		List<TableJoin> jc = null;
 		MappingContext fkMC = null;
@@ -492,7 +492,7 @@ public class AppSchemaMapper {
 			}
 		}
 		else {
-			LOG.warn("Ambiguous feature property type '" + pt.getName() + "'. Not creating a Join mapping.");
+			LOG.warn("Ambiguous feature property type '{}'. Not creating a Join mapping.", pt.getName());
 		}
 
 		return new FeatureMapping(path, pt.getMinOccurs() == 0, new DBField(hrefMC.getColumn()), pt.getFTName(), jc);
@@ -500,11 +500,11 @@ public class AppSchemaMapper {
 
 	private CompoundMapping generatePropMapping(CustomPropertyType pt, MappingContext mc, CycleAnalyser cycleAnalyser) {
 
-		LOG.debug("Mapping custom property '" + pt.getName() + "'");
+		LOG.debug("Mapping custom property '{}'", pt.getName());
 
 		XSComplexTypeDefinition xsTypeDef = pt.getXSDValueType();
 		if (xsTypeDef == null) {
-			LOG.warn("No XSD type definition available for custom property '" + pt.getName() + "'. Skipping it.");
+			LOG.warn("No XSD type definition available for custom property '{}'. Skipping it.", pt.getName());
 			return null;
 		}
 
@@ -530,13 +530,13 @@ public class AppSchemaMapper {
 			return new CompoundMapping(path, pt.getMinOccurs() == 0, particles, jc, pt.getElementDecl());
 		}
 		catch (Throwable t) {
-			LOG.warn("Full relational mapping of property '" + pt.getName() + "' failed: " + t.getMessage());
+			LOG.warn("Full relational mapping of property '{}' failed: {}", pt.getName(), t.getMessage());
 		}
 		return new CompoundMapping(path, pt.getMinOccurs() == 0, Collections.emptyList(), jc, pt.getElementDecl());
 	}
 
 	private CompoundMapping generatePropMapping(CodePropertyType pt, MappingContext mc) {
-		LOG.debug("Mapping code property '" + pt.getName() + "'");
+		LOG.debug("Mapping code property '{}'", pt.getName());
 		ValueReference path = getPropName(pt.getName());
 		MappingContext propMc = null;
 		MappingContext codeSpaceMc = null;
@@ -727,8 +727,7 @@ public class AppSchemaMapper {
 						particles.addAll(generateMapping(particle, opt.getMaxOccurs(), mc, cycleAnalyser));
 					}
 				default:
-					LOG.warn("Unhandled object property type '" + opt.getClass() + "' with category "
-							+ opt.getCategory());
+					LOG.warn("Unhandled object property type '{}' with category {}", opt.getClass(), opt.getCategory());
 			}
 		}
 
@@ -960,7 +959,7 @@ public class AppSchemaMapper {
 			sb.append(" -> ");
 		}
 		sb.append("wildcard");
-		LOG.debug("Skipping wildcard at path: " + sb);
+		LOG.debug("Skipping wildcard at path: {}", sb);
 		return new ArrayList<>();
 	}
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/CycleAnalyser.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/CycleAnalyser.java
@@ -54,7 +54,7 @@ public class CycleAnalyser {
 		boolean isCycle = isCycle(typeDef);
 		if (isCycle) {
 			if (stop(getQName(typeDef))) {
-				LOG.info("Allowed cycle depth of " + allowedCycleDepth + " reached. Mapping will stop at this cycle.");
+				LOG.info("Allowed cycle depth of {} reached. Mapping will stop at this cycle.", allowedCycleDepth);
 				return true;
 			}
 		}
@@ -159,7 +159,7 @@ public class CycleAnalyser {
 			sb.append(step);
 			sb.append(" (cycle depth: ").append(nameToCycleDepth.get(step)).append(")");
 		}
-		LOG.info("Current path:" + sb.toString());
+		LOG.info("Current path:{}", sb.toString());
 	}
 
 	private QName getQName(XSTypeDefinition xsType) {
@@ -177,7 +177,7 @@ public class CycleAnalyser {
 			for (XSComplexTypeDefinition ct : parentCTs) {
 				if (ct.getName() != null) {
 					if (typeDef.getName().equals(ct.getName()) && typeDef.getNamespace().equals(ct.getNamespace())) {
-						LOG.info("Found cycle at " + getQName(typeDef));
+						LOG.info("Found cycle at {}", getQName(typeDef));
 						return true;
 					}
 				}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/rules/FeatureBuilderRelational.java
@@ -217,7 +217,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 				addSelectColumns(mapping, qualifiedSqlExprToRsIdx, alias, true);
 			}
 		}
-		LOG.debug("Initial select columns: " + qualifiedSqlExprToRsIdx);
+		LOG.debug("Initial select columns: {}", qualifiedSqlExprToRsIdx);
 		return new ArrayList<String>(qualifiedSqlExprToRsIdx.keySet());
 	}
 
@@ -243,7 +243,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 					addColumn(colToRsIdx, particleConverter.getSelectSnippet(tableAlias));
 				}
 				else {
-					LOG.info("Omitting mapping '" + mapping + "' from SELECT list. Not mapped to column.'");
+					LOG.info("Omitting mapping '{}' from SELECT list. Not mapped to column.'", mapping);
 				}
 			}
 			else {
@@ -259,7 +259,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 					addColumn(colToRsIdx, particleConverter.getSelectSnippet(tableAlias));
 				}
 				else {
-					LOG.info("Omitting mapping '" + mapping + "' from SELECT list. Not mapped to column.'");
+					LOG.info("Omitting mapping '{}' from SELECT list. Not mapped to column.'", mapping);
 				}
 			}
 			else if (mapping instanceof GeometryMapping) {
@@ -267,7 +267,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 					addColumn(colToRsIdx, particleConverter.getSelectSnippet(tableAlias));
 				}
 				else {
-					LOG.info("Omitting mapping '" + mapping + "' from SELECT list. Not mapped to column.'");
+					LOG.info("Omitting mapping '{}' from SELECT list. Not mapped to column.'", mapping);
 				}
 			}
 			else if (mapping instanceof FeatureMapping) {
@@ -275,7 +275,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 					addColumn(colToRsIdx, particleConverter.getSelectSnippet(tableAlias));
 				}
 				else {
-					LOG.info("Omitting mapping '" + mapping + "' from SELECT list. Not mapped to column.'");
+					LOG.info("Omitting mapping '{}' from SELECT list. Not mapped to column.'", mapping);
 				}
 			}
 			else if (mapping instanceof CompoundMapping) {
@@ -288,7 +288,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 				// nothing to do
 			}
 			else {
-				LOG.warn("Mappings of type '" + mapping.getClass() + "' are not handled yet.");
+				LOG.warn("Mappings of type '{}' are not handled yet.", mapping.getClass());
 			}
 		}
 	}
@@ -313,7 +313,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 					feature = (Feature) fs.getCache().get(gmlId);
 				}
 				if (feature == null) {
-					LOG.debug("Recreating feature '" + gmlId + "' from db (relational mode).");
+					LOG.debug("Recreating feature '{}' from db (relational mode).", gmlId);
 					List<Property> props = new ArrayList<Property>();
 					for (Mapping mapping : ftMapping.getMappings()) {
 						ValueReference propName = mapping.getPath();
@@ -324,9 +324,9 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 							addProperties(ft, props, pt, mapping, rs, tableAlias, idPrefix);
 						}
 						else {
-							LOG.warn("Omitting mapping '" + mapping
-									+ "'. Only single child element steps (optionally with number predicate)"
-									+ " are currently supported.");
+							LOG.warn(
+									"Omitting mapping '{}'. Only single child element steps (optionally with number predicate) are currently supported.",
+									mapping);
 						}
 					}
 					features.add(ft.newFeature(gmlId, props, null));
@@ -372,8 +372,8 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 						Collections.<TypedObjectNode>emptyList()));
 			}
 			else {
-				LOG.warn("Unable to map NULL value for mapping '" + propMapping.getPath().getAsText()
-						+ "' to output. This will result in schema violations.");
+				LOG.warn("Unable to map NULL value for mapping '{}' to output. This will result in schema violations.",
+						propMapping.getPath().getAsText());
 			}
 		}
 		for (final TypedObjectNode particle : particles) {
@@ -550,13 +550,13 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 				if (xpath instanceof LocationPath) {
 					LocationPath lp = (LocationPath) xpath;
 					if (lp.getSteps().size() != 1) {
-						LOG.warn("Unhandled location path: '" + particleMapping.getPath()
-								+ "'. Only single step paths are handled.");
+						LOG.warn("Unhandled location path: '{}'. Only single step paths are handled.",
+								particleMapping.getPath());
 						continue;
 					}
 					if (lp.isAbsolute()) {
-						LOG.warn("Unhandled location path: '" + particleMapping.getPath()
-								+ "'. Only relative paths are handled.");
+						LOG.warn("Unhandled location path: '{}'. Only relative paths are handled.",
+								particleMapping.getPath());
 						continue;
 					}
 					Step step = (Step) lp.getSteps().get(0);
@@ -572,8 +572,8 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 							}
 						}
 						else {
-							LOG.warn("Unhandled location path: '" + particleMapping.getPath()
-									+ "'. Only unpredicated steps are handled.");
+							LOG.warn("Unhandled location path: '{}'. Only unpredicated steps are handled.",
+									particleMapping.getPath());
 							continue;
 						}
 					}
@@ -612,8 +612,8 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 							}
 						}
 						else {
-							LOG.warn("Unhandled axis type '" + step.getAxis() + "' for path: '"
-									+ particleMapping.getPath() + "'");
+							LOG.warn("Unhandled axis type '{}' for path: '{}'", step.getAxis(),
+									particleMapping.getPath());
 						}
 					}
 					else {
@@ -624,8 +624,8 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 					}
 				}
 				else {
-					LOG.warn("Unhandled mapping type '" + particleMapping.getClass() + "' for path: '"
-							+ particleMapping.getPath() + "'");
+					LOG.warn("Unhandled mapping type '{}' for path: '{}'", particleMapping.getClass(),
+							particleMapping.getPath());
 				}
 			}
 
@@ -661,8 +661,9 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 								}
 								PrimitiveValue attrValue = attrs.get(attrName);
 								if (attrValue == null) {
-									LOG.debug("Required attribute " + attrName
-											+ "not present. Cannot void using xsi:nil. Escalating void value.");
+									LOG.debug(
+											"Required attribute {}not present. Cannot void using xsi:nil. Escalating void value.",
+											attrName);
 									return null;
 								}
 								nilAttrs.put(attrName, attrValue);
@@ -687,7 +688,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 
 		}
 		else {
-			LOG.warn("Handling of '" + mapping.getClass() + "' mappings is not implemented yet.");
+			LOG.warn("Handling of '{}' mappings is not implemented yet.", mapping.getClass());
 		}
 
 		if (particle == null) {
@@ -716,7 +717,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 				props.add(new GenericProperty(pt, xmlEl.getName(), null, xmlEl.getAttributes(), xmlEl.getChildren()));
 			}
 			else {
-				LOG.warn("Unhandled particle: " + child);
+				LOG.warn("Unhandled particle: {}", child);
 			}
 		}
 		if (geom == null) {
@@ -860,7 +861,7 @@ public class FeatureBuilderRelational implements FeatureBuilder {
 							String ns = ref.getNsContext().translateNamespacePrefixToUri(prefix);
 							qName = new QName(ns, step.getLocalName(), prefix);
 						}
-						LOG.debug("QName: " + qName);
+						LOG.debug("QName: {}", qName);
 					}
 				}
 			}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/SQLFeatureStoreAIXMTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/SQLFeatureStoreAIXMTest.java
@@ -408,7 +408,7 @@ public class SQLFeatureStoreAIXMTest {
 			}
 		}
 		catch (Throwable t) {
-			LOG.error("Access to test databases not configured properly: " + t.getMessage());
+			LOG.error("Access to test databases not configured properly: {}", t.getMessage());
 		}
 		return settings;
 	}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTOPPStatesTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/SQLFeatureStoreTOPPStatesTest.java
@@ -311,7 +311,7 @@ public class SQLFeatureStoreTOPPStatesTest {
 			}
 		}
 		catch (Throwable t) {
-			LOG.error("Access to test databases not configured properly: " + t.getMessage());
+			LOG.error("Access to test databases not configured properly: {}", t.getMessage());
 		}
 		return settings;
 	}

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/src/main/java/org/deegree/metadata/persistence/inspectors/MetadataSchemaValidationInspector.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/src/main/java/org/deegree/metadata/persistence/inspectors/MetadataSchemaValidationInspector.java
@@ -82,7 +82,7 @@ public class MetadataSchemaValidationInspector<T extends MetadataRecord> impleme
 			is = os.getInputStream();
 		}
 		catch (Throwable e) {
-			LOG.debug("error: " + e.getMessage(), e);
+			LOG.debug("error: {}", e.getMessage(), e);
 			throw new MetadataInspectorException(e.getMessage());
 		}
 

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/EbrimEOMDStore.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/EbrimEOMDStore.java
@@ -183,7 +183,7 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 						XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader(is);
 						AdhocQuery query = new AdhocQuery(xmlStream);
 						idToQuery.put(query.getId(), query);
-						LOG.info("Found adhocQuery " + file + " with id " + query.getId());
+						LOG.info("Found adhocQuery {} with id {}", file, query.getId());
 					}
 					catch (Throwable t) {
 						LOG.error(t.getMessage(), t);
@@ -244,7 +244,7 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 				if (result.next()) {
 					regPackId = result.getString(1);
 				}
-				LOG.debug("Profile in database: " + regPackId + " from " + lastInserted);
+				LOG.debug("Profile in database: {} from {}", regPackId, lastInserted);
 				String insertedId = updateProfile(regPackId, lastInserted, profile, lastModified);
 				if (insertedId != null) {
 					sql = "DELETE FROM management where key = 'REGISTRYPACKAGE_ID' or key = 'LAST_INSERTED'";
@@ -299,8 +299,8 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 			if (profile != null && lastModified != null
 					&& ((lastInserted != null && lastInserted.before(lastModified)) || lastInserted == null)) {
 				if (regPackId != null) {
-					LOG.info("profile has changed: Delete old profile with id " + regPackId + ", last inserted: "
-							+ lastInserted);
+					LOG.info("profile has changed: Delete old profile with id {}, last inserted: {}", regPackId,
+							lastInserted);
 					ValueReference propertyName = new ValueReference("rim:RegistryPackage/@id", nsContext);
 					Literal<PrimitiveValue> lit = new Literal<PrimitiveValue>(
 							new PrimitiveValue(regPackId, new PrimitiveType(BaseType.STRING)), null);
@@ -311,7 +311,7 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 					.performInsert(new InsertOperation(Collections.singletonList(profile), null, null));
 				trans.commit();
 				if (!performInsert.isEmpty()) {
-					LOG.info("Inserted profile with id " + performInsert.get(0));
+					LOG.info("Inserted profile with id {}", performInsert.get(0));
 					return performInsert.get(0);
 				}
 			}
@@ -436,7 +436,7 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 				}
 			}
 
-			LOG.debug("Execute: " + stmt.toString());
+			LOG.debug("Execute: {}", stmt.toString());
 			rs = executeQuery(stmt, prov, queryTimeout);
 			return new EbrimEOMDResultSet(rs, conn, stmt);
 		}
@@ -514,7 +514,7 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 				}
 			}
 
-			LOG.debug("Execute: " + stmt.toString());
+			LOG.debug("Execute: {}", stmt.toString());
 			rs = executeQuery(stmt, prov, queryTimeout);
 			rs.next();
 			return rs.getInt(1);
@@ -584,7 +584,7 @@ public class EbrimEOMDStore implements MetadataStore<RegistryObject> {
 				i++;
 			}
 
-			LOG.debug("Execute: " + stmt.toString());
+			LOG.debug("Execute: {}", stmt.toString());
 			rs = executeQuery(stmt, prov, queryTimeout);
 			return new EbrimEOMDResultSet(rs, conn, stmt);
 		}

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/EbrimEOMDStoreTransaction.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/EbrimEOMDStoreTransaction.java
@@ -208,7 +208,7 @@ public class EbrimEOMDStoreTransaction implements MetadataStoreTransaction {
 					argument.setArgument(stm, i++);
 				}
 			}
-			LOG.debug("Execute: " + stm.toString());
+			LOG.debug("Execute: {}", stm.toString());
 			return stm.executeUpdate();
 		}
 		catch (Throwable t) {
@@ -239,7 +239,7 @@ public class EbrimEOMDStoreTransaction implements MetadataStoreTransaction {
 			ir.addPreparedArgument(new SQLIdentifier("description"), registryPackage.getDesc());
 			ir.addPreparedArgument(new SQLIdentifier("data"), getAsByteArray(registryPackage.getElement()));
 
-			LOG.debug("Execute statement " + ir.getSql());
+			LOG.debug("Execute statement {}", ir.getSql());
 
 			ir.performInsert(conn);
 

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/mapping/EOPropertyNameMapper.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/mapping/EOPropertyNameMapper.java
@@ -162,7 +162,7 @@ public class EOPropertyNameMapper implements PropertyNameMapper {
 				throw new MetadataStoreException(msg);
 			}
 			String tableAlias = "X" + (aliasNo++);
-			LOG.debug("Query type: " + queriedType + ", table: " + table + ", table alias: " + tableAlias);
+			LOG.debug("Query type: {}, table: {}, table alias: {}", queriedType, table, tableAlias);
 			aliasToTableAlias.put(queriedType.getAlias(), tableAlias);
 			aliasToTable.put(queriedType.getAlias(), table);
 		}

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/src/main/java/org/deegree/metadata/iso/persistence/memory/TransactionCommitter.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/src/main/java/org/deegree/metadata/iso/persistence/memory/TransactionCommitter.java
@@ -107,7 +107,7 @@ class TransactionCommitter {
 		}
 		if (!fileToWrite.exists()) {
 			boolean created = fileToWrite.createNewFile();
-			LOG.debug("File {} was " + (created ? "successful" : "not") + " created.", fileToWrite);
+			LOG.debug("File {} was {} created.", (created ? "successful" : "not"), fileToWrite);
 		}
 		OutputStream stream = null;
 		XMLStreamWriter writer = null;
@@ -137,7 +137,7 @@ class TransactionCommitter {
 
 	private void deleteFile(TransactionStatus status, File file) throws MetadataStoreException {
 		boolean deleted = file.delete();
-		LOG.debug("File {} was " + (deleted ? "successful" : "not") + " deleted", file);
+		LOG.debug("File {} was {} deleted", (deleted ? "successful" : "not"), file);
 		if (!deleted)
 			throw new MetadataStoreException("Commit failed: could not " + status + " record at " + file);
 	}

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOMetadataStore.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOMetadataStore.java
@@ -267,7 +267,7 @@ public class ISOMetadataStore implements MetadataStore<ISORecord> {
 			ta = new ISOMetadataStoreTransaction(conn, dialect, inspectorChain, getQueryables(), config.getAnyText());
 		}
 		catch (SQLException e) {
-			LOG.error("error " + e.getMessage(), e);
+			LOG.error("error {}", e.getMessage(), e);
 			throw new MetadataStoreException(e.getMessage(), e);
 		}
 		return ta;

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOMetadataStoreTransaction.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOMetadataStoreTransaction.java
@@ -147,7 +147,7 @@ public class ISOMetadataStoreTransaction implements MetadataStoreTransaction {
 			ISOMetadataResultSet isoRs = qh.execute(query, conn);
 			while (isoRs.next()) {
 				ISORecord rec = isoRs.getRecord();
-				LOG.debug("record to update" + rec);
+				LOG.debug("record to update{}", rec);
 				boolean updated = false;
 
 				if (update.getRecord() != null) {
@@ -166,28 +166,28 @@ public class ISOMetadataStoreTransaction implements MetadataStoreTransaction {
 						Object value = metadataProperty.getReplacementValue();
 
 						if (value == null) {
-							LOG.debug("    Remove: " + name);
+							LOG.debug("    Remove: {}", name);
 							rec.removeNode(name);
 							updated = true;
 						}
 						else if (value instanceof String) {
-							LOG.debug("    Update: " + name + " with: " + value);
+							LOG.debug("    Update: {} with: {}", name, value);
 							try {
 								rec.update(name, (String) value);
 								updated = true;
 							}
 							catch (Exception e) {
-								LOG.info("Update or record " + rec + " failed: " + e.getMessage());
+								LOG.info("Update or record {} failed: {}", rec, e.getMessage());
 							}
 						}
 						else if (value instanceof OMElement) {
-							LOG.debug("    Update: " + name + " with xml: " + value);
+							LOG.debug("    Update: {} with xml: {}", name, value);
 							rec.update(name, (OMElement) value);
 							updated = true;
 						}
 						else {
-							LOG.warn("Could not update propertyName: " + name
-									+ ": must be a string, an OMELement or null!");
+							LOG.warn("Could not update propertyName: {}: must be a string, an OMELement or null!",
+									name);
 						}
 					}
 					// inspect element if it is still valid

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/FIInspector.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/FIInspector.java
@@ -155,7 +155,7 @@ public class FIInspector implements RecordInspector<ISORecord> {
 			String resourceIdentifier = a.getNodeAsString(resourceElement, new XPath(
 					"./gmd:MD_Identifier/gmd:code/gco:CharacterString | ./gmd:RS_Identifier/gmd:code/gco:CharacterString",
 					nsContext), null);
-			LOG.debug("resourceIdentifier: '" + resourceIdentifier + "' ");
+			LOG.debug("resourceIdentifier: '{}' ", resourceIdentifier);
 			resourceIdentifierList.add(resourceIdentifier);
 
 		}

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/NamespaceNormalizationInspector.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/NamespaceNormalizationInspector.java
@@ -77,7 +77,7 @@ public class NamespaceNormalizationInspector implements RecordInspector<ISORecor
 			for (NamespaceBinding binding : config.getNamespaceBinding()) {
 				String prefix = binding.getPrefix();
 				String namespaceUri = binding.getNamespaceURI();
-				LOG.debug("'" + prefix + "' -> '" + namespaceUri + "'");
+				LOG.debug("'{}' -> '{}'", prefix, namespaceUri);
 				nsBindings.addNamespace(prefix, namespaceUri);
 			}
 		}
@@ -105,7 +105,7 @@ public class NamespaceNormalizationInspector implements RecordInspector<ISORecor
 			result = new ISORecord(xmlStream);
 		}
 		catch (Throwable t) {
-			LOG.error("Namespace normalization failed. Proceeding with unnormalized record. Error: " + t.getMessage());
+			LOG.error("Namespace normalization failed. Proceeding with unnormalized record. Error: {}", t.getMessage());
 		}
 
 		return result;

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/sql/DefaultQueryService.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/sql/DefaultQueryService.java
@@ -256,7 +256,7 @@ public class DefaultQueryService extends AbstractSqlHelper implements QueryServi
 			logSqlAndArguments(preparedStatement, sql, arguments);
 			rs = preparedStatement.executeQuery();
 			rs.next();
-			LOG.debug("rs for rowCount: " + rs.getInt(1));
+			LOG.debug("rs for rowCount: {}", rs.getInt(1));
 			return rs.getInt(1);
 		}
 		catch (SQLException e) {
@@ -291,13 +291,13 @@ public class DefaultQueryService extends AbstractSqlHelper implements QueryServi
 			String sql = select.toString();
 			stmt = createPreparedStatement(conn, sql);
 			stmt.setFetchSize(DEFAULT_FETCH_SIZE);
-			LOG.debug("select RecordById statement: " + stmt);
+			LOG.debug("select RecordById statement: {}", stmt);
 			LOG.trace(sql);
 			int i = 1;
 			for (String identifier : idList) {
 				stmt.setString(i, identifier);
-				LOG.debug("identifier: " + identifier);
-				LOG.debug("" + stmt);
+				LOG.debug("identifier: {}", identifier);
+				LOG.debug("{}", stmt);
 				i++;
 			}
 			rs = stmt.executeQuery();

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/sql/DefaultTransactionService.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/sql/DefaultTransactionService.java
@@ -208,7 +208,7 @@ public class DefaultTransactionService extends AbstractSqlHelper implements Tran
 
 			while (rs.next()) {
 				requestedId = rs.getInt(1);
-				LOG.debug("resultSet: " + rs.getInt(1));
+				LOG.debug("resultSet: {}", rs.getInt(1));
 			}
 
 			if (requestedId > -1) {
@@ -235,7 +235,7 @@ public class DefaultTransactionService extends AbstractSqlHelper implements Tran
 			throw new MetadataStoreException(msg);
 		}
 		catch (FactoryConfigurationError e) {
-			LOG.debug("error: " + e.getMessage(), e);
+			LOG.debug("error: {}", e.getMessage(), e);
 			throw new MetadataStoreException(e.getMessage());
 		}
 		finally {

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/ISOMetadatStoreTransactionTest.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/ISOMetadatStoreTransactionTest.java
@@ -111,7 +111,7 @@ public class ISOMetadatStoreTransactionTest extends AbstractISOTest {
 		File[] fileArray = folder.listFiles();
 
 		if (fileArray == null) {
-			LOG.error("test folder does not exist: " + test_folder);
+			LOG.error("test folder does not exist: {}", test_folder);
 			return;
 		}
 
@@ -151,7 +151,7 @@ public class ISOMetadatStoreTransactionTest extends AbstractISOTest {
 
 		List<String> ids = TstUtils.insertMetadata(store, TstConstants.tst_9, TstConstants.tst_10, TstConstants.tst_1);
 
-		LOG.info("Inserted records with ids: " + ids + ". Now: delete them...");
+		LOG.info("Inserted records with ids: {}. Now: delete them...", ids);
 		String fileString = TstConstants.propEqualToID.getFile();
 		if (fileString == null) {
 			LOG.warn("Skipping test (file with filterExpression not found).");
@@ -503,7 +503,7 @@ public class ISOMetadatStoreTransactionTest extends AbstractISOTest {
 		Assume.assumeNotNull(store);
 
 		List<String> ids = TstUtils.insertMetadata(store, TstConstants.tst_9);
-		LOG.info("Inserted records with ids: " + ids + ". Now: update " + ids);
+		LOG.info("Inserted records with ids: {}. Now: update {}", ids, ids);
 
 		assertNotNull(ids);
 		assertTrue(ids.size() > 0);

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/ISORecordSerializeTest.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/ISORecordSerializeTest.java
@@ -111,8 +111,8 @@ public class ISORecordSerializeTest extends AbstractISOTest {
 		streamExpected.append("gts=http://www.isotc211.org/2005/gts").append(' ');
 		streamExpected.append("xsi=http://www.w3.org/2001/XMLSchema-instance").append(' ');
 
-		LOG.info("streamThis: " + streamExpected.toString());
-		LOG.info("streamThat: " + streamActual.toString());
+		LOG.info("streamThis: {}", streamExpected.toString());
+		LOG.info("streamThat: {}", streamActual.toString());
 		System.out.println(streamActual);
 		Assert.assertEquals(streamExpected.toString(), streamActual.toString());
 
@@ -200,7 +200,7 @@ public class ISORecordSerializeTest extends AbstractISOTest {
 
 		StringBuilder streamThat = new StringBuilder();
 		if (fout instanceof FileOutputStream) {
-			LOG.warn("The output is written into a file: " + file);
+			LOG.warn("The output is written into a file: {}", file);
 			return null;
 		}
 		else if (fout instanceof ByteArrayOutputStream) {

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/TstUtils.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/TstUtils.java
@@ -73,7 +73,7 @@ public class TstUtils {
 			records = new ArrayList<ISORecord>();
 			ta = store.acquireTransaction();
 			OMElement record = new XMLAdapter(file).getRootElement();
-			LOG.info("inserting filename: " + file.getFile());
+			LOG.info("inserting filename: {}", file.getFile());
 			records.add(new ISORecord(record));
 			try {
 				if (countInsert > 0) {
@@ -105,7 +105,7 @@ public class TstUtils {
 			countInserted += ids.size();
 		}
 
-		LOG.info(countInserted + " from " + countInsert + " Metadata inserted.");
+		LOG.info("{} from {} Metadata inserted.", countInserted, countInsert);
 		return ids;
 	}
 

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/parsing/ParseISOTest.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/test/java/org/deegree/metadata/iso/persistence/parsing/ParseISOTest.java
@@ -130,7 +130,7 @@ public class ParseISOTest extends AbstractISOTest {
 				s_b.append(e.getMin().get0()).append(' ').append(e.getMin().get1()).append(' ');
 				s_b.append(e.getMax().get0()).append(' ').append(e.getMax().get1()).append(' ');
 				s_b.append(e.getCoordinateSystem().getAlias());
-				LOG.debug("boundingBox: " + s_b.toString());
+				LOG.debug("boundingBox: {}", s_b.toString());
 			}
 
 			Assert.assertEquals("identifier: ", "d0e5c36eec7f473b91b8b249da87d522", s_ident.toString());

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTiffUtils.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTiffUtils.java
@@ -84,7 +84,7 @@ public class GeoTiffUtils {
 						crs = ref;
 					}
 					catch (ReferenceResolvingException e) {
-						LOG.error("No coordinate system found for EPSG:" + epsgCode);
+						LOG.error("No coordinate system found for EPSG:{}", epsgCode);
 					}
 				}
 			}

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/java/org/deegree/tile/persistence/merge/MergingTileStore.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/src/main/java/org/deegree/tile/persistence/merge/MergingTileStore.java
@@ -102,7 +102,7 @@ class MergingTileStore implements TileStore {
 
 	private void addDatasets(Map<String, Map<String, MergingTileDataLevel>> datasetIdToLevelIdToLevel) {
 		for (String datasetId : datasetIdToLevelIdToLevel.keySet()) {
-			LOG.info("- Dataset: " + datasetId);
+			LOG.info("- Dataset: {}", datasetId);
 			Map<String, MergingTileDataLevel> levelIdToLevel = datasetIdToLevelIdToLevel.get(datasetId);
 			addDataset(datasetId, levelIdToLevel);
 		}
@@ -113,7 +113,7 @@ class MergingTileStore implements TileStore {
 		List<TileDataLevel> levels = new ArrayList<TileDataLevel>(levelIdToLevel.values());
 		for (TileDataLevel level : levels) {
 			List<TileDataLevel> mergeLevels = ((MergingTileDataLevel) level).getMergeLevels();
-			LOG.info(" - Level: " + level.getMetadata().getIdentifier() + ", merge size: " + mergeLevels.size());
+			LOG.info(" - Level: {}, merge size: {}", level.getMetadata().getIdentifier(), mergeLevels.size());
 		}
 		TileDataSet dataset = new DefaultTileDataSet(levels, tileMatrixSet, FORMAT);
 		datasetIdToDataset.put(datasetId, dataset);

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
@@ -125,7 +125,7 @@ public class FeatureLayer extends AbstractLayer {
 
 		QName ftName = featureType == null ? style.getFeatureType() : featureType;
 		if (ftName != null && featureStore.getSchema().getFeatureType(ftName) == null) {
-			LOG.warn("FeatureType '" + ftName + "' is not known to the FeatureStore.");
+			LOG.warn("FeatureType '{}' is not known to the FeatureStore.", ftName);
 			return null;
 		}
 

--- a/deegree-layers/deegree-layers-gdal/src/main/java/org/deegree/layer/persistence/gdal/GdalLayerData.java
+++ b/deegree-layers/deegree-layers-gdal/src/main/java/org/deegree/layer/persistence/gdal/GdalLayerData.java
@@ -238,7 +238,7 @@ class GdalLayerData implements LayerData {
 					regions.add(dataset.extractRegionAsByteArray(bbox, width, height, true));
 				}
 				catch (Exception e) {
-					LOG.error("Error extracting region from dataset: " + e.getMessage(), e);
+					LOG.error("Error extracting region from dataset: {}", e.getMessage(), e);
 				}
 				finally {
 					if (dataset != null) {
@@ -246,7 +246,7 @@ class GdalLayerData implements LayerData {
 							pool.returnDataset(dataset);
 						}
 						catch (Exception e) {
-							LOG.error("Error returning dataset to pool: " + e.getMessage());
+							LOG.error("Error returning dataset to pool: {}", e.getMessage());
 						}
 					}
 				}

--- a/deegree-processproviders/deegree-processprovider-fme/src/main/java/org/deegree/services/wps/provider/fme/FMEProcessProviderBuilder.java
+++ b/deegree-processproviders/deegree-processprovider-fme/src/main/java/org/deegree/services/wps/provider/fme/FMEProcessProviderBuilder.java
@@ -167,11 +167,11 @@ public class FMEProcessProviderBuilder implements ResourceBuilder<ProcessProvide
 			FMEProcess process = createProcess(base, tokenurl, repositories, map, token, repo, ws, workspace);
 			CodeType id = repositories.size() == 1 ? new CodeType(process.getDescription().getIdentifier().getValue())
 					: new CodeType(process.getDescription().getIdentifier().getValue(), repo);
-			LOG.debug("Created FMEProcess: " + id);
+			LOG.debug("Created FMEProcess: {}", id);
 			processes.put(id, process);
 		}
 		catch (Exception e) {
-			LOG.error("Unable to create FMEProcess from element '" + workspace + "': " + e.getMessage(), e);
+			LOG.error("Unable to create FMEProcess from element '{}': {}", workspace, e.getMessage(), e);
 		}
 	}
 

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/authentication/HttpBasicAuthentication.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/authentication/HttpBasicAuthentication.java
@@ -118,16 +118,16 @@ public class HttpBasicAuthentication implements CredentialsProvider {
 	 */
 	private Credentials doBasicAuthentication(HttpServletRequest req, HttpServletResponse response) {
 		// look for HTTP Basic Authentification info
-		LOG.debug("header: " + req.getHeader("authorization"));
+		LOG.debug("header: {}", req.getHeader("authorization"));
 		String authorizationHeader = req.getHeader("authorization");
 		if (authorizationHeader != null) {
 			if (authorizationHeader.startsWith("Basic ") || authorizationHeader.startsWith("BASIC ")) {
-				LOG.debug("Found basic authorization header: '" + authorizationHeader + "'.");
+				LOG.debug("Found basic authorization header: '{}'.", authorizationHeader);
 				// 6: length of "Basic "
 				String encodedCreds = authorizationHeader.substring(6).trim();
-				LOG.debug("encodedCreds: " + encodedCreds);
+				LOG.debug("encodedCreds: {}", encodedCreds);
 				String creds = new String(Base64.decodeBase64(encodedCreds));
-				LOG.debug("creds: " + creds);
+				LOG.debug("creds: {}", creds);
 				int delimPos = creds.indexOf(':');
 				if (delimPos != -1) {
 
@@ -135,8 +135,8 @@ public class HttpBasicAuthentication implements CredentialsProvider {
 
 					String password = creds.substring(delimPos + 1);
 
-					LOG.debug("user: " + user);
-					LOG.debug("password: " + password);
+					LOG.debug("user: {}", user);
+					LOG.debug("password: {}", password);
 					return new Credentials(user, password);
 
 				}

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/authentication/SOAPAuthentication.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/authentication/SOAPAuthentication.java
@@ -101,7 +101,7 @@ public class SOAPAuthentication implements CredentialsProvider {
 		soapXMLHeader.setRootElement(requestHeader);
 		SoapHeader soapHeader = soapXMLHeader.parseHeader();
 
-		LOG.info(soapHeader.getUsername() + " " + soapHeader.getPassword());
+		LOG.info("{} {}", soapHeader.getUsername(), soapHeader.getPassword());
 		return new Credentials(soapHeader.getUsername(), soapHeader.getPassword());
 
 	}

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/OwsGlobalConfigLoader.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/OwsGlobalConfigLoader.java
@@ -185,34 +185,38 @@ public class OwsGlobalConfigLoader implements Initializable {
 			}
 			catch (InstantiationException e) {
 				LOG.info(
-						"The request logger class '{}' could not be instantiated"
-								+ " (needs a default constructor without arguments if no configuration is given).",
+						"The request logger class '{}' could not be instantiated (needs a default constructor without arguments if no configuration is given).",
 						cls);
 				LOG.trace("Stack trace:", e);
 			}
 			catch (IllegalAccessException e) {
-				LOG.info("The request logger class '{}' could not be instantiated"
-						+ " (default constructor needs to be accessible if no configuration is given).", cls);
+				LOG.info(
+						"The request logger class '{}' could not be instantiated (default constructor needs to be accessible if no configuration is given).",
+						cls);
 				LOG.trace("Stack trace:", e);
 			}
 			catch (IllegalArgumentException e) {
-				LOG.info("The request logger class '{}' could not be instantiated"
-						+ " (constructor needs to take an object argument if configuration is given).", cls);
+				LOG.info(
+						"The request logger class '{}' could not be instantiated (constructor needs to take an object argument if configuration is given).",
+						cls);
 				LOG.trace("Stack trace:", e);
 			}
 			catch (java.lang.SecurityException e) {
-				LOG.info("The request logger class '{}' could not be instantiated"
-						+ " (JVM does have insufficient rights to instantiate the class).", cls);
+				LOG.info(
+						"The request logger class '{}' could not be instantiated (JVM does have insufficient rights to instantiate the class).",
+						cls);
 				LOG.trace("Stack trace:", e);
 			}
 			catch (InvocationTargetException e) {
-				LOG.info("The request logger class '{}' could not be instantiated"
-						+ " (constructor call threw an exception).", cls);
+				LOG.info(
+						"The request logger class '{}' could not be instantiated (constructor call threw an exception).",
+						cls);
 				LOG.trace("Stack trace:", e);
 			}
 			catch (NoSuchMethodException e) {
-				LOG.info("The request logger class '{}' could not be instantiated"
-						+ " (constructor needs to take an object argument if configuration is given).", cls);
+				LOG.info(
+						"The request logger class '{}' could not be instantiated (constructor needs to take an object argument if configuration is given).",
+						cls);
 				LOG.trace("Stack trace:", e);
 			}
 		}

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/utils/HttpResponseBuffer.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/controller/utils/HttpResponseBuffer.java
@@ -288,13 +288,13 @@ public class HttpResponseBuffer extends HttpServletResponseWrapper {
 
 				long elapsed = System.currentTimeMillis() - begin;
 				if (messages.size() == 0) {
-					LOG.info("Output is valid. Validation took " + elapsed + " ms.");
+					LOG.info("Output is valid. Validation took {} ms.", elapsed);
 				}
 				else {
-					LOG.error("Output is ***invalid***: " + messages.size() + " error(s)/warning(s). Validation took "
-							+ elapsed + " ms.");
+					LOG.error("Output is ***invalid***: {} error(s)/warning(s). Validation took {} ms.",
+							messages.size(), elapsed);
 					for (String msg : messages) {
-						LOG.error("***" + msg);
+						LOG.error("***{}", msg);
 					}
 				}
 			}

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/i18n/Messages.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/i18n/Messages.java
@@ -88,8 +88,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			is = Messages.class.getResourceAsStream(fileName);
 			defaultProps.load(is);
@@ -110,7 +110,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 		finally {
 			closeSilently(is);
@@ -180,7 +180,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/resources/ResourcesServlet.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/resources/ResourcesServlet.java
@@ -96,7 +96,7 @@ public class ResourcesServlet extends HttpServlet {
 		if (resourcePath.endsWith(".wsdl/ALL"))
 			resourcePath = resourcePath.substring(0, resourcePath.length() - 4);
 
-		LOG.debug("Requested resource: " + resourcePath);
+		LOG.debug("Requested resource: {}", resourcePath);
 		File wsDir = OGCFrontController.getServiceWorkspace().getLocation();
 		File resource = new File(wsDir, resourcePath);
 		if (!resource.exists()) {

--- a/deegree-services/deegree-services-config/src/main/java/org/deegree/services/config/actions/UpdateBboxCache.java
+++ b/deegree-services/deegree-services-config/src/main/java/org/deegree/services/config/actions/UpdateBboxCache.java
@@ -96,8 +96,8 @@ public class UpdateBboxCache {
 			}
 			catch (FeatureStoreException e) {
 				updateLog.addFailed(featureStoreId, featureTypeName);
-				LOG.debug("Update of FeatureType " + featureTypeName + ", from FeatureStore with ID " + featureStoreId
-						+ " failed", e);
+				LOG.debug("Update of FeatureType {}, from FeatureStore with ID {} failed", featureTypeName,
+						featureStoreId, e);
 			}
 		}
 	}

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CSWController.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/CSWController.java
@@ -240,8 +240,8 @@ public class CSWController extends AbstractOWS {
 		if (jaxbConfig.getExtendedCapabilities() != null) {
 			extendedCapabilities = metadata.getLocation().resolveToUrl(jaxbConfig.getExtendedCapabilities());
 			if (extendedCapabilities == null) {
-				LOG.warn("Could not resolve path to extended capabilities : " + extendedCapabilities
-						+ ". Ignore extended capabilities.");
+				LOG.warn("Could not resolve path to extended capabilities : {}. Ignore extended capabilities.",
+						extendedCapabilities);
 			}
 		}
 		int maxMatches = jaxbConfig.getMaxMatches() == null ? 0 : jaxbConfig.getMaxMatches().intValue();

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/DescribeRecordHandler.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/DescribeRecordHandler.java
@@ -197,7 +197,7 @@ public class DescribeRecordHandler {
 			dcHelper.exportSchemaComponent(writer, typeName, isr);
 		}
 		catch (Exception e) {
-			LOG.info("Could not get connection to " + url.toExternalForm() + ". Try to export schema as reference.");
+			LOG.info("Could not get connection to {}. Try to export schema as reference.", url.toExternalForm());
 			List<URL> schemaReferenceSnippet = profile.getSchemaReferences(typeName);
 			for (URL ref : schemaReferenceSnippet) {
 				writeSchemaReference(writer, typeName, ref);
@@ -207,7 +207,7 @@ public class DescribeRecordHandler {
 
 	private void writeSchemaReference(XMLStreamWriter writer, QName typeName, URL url) throws MetadataStoreException {
 		if (url == null) {
-			LOG.info("Could not find schema reference snippet for type name " + typeName);
+			LOG.info("Could not find schema reference snippet for type name {}", typeName);
 			return;
 		}
 		try {

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/GetRecordsHandler.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/GetRecordsHandler.java
@@ -127,7 +127,7 @@ public class GetRecordsHandler {
 	public void doGetRecords(GetRecords getRec, HttpResponseBuffer response, MetadataStore<?> store)
 			throws XMLStreamException, IOException, OWSException {
 
-		LOG.debug("doGetRecords: " + getRec);
+		LOG.debug("doGetRecords: {}", getRec);
 
 		Version version = getRec.getVersion();
 		String outputFormat = getRec.getOutputFormat();

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/TransactionHandler.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/exporthandling/TransactionHandler.java
@@ -85,7 +85,7 @@ public class TransactionHandler {
 	public void doTransaction(Transaction trans, HttpResponseBuffer response, MetadataStore<?> store)
 			throws XMLStreamException, OWSException, IOException {
 
-		LOG.debug("doTransaction: " + trans);
+		LOG.debug("doTransaction: {}", trans);
 
 		Version version = trans.getVersion();
 
@@ -257,7 +257,7 @@ public class TransactionHandler {
 		// String prefix = insert.getElements().get( 0 ).getNamespace().getPrefix();
 
 		List<String> ids = ta.performInsert(insert);
-		LOG.debug("inserted metadata: " + ids);
+		LOG.debug("inserted metadata: {}", ids);
 		LOG.info("Insert done!");
 		return ids;
 	}

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/getrecordbyid/DefaultGetRecordByIdHandler.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/getrecordbyid/DefaultGetRecordByIdHandler.java
@@ -80,7 +80,7 @@ public class DefaultGetRecordByIdHandler implements GetRecordByIdHandler {
 			ServiceProfile profile)
 			throws XMLStreamException, IOException, InvalidParameterValueException, OWSException {
 		this.profile = profile;
-		LOG.debug("doGetRecordById: " + getRecBI);
+		LOG.debug("doGetRecordById: {}", getRecBI);
 		Version version = getRecBI.getVersion();
 
 		String outputFormat = getRecBI.getOutputFormat();

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/getrecordbyid/GetRecordByIdXMLAdapter.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/getrecordbyid/GetRecordByIdXMLAdapter.java
@@ -123,7 +123,7 @@ public class GetRecordByIdXMLAdapter extends AbstractCSWRequestXMLAdapter {
 		List<String> ids = null;
 		try {
 			List<OMElement> idList = getRequiredNodes(rootElement, new XPath("csw:Id", nsContext));
-			LOG.debug("idList: " + idList);
+			LOG.debug("idList: {}", idList);
 			ids = new ArrayList<String>();
 			for (OMElement elem : idList) {
 				String idString = getNodeAsString(elem, new XPath("text()", nsContext), "");

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/getrecords/Query.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/getrecords/Query.java
@@ -167,7 +167,7 @@ public class Query {
 			QName[] queryTypeNames = new QName[queryTypeNamesString.length];
 			int counterQName = 0;
 			for (String s : queryTypeNamesString) {
-				LOG.debug("Parsing typeName '" + s + "' of Query as QName. ");
+				LOG.debug("Parsing typeName '{}' of Query as QName. ", s);
 				QName qname = adapter.parseQName(s, adapter.getRootElement());
 				queryTypeNames[counterQName++] = qname;
 			}

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/profile/CommonCSWProfile.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/profile/CommonCSWProfile.java
@@ -154,7 +154,7 @@ public class CommonCSWProfile implements ServiceProfile {
 				return new URL(CSWConstants.CSW_202_RECORD);
 			}
 			catch (MalformedURLException e) {
-				LOG.info("Could not resolve URL " + CSWConstants.CSW_202_RECORD);
+				LOG.info("Could not resolve URL {}", CSWConstants.CSW_202_RECORD);
 			}
 		}
 		return null;

--- a/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/profile/ServiceProfileManager.java
+++ b/deegree-services/deegree-services-csw/src/main/java/org/deegree/services/csw/profile/ServiceProfileManager.java
@@ -49,7 +49,7 @@ public class ServiceProfileManager {
 	private static final Logger LOG = getLogger(ServiceProfileManager.class);
 
 	public static ServiceProfile createProfile(MetadataStore<?> store) {
-		LOG.info("Create profile for store with type " + store.getType());
+		LOG.info("Create profile for store with type {}", store.getType());
 		if ("iso".equals(store.getType())) {
 			return new CommonCSWProfile();
 		}

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/WCServiceBuilder.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/WCServiceBuilder.java
@@ -173,8 +173,8 @@ public class WCServiceBuilder {
 						}
 					}
 					catch (TransformationException e) {
-						LOG.debug("Could not create an envelope for the output crs: " + crs + " because: "
-								+ e.getLocalizedMessage());
+						LOG.debug("Could not create an envelope for the output crs: {} because: {}", crs,
+								e.getLocalizedMessage());
 					}
 				}
 			}

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/getcoverage/GetCoverage100KVPAdapter.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/getcoverage/GetCoverage100KVPAdapter.java
@@ -279,7 +279,7 @@ public class GetCoverage100KVPAdapter {
 			result = Interval.createFromStrings(type.toString(), min, max, Closure.closed, null, false, spacing);
 		}
 		else {
-			LOG.warn("Given intervall: " + interval + " has not enough values, maybe a default value is ment?");
+			LOG.warn("Given intervall: {} has not enough values, maybe a default value is ment?", interval);
 		}
 		return result;
 	}

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/GetCapabilitiesHandler.java
@@ -253,7 +253,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 			if (ftName.getNamespaceURI() != "") {
 				prefix = ftName.getPrefix();
 				if (ftName.getPrefix() == null || ftName.getPrefix().equals("")) {
-					LOG.warn("Feature type '" + ftName + "' has no prefix!? This should not happen.");
+					LOG.warn("Feature type '{}' has no prefix!? This should not happen.", ftName);
 					prefix = "app";
 				}
 				writer.writeNamespace(prefix, ftName.getNamespaceURI());
@@ -304,7 +304,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 				env = fs.getEnvelope(ftName);
 			}
 			catch (FeatureStoreException e) {
-				LOG.error("Error retrieving envelope from FeatureStore: " + e.getMessage(), e);
+				LOG.error("Error retrieving envelope from FeatureStore: {}", e.getMessage(), e);
 			}
 			if (env != null) {
 				try {
@@ -323,7 +323,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 					writer.writeEndElement();
 				}
 				catch (Exception e) {
-					LOG.error("Cannot generate WGS84 envelope for feature type '" + ftName + "'.", e);
+					LOG.error("Cannot generate WGS84 envelope for feature type '{}'.", ftName, e);
 				}
 			}
 
@@ -634,7 +634,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 				writer.writeStartElement(WFS_NS, "Name");
 				String prefix = ftName.getPrefix();
 				if (prefix == null || prefix.equals("")) {
-					LOG.warn("Feature type '" + ftName + "' has no prefix!? This should not happen.");
+					LOG.warn("Feature type '{}' has no prefix!? This should not happen.", ftName);
 					prefix = "app";
 				}
 				if (!"".equals(ftName.getNamespaceURI())) {
@@ -686,7 +686,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 					env = fs.getEnvelope(ftName);
 				}
 				catch (FeatureStoreException e) {
-					LOG.error("Error retrieving envelope from FeatureStore: " + e.getMessage(), e);
+					LOG.error("Error retrieving envelope from FeatureStore: {}", e.getMessage(), e);
 				}
 
 				if (env != null) {
@@ -716,8 +716,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 					maxY = max.get1();
 				}
 				catch (ArrayIndexOutOfBoundsException e) {
-					LOG.error("Cannot generate WGS84 envelope for feature type '" + ftName + "'. Using full extent.",
-							e);
+					LOG.error("Cannot generate WGS84 envelope for feature type '{}'. Using full extent.", ftName, e);
 					minX = -180.0;
 					minY = -90.0;
 					maxX = 180.0;
@@ -981,7 +980,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 				writer.writeStartElement(WFS_200_NS, "Name");
 				String prefix = ftName.getPrefix();
 				if (prefix == null || prefix.equals("")) {
-					LOG.warn("Feature type '" + ftName + "' has no prefix!? This should not happen.");
+					LOG.warn("Feature type '{}' has no prefix!? This should not happen.", ftName);
 					prefix = "app";
 				}
 				if (!"".equals(ftName.getNamespaceURI())) {
@@ -1030,7 +1029,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 					env = fs.getEnvelope(ftName);
 				}
 				catch (FeatureStoreException e) {
-					LOG.error("Error retrieving envelope from FeatureStore: " + e.getMessage(), e);
+					LOG.error("Error retrieving envelope from FeatureStore: {}", e.getMessage(), e);
 				}
 
 				if (env != null) {
@@ -1060,8 +1059,7 @@ class GetCapabilitiesHandler extends OWSCapabilitiesXMLAdapter {
 					maxY = max.get1();
 				}
 				catch (ArrayIndexOutOfBoundsException e) {
-					LOG.error("Cannot generate WGS84 envelope for feature type '" + ftName + "'. Using full extent.",
-							e);
+					LOG.error("Cannot generate WGS84 envelope for feature type '{}'. Using full extent.", ftName, e);
 					minX = -180.0;
 					minY = -90.0;
 					maxX = 180.0;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/LockFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/LockFeatureHandler.java
@@ -107,7 +107,7 @@ class LockFeatureHandler {
 	void doLockFeature(LockFeature request, HttpResponseBuffer response)
 			throws OWSException, XMLStreamException, IOException {
 
-		LOG.debug("doLockFeature: " + request);
+		LOG.debug("doLockFeature: {}", request);
 
 		LockManager manager = getLockManager();
 		Lock lock = acquireOrRenewLock(request, manager);

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/TransactionHandler.java
@@ -207,7 +207,7 @@ class TransactionHandler {
 	 */
 	void doTransaction(HttpResponseBuffer response) throws OWSException, XMLStreamException, IOException {
 
-		LOG.debug("doTransaction: " + request);
+		LOG.debug("doTransaction: {}", request);
 
 		try {
 			Lock lock = null;
@@ -260,7 +260,7 @@ class TransactionHandler {
 			}
 
 			for (FeatureStoreTransaction ta : acquiredTransactions.values()) {
-				LOG.debug("Committing feature store transaction:" + ta);
+				LOG.debug("Committing feature store transaction:{}", ta);
 				ta.commit();
 			}
 		}
@@ -269,11 +269,11 @@ class TransactionHandler {
 			LOG.debug("Error occured during transaction, performing rollback.");
 			for (FeatureStoreTransaction ta : acquiredTransactions.values()) {
 				try {
-					LOG.debug("Rolling back feature store transaction:" + ta);
+					LOG.debug("Rolling back feature store transaction:{}", ta);
 					ta.rollback();
 				}
 				catch (FeatureStoreException e1) {
-					LOG.debug("Error occured during rollback: " + e.getMessage(), e);
+					LOG.debug("Error occured during rollback: {}", e.getMessage(), e);
 				}
 			}
 			if (request.getVersion().equals(VERSION_100)) {
@@ -288,11 +288,11 @@ class TransactionHandler {
 			LOG.debug("Error occured during transaction, performing rollback.");
 			for (FeatureStoreTransaction ta : acquiredTransactions.values()) {
 				try {
-					LOG.debug("Rolling back feature store transaction:" + ta);
+					LOG.debug("Rolling back feature store transaction:{}", ta);
 					ta.rollback();
 				}
 				catch (FeatureStoreException e1) {
-					LOG.debug("Error occured during rollback: " + e.getMessage(), e);
+					LOG.debug("Error occured during rollback: {}", e.getMessage(), e);
 				}
 			}
 			if (request.getVersion().equals(VERSION_100)) {
@@ -306,11 +306,11 @@ class TransactionHandler {
 			LOG.debug("Error occured during transaction, performing rollback.");
 			for (FeatureStoreTransaction ta : acquiredTransactions.values()) {
 				try {
-					LOG.debug("Rolling back feature store transaction:" + ta);
+					LOG.debug("Rolling back feature store transaction:{}", ta);
 					ta.rollback();
 				}
 				catch (FeatureStoreException e1) {
-					LOG.debug("Error occured during rollback: " + e.getMessage(), e);
+					LOG.debug("Error occured during rollback: {}", e.getMessage(), e);
 				}
 			}
 			throw e;
@@ -320,11 +320,11 @@ class TransactionHandler {
 			LOG.trace("Stack trace:", e);
 			for (FeatureStoreTransaction ta : acquiredTransactions.values()) {
 				try {
-					LOG.debug("Rolling back feature store transaction:" + ta);
+					LOG.debug("Rolling back feature store transaction:{}", ta);
 					ta.rollback();
 				}
 				catch (FeatureStoreException e1) {
-					LOG.debug("Error occured during rollback: " + e.getMessage(), e);
+					LOG.debug("Error occured during rollback: {}", e.getMessage(), e);
 				}
 			}
 			throw new OWSException("Error occured during transaction: " + e.getMessage(), NO_APPLICABLE_CODE);
@@ -346,7 +346,7 @@ class TransactionHandler {
 
 	private void doDelete(Delete delete, Lock lock) throws OWSException {
 
-		LOG.debug("doDelete: " + delete);
+		LOG.debug("doDelete: {}", delete);
 		QName ftName = delete.getTypeName();
 		FeatureStore fs = service.getStore(ftName);
 		if (fs == null) {
@@ -378,7 +378,7 @@ class TransactionHandler {
 
 	private void doInsert(Insert insert) throws OWSException {
 
-		LOG.debug("doInsert: " + insert);
+		LOG.debug("doInsert: {}", insert);
 
 		if (service.getStores().length == 0) {
 			throw new OWSException("Cannot perform insert. No feature store defined.", NO_APPLICABLE_CODE);
@@ -520,12 +520,12 @@ class TransactionHandler {
 					}
 				}
 				else {
-					LOG.debug("Ignoring element '" + elName + "'");
+					LOG.debug("Ignoring element '{}'", elName);
 					XMLStreamUtils.skipElement(xmlStream);
 				}
 			}
 			else {
-				LOG.debug("Ignoring element '" + elName + "'");
+				LOG.debug("Ignoring element '{}'", elName);
 				XMLStreamUtils.skipElement(xmlStream);
 			}
 		}
@@ -536,7 +536,7 @@ class TransactionHandler {
 	}
 
 	private void doNative(Native nativeOp) throws OWSException {
-		LOG.debug("doNative: " + nativeOp);
+		LOG.debug("doNative: {}", nativeOp);
 		if (nativeOp.isSafeToIgnore() == false) {
 			throw new OWSException("Native operations are not supported by this WFS.", INVALID_PARAMETER_VALUE,
 					"Native");
@@ -553,7 +553,7 @@ class TransactionHandler {
 	}
 
 	private void doUpdate(Update update, Lock lock) throws OWSException {
-		LOG.debug("doUpdate: " + update);
+		LOG.debug("doUpdate: {}", update);
 		QName ftName = update.getTypeName();
 		FeatureType ft = service.lookupFeatureType(ftName);
 		FeatureStore fs = service.getStore(ftName);
@@ -693,7 +693,7 @@ class TransactionHandler {
 
 	private void doReplace(Replace replace, Lock lock) throws OWSException {
 
-		LOG.debug("doReplace: " + replace);
+		LOG.debug("doReplace: {}", replace);
 		XMLStreamReader xmlStream = replace.getReplacementFeatureStream();
 		QName ftName = xmlStream.getName();
 		FeatureStore fs = service.getStore(ftName);
@@ -730,7 +730,7 @@ class TransactionHandler {
 		FeatureStoreTransaction ta = acquiredTransactions.get(fs);
 		if (ta == null) {
 			try {
-				LOG.debug("Acquiring transaction for feature store " + fs);
+				LOG.debug("Acquiring transaction for feature store {}", fs);
 				ta = fs.acquireTransaction();
 				acquiredTransactions.put(fs, ta);
 			}
@@ -758,7 +758,7 @@ class TransactionHandler {
 				writeHandle(xmlWriter, handle);
 				Collection<String> fids = inserted.getFids(handle);
 				for (String fid : fids) {
-					LOG.debug("Inserted fid: " + fid);
+					LOG.debug("Inserted fid: {}", fid);
 					xmlWriter.writeStartElement("ogc", "FeatureId", OGCNS);
 					xmlWriter.writeAttribute("fid", fid);
 					xmlWriter.writeEndElement();
@@ -768,7 +768,7 @@ class TransactionHandler {
 			if (!inserted.getFidsWithoutHandle().isEmpty()) {
 				xmlWriter.writeStartElement("wfs", "InsertResult", WFS_NS);
 				for (String fid : inserted.getFidsWithoutHandle()) {
-					LOG.debug("Inserted fid: " + fid);
+					LOG.debug("Inserted fid: {}", fid);
 					xmlWriter.writeStartElement("ogc", "FeatureId", OGCNS);
 					xmlWriter.writeAttribute("fid", fid);
 					xmlWriter.writeEndElement();
@@ -823,7 +823,7 @@ class TransactionHandler {
 			for (String handle : inserted.getHandles()) {
 				Collection<String> fids = inserted.getFids(handle);
 				for (String fid : fids) {
-					LOG.debug("Inserted fid: " + fid);
+					LOG.debug("Inserted fid: {}", fid);
 					xmlWriter.writeStartElement(WFS_NS, "Feature");
 					xmlWriter.writeAttribute("handle", handle);
 					xmlWriter.writeStartElement(OGCNS, "FeatureId");
@@ -833,7 +833,7 @@ class TransactionHandler {
 				}
 			}
 			for (String fid : inserted.getFidsWithoutHandle()) {
-				LOG.debug("Inserted fid: " + fid);
+				LOG.debug("Inserted fid: {}", fid);
 				xmlWriter.writeStartElement(WFS_NS, "Feature");
 				xmlWriter.writeStartElement(OGCNS, "FeatureId");
 				xmlWriter.writeAttribute("fid", fid);
@@ -984,8 +984,9 @@ class TransactionHandler {
 
 	private void evaluateValidDomain(Feature feature, ICRS crs, Geometry geometry, String handle) throws OWSException {
 		if (crs == null) {
-			LOG.warn("CRS of geometry of fetaure with id {} is not available. Check if geometry is inside the valid "
-					+ "domain not possible. The check is skipped and insert processed.", feature.getId());
+			LOG.warn(
+					"CRS of geometry of fetaure with id {} is not available. Check if geometry is inside the valid domain not possible. The check is skipped and insert processed.",
+					feature.getId());
 			return;
 		}
 		double[] validDomain = crs.getValidDomain();

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -529,7 +529,7 @@ public class WebFeatureService extends AbstractOWS {
 		for (String queryCRS : queryCRSLists) {
 			String[] querySrs = StringUtils.split(queryCRS, " ", REMOVE_EMPTY_FIELDS | REMOVE_DOUBLE_FIELDS);
 			for (String srs : querySrs) {
-				LOG.debug("Query CRS: " + srs);
+				LOG.debug("Query CRS: {}", srs);
 				ICRS crs = CRSManager.getCRSRef(srs);
 				this.queryCRS.add(crs);
 			}
@@ -595,7 +595,7 @@ public class WebFeatureService extends AbstractOWS {
 				else if (formatDef instanceof CustomFormat) {
 					CustomFormat cf = (CustomFormat) formatDef;
 					String className = cf.getJavaClass();
-					LOG.info("Using custom format class '" + className + "'.");
+					LOG.info("Using custom format class '{}'.", className);
 					try {
 						format = (org.deegree.services.wfs.format.CustomFormat) Class.forName(className).newInstance();
 						((org.deegree.services.wfs.format.CustomFormat) format).init(this, cf.getConfig());
@@ -1267,7 +1267,7 @@ public class WebFeatureService extends AbstractOWS {
 	private void doGetCapabilities(GetCapabilities request, HttpResponseBuffer response)
 			throws XMLStreamException, IOException, OWSException {
 
-		LOG.debug("doGetCapabilities: " + request);
+		LOG.debug("doGetCapabilities: {}", request);
 		Version negotiatedVersion = negotiateVersion(request);
 
 		// cope with the 'All' section specifier
@@ -1313,8 +1313,8 @@ public class WebFeatureService extends AbstractOWS {
 				}
 			}
 			else {
-				LOG.warn("Found metadata for feature type '" + ftName
-						+ "', but feature type is not available from any store.");
+				LOG.warn("Found metadata for feature type '{}', but feature type is not available from any store.",
+						ftName);
 			}
 		}
 		return sortedFts;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WfsFeatureStoreManager.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WfsFeatureStoreManager.java
@@ -118,10 +118,10 @@ public class WfsFeatureStoreManager {
 
 		LOG.debug("The following prefix-to-namespace and namespace-to-prefix bindings are used for resolution...");
 		for (String prefix : prefixToNs.keySet()) {
-			LOG.debug(prefix + " --> " + prefixToNs.get(prefix));
+			LOG.debug("{} --> {}", prefix, prefixToNs.get(prefix));
 		}
 		for (String ns : targetNsToPrefix.keySet()) {
-			LOG.debug(ns + " <-- " + targetNsToPrefix.get(ns));
+			LOG.debug("{} <-- {}", ns, targetNsToPrefix.get(ns));
 		}
 	}
 
@@ -170,8 +170,8 @@ public class WfsFeatureStoreManager {
 		if (ft == null) {
 			QName match = QNameUtils.findBestMatch(ftName, ftNameToFt.keySet());
 			if (match != null && (!match.equals(ftName))) {
-				LOG.debug("Repairing unqualified FeatureType name: " + QNameUtils.toString(ftName) + " -> "
-						+ QNameUtils.toString(match));
+				LOG.debug("Repairing unqualified FeatureType name: {} -> {}", QNameUtils.toString(ftName),
+						QNameUtils.toString(match));
 				ft = ftNameToFt.get(match);
 			}
 		}

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/csv/CsvFeatureWriter.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/csv/CsvFeatureWriter.java
@@ -116,11 +116,11 @@ public class CsvFeatureWriter {
 			csvPrinter.printRecord(record);
 		}
 		catch (IOException e) {
-			LOG.debug("Export of feature with ID " + feature.getId() + " failed", e);
+			LOG.debug("Export of feature with ID {} failed", feature.getId(), e);
 			throw e;
 		}
 		catch (TransformationException | UnknownCRSException e) {
-			LOG.debug("Export of feature with ID " + feature.getId() + " failed", e);
+			LOG.debug("Export of feature with ID {} failed", feature.getId(), e);
 			throw new IOException("Could not write Feature as CSV Entry.", e);
 		}
 	}
@@ -159,7 +159,7 @@ public class CsvFeatureWriter {
 				|| p instanceof FeaturePropertyType || p instanceof GeometryPropertyType
 				|| p instanceof SimplePropertyType || p instanceof StringOrRef;
 		if (!isSupportedProperty)
-			LOG.warn("Property with name " + p.getName() + " cannot be exported as CSV");
+			LOG.warn("Property with name {} cannot be exported as CSV", p.getName());
 		return isSupportedProperty;
 	}
 

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/BufferableXMLStreamWriter.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/BufferableXMLStreamWriter.java
@@ -236,7 +236,7 @@ public class BufferableXMLStreamWriter implements XMLStreamWriter {
 
 	public void activateBuffering() throws XMLStreamException {
 		if (activeWriter == sink) {
-			LOG.debug("Switching to buffered XMLStreamWriter, openElements: " + openElements);
+			LOG.debug("Switching to buffered XMLStreamWriter, openElements: {}", openElements);
 			buffer = new StreamBufferStore(MEMORY_BUFFER_SIZE_IN_BYTES);
 			XMLOutputFactory of = XMLOutputFactory.newInstance();
 			activeWriter = of.createXMLStreamWriter(buffer, "UTF-8");
@@ -252,7 +252,7 @@ public class BufferableXMLStreamWriter implements XMLStreamWriter {
 			String ns = namespaceIter.next();
 			String prefix = nsBindings.getPrefix(ns);
 			activeWriter.writeNamespace(prefix, ns);
-			LOG.debug(prefix + "->" + ns);
+			LOG.debug("{}->{}", prefix, ns);
 		}
 		if (nsBindings.getPrefix(XSINS) == null) {
 			activeWriter.writeNamespace(XSI_PREFIX, XSINS);

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
@@ -198,7 +198,7 @@ public class GmlFormat implements Format {
 					formatter = (CoordinateFormatter) Class.forName(customFormatterConf.getJavaClass()).newInstance();
 				}
 				else {
-					LOG.warn("Unexpected JAXB type '" + formatterConf.getClass() + "'.");
+					LOG.warn("Unexpected JAXB type '{}'.", formatterConf.getClass());
 				}
 			}
 		}

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlDescribeFeatureTypeHandler.java
@@ -130,7 +130,7 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
 		URL baseUrl = DescribeFeatureType.class.getResource("/META-INF/SCHEMAS_OPENGIS_NET");
 		if (baseUrl != null) {
 			this.ogcSchemaJarBaseURL = baseUrl.toString();
-			LOG.debug("GmlDescribeFeatureTypeHandler OGC Schema Jar Base URL: '" + this.ogcSchemaJarBaseURL + "'");
+			LOG.debug("GmlDescribeFeatureTypeHandler OGC Schema Jar Base URL: '{}'", this.ogcSchemaJarBaseURL);
 
 		}
 	}
@@ -153,13 +153,13 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
 	 */
 	public void doDescribeFeatureType(DescribeFeatureType request, HttpResponseBuffer response)
 			throws OWSException, XMLStreamException, IOException {
-		LOG.debug("doDescribeFeatureType: " + request);
+		LOG.debug("doDescribeFeatureType: {}", request);
 
 		String mimeType = options.getMimeType();
 		GMLVersion version = options.getGmlVersion();
 
-		LOG.debug("contentType:" + response.getContentType());
-		LOG.debug("characterEncoding:" + response.getCharacterEncoding());
+		LOG.debug("contentType:{}", response.getContentType());
+		LOG.debug("characterEncoding:{}", response.getCharacterEncoding());
 
 		XMLStreamWriter writer = WebFeatureService.getXMLResponseWriter(response, mimeType, null);
 
@@ -187,13 +187,13 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
 	 */
 	public void doDescribeFeatureTypeInSoap(DescribeFeatureType request, HttpResponseBuffer response)
 			throws OWSException, XMLStreamException, IOException {
-		LOG.debug("doDescribeFeatureTypeInSoap: " + request);
+		LOG.debug("doDescribeFeatureTypeInSoap: {}", request);
 
 		String mimeType = options.getMimeType();
 		GMLVersion version = options.getGmlVersion();
 
-		LOG.debug("contentType:" + response.getContentType());
-		LOG.debug("characterEncoding:" + response.getCharacterEncoding());
+		LOG.debug("contentType:{}", response.getContentType());
+		LOG.debug("characterEncoding:{}", response.getCharacterEncoding());
 
 		XMLStreamWriter writer = WebFeatureService.getXMLResponseWriter(response, mimeType, null);
 
@@ -337,12 +337,13 @@ public class GmlDescribeFeatureTypeHandler extends AbstractGmlRequestHandler {
 		String ogcSchemaPath = uri.substring(ogcSchemaJarBaseURL.length());
 		if (!ogcSchemaPath.startsWith("/")) {
 			ogcSchemaLocation.append("/");
-			LOG.debug("OGC Schema path from internal Jar did not include starting '/'. Path: '" + ogcSchemaPath
-					+ "'. Prefixed with '/' to complete URL....");
+			LOG.debug(
+					"OGC Schema path from internal Jar did not include starting '/'. Path: '{}'. Prefixed with '/' to complete URL....",
+					ogcSchemaPath);
 		}
 		ogcSchemaLocation.append(ogcSchemaPath);
 
-		LOG.debug("Translated OGC Schema Jar URL to schemaLocation: '" + ogcSchemaLocation + "'");
+		LOG.debug("Translated OGC Schema Jar URL to schemaLocation: '{}'", ogcSchemaLocation);
 
 		return ogcSchemaLocation.toString();
 		// Old behaviour

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetFeatureHandler.java
@@ -750,7 +750,7 @@ public class GmlGetFeatureHandler extends AbstractGmlRequestHandler {
 			if (request.getQueries().get(0) instanceof StoredQuery) {
 				StoredQuery getFeatureByIdQuery = (StoredQuery) request.getQueries().get(0);
 				if (getFeatureByIdQuery.getId().equals(GET_FEATURE_BY_ID)) {
-					LOG.debug("processing " + GET_FEATURE_BY_ID + " request");
+					LOG.debug("processing {} request", GET_FEATURE_BY_ID);
 					return true;
 				}
 			}

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetPropertyValueHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/request/GmlGetPropertyValueHandler.java
@@ -95,7 +95,7 @@ public class GmlGetPropertyValueHandler extends AbstractGmlRequestHandler {
 
 	public void doGetPropertyValueResult(GetPropertyValue request, HttpResponseBuffer response) throws Exception {
 
-		LOG.debug("doGetPropertyValue: " + request);
+		LOG.debug("doGetPropertyValue: {}", request);
 
 		QueryAnalyzer analyzer = new QueryAnalyzer(Collections.singletonList(request.getQuery()), format.getMaster(),
 				format.getMaster().getStoreManager(), options.isCheckAreaOfUse());
@@ -279,7 +279,7 @@ public class GmlGetPropertyValueHandler extends AbstractGmlRequestHandler {
 	public void doGetPropertyValueHits(GetPropertyValue request, HttpResponseBuffer response)
 			throws FeatureStoreException, FilterEvaluationException, IOException, OWSException, XMLStreamException {
 
-		LOG.debug("Performing doGetPropertyValue (HITS) request: " + request);
+		LOG.debug("Performing doGetPropertyValue (HITS) request: {}", request);
 
 		QueryAnalyzer analyzer = new QueryAnalyzer(Collections.singletonList(request.getQuery()), format.getMaster(),
 				format.getMaster().getStoreManager(), options.isCheckAreaOfUse());

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/QueryAnalyzer.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/QueryAnalyzer.java
@@ -580,8 +580,8 @@ public class QueryAnalyzer {
 			throw new OWSException(msg, INVALID_PARAMETER_VALUE, "PropertyName");
 		}
 		if (!match.equals(propName.getAsQName())) {
-			LOG.debug("Repairing unqualified PropertyName: " + QNameUtils.toString(propName.getAsQName()) + " -> "
-					+ QNameUtils.toString(match));
+			LOG.debug("Repairing unqualified PropertyName: {} -> {}", QNameUtils.toString(propName.getAsQName()),
+					QNameUtils.toString(match));
 			// vague match
 			String text = match.getLocalPart();
 			if (!match.getPrefix().equals(DEFAULT_NS_PREFIX)) {

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/StoredQueryHandler.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/StoredQueryHandler.java
@@ -404,8 +404,8 @@ public class StoredQueryHandler {
 
 	private void loadManagedStoredQueries(File managedStoredQueryDirectory) {
 		if (!supportsManagedStoredQuery) {
-			LOG.warn("Managed stored query directory does not exist. "
-					+ "CreateStoredQuery/DropStoredQuery requests cannot be processed.");
+			LOG.warn(
+					"Managed stored query directory does not exist. CreateStoredQuery/DropStoredQuery requests cannot be processed.");
 			return;
 		}
 		for (File managedStoredQuery : managedStoredQueryDirectory.listFiles()) {
@@ -555,7 +555,7 @@ public class StoredQueryHandler {
 			addStoredQuery(xmlAdapter.parse(), u, isManaged);
 		}
 		catch (Exception e) {
-			LOG.warn("Could not parse stored query " + u.toString() + ". Reason: " + e.getMessage());
+			LOG.warn("Could not parse stored query {}. Reason: {}", u.toString(), e.getMessage());
 			LOG.trace("Stack trace:", e);
 		}
 	}

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -785,7 +785,7 @@ public class WMSController extends AbstractOWS {
 			img = ColorQuantizer.quantizeImage(img, 256, false, false);
 			format = "png";
 		}
-		LOG.debug("Sending in format " + format);
+		LOG.debug("Sending in format {}", format);
 		if (!write(img, format, response.getOutputStream())) {
 			throw new OWSException(get("WMS.CANNOT_ENCODE_IMAGE", format), OWSException.NO_APPLICABLE_CODE);
 		}

--- a/deegree-services/deegree-services-wmts/src/main/java/org/deegree/services/wmts/controller/capabilities/WMTSCapabilitiesWriter.java
+++ b/deegree-services/deegree-services-wmts/src/main/java/org/deegree/services/wmts/controller/capabilities/WMTSCapabilitiesWriter.java
@@ -207,8 +207,7 @@ public class WMTSCapabilitiesWriter extends OWSCapabilitiesXMLAdapter {
 					maxY = max.get1();
 				}
 				catch (ArrayIndexOutOfBoundsException e) {
-					LOG.error(
-							"Cannot generate WGS84 envelope for tile layer '" + md.getName() + "'. Using full extent.",
+					LOG.error("Cannot generate WGS84 envelope for tile layer '{}'. Using full extent.", md.getName(),
 							e);
 					minX = -180.0;
 					minY = -90.0;

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/ExecutionManager.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/ExecutionManager.java
@@ -179,8 +179,8 @@ public class ExecutionManager {
 		ProcessDefinition processDef = request.getProcessDefinition();
 		ProcessletInputs inputs = request.getDataInputs();
 		RequestedOutput output = ((RawDataOutput) request.getResponseForm()).getRequestedOutput();
-		LOG.debug("RawDataOutput, parameter: " + output.getOutputType().getIdentifier().getValue() + ", mimeType: "
-				+ output.getMimeType());
+		LOG.debug("RawDataOutput, parameter: {}, mimeType: {}", output.getOutputType().getIdentifier().getValue(),
+				output.getMimeType());
 
 		String mimeType = output.getMimeType();
 		String encoding = output.getEncoding();
@@ -251,7 +251,7 @@ public class ExecutionManager {
 				.getProcessOutput();
 			for (JAXBElement<? extends ProcessletOutputDefinition> element : outputParameters) {
 				ProcessletOutputDefinition outputType = element.getValue();
-				LOG.debug("- " + outputType.getIdentifier().getValue());
+				LOG.debug("- {}", outputType.getIdentifier().getValue());
 				String mimeType = null;
 				String encoding = null;
 				String schema = null;
@@ -337,8 +337,7 @@ public class ExecutionManager {
 
 		ProcessExecution status = responseDocumentIdToState.get(location);
 
-		LOG.debug(
-				"Checking if a process corresponding to output '" + location.getId() + "' is known (=still running).");
+		LOG.debug("Checking if a process corresponding to output '{}' is known (=still running).", location.getId());
 		if (status == null) {
 			LOG.debug("No. Trying to return the stored response document.");
 			if (location.getFile().exists()) {
@@ -502,7 +501,7 @@ public class ExecutionManager {
 			try {
 				executeProcess(process, request.getDataInputs(), outputs, state);
 
-				LOG.debug("Storing final response document at " + responseStorage);
+				LOG.debug("Storing final response document at {}", responseStorage);
 
 				// write final ExecuteResponse document
 				try {

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/WPService.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/WPService.java
@@ -197,7 +197,7 @@ public class WPService extends AbstractOWS {
 	public void doKVP(Map<String, String> kvpParamsUC, HttpServletRequest request, HttpResponseBuffer response,
 			List<FileItem> multiParts) throws ServletException, IOException {
 
-		LOG.trace("doKVP invoked, version: " + kvpParamsUC.get("VERSION"));
+		LOG.trace("doKVP invoked, version: {}", kvpParamsUC.get("VERSION"));
 
 		RequestUtils.getCurrentThreadRequestParameters().set(kvpParamsUC);
 		try {
@@ -433,7 +433,7 @@ public class WPService extends AbstractOWS {
 	private void doGetCapabilities(GetCapabilities request, HttpResponseBuffer response)
 			throws OWSException, XMLStreamException, IOException {
 
-		LOG.trace("doGetCapabilities invoked, request: " + request);
+		LOG.trace("doGetCapabilities invoked, request: {}", request);
 
 		// generic check if requested version is supported (currently this is only 1.0.0)
 		negotiateVersion(request);
@@ -448,12 +448,12 @@ public class WPService extends AbstractOWS {
 
 	private void doDescribeProcess(DescribeProcessRequest request, HttpResponseBuffer response) throws OWSException {
 
-		LOG.trace("doDescribeProcess invoked, request: " + request);
+		LOG.trace("doDescribeProcess invoked, request: {}", request);
 
 		// check that all requested processes exist (and resolve special value 'ALL')
 		List<WPSProcess> processes = new ArrayList<WPSProcess>();
 		for (CodeType identifier : request.getIdentifiers()) {
-			LOG.debug("Looking up process '" + identifier + "'");
+			LOG.debug("Looking up process '{}'", identifier);
 			if (ALL_PROCESSES_IDENTIFIER.equals(identifier)) {
 				processes.addAll(processManager.getProcesses().values());
 				break;
@@ -491,7 +491,7 @@ public class WPService extends AbstractOWS {
 		}
 		catch (XMLStreamException e) {
 			e.printStackTrace();
-			LOG.error("Internal error: " + e.getMessage());
+			LOG.error("Internal error: {}", e.getMessage());
 			throw new OWSException("Error occured while creating response for DescribeProcess operation",
 					NO_APPLICABLE_CODE);
 		}
@@ -501,7 +501,7 @@ public class WPService extends AbstractOWS {
 		}
 		catch (Exception e) {
 			e.printStackTrace();
-			LOG.error("Internal error: " + e.getMessage());
+			LOG.error("Internal error: {}", e.getMessage());
 		}
 
 		LOG.trace("doDescribeProcess finished");
@@ -509,7 +509,7 @@ public class WPService extends AbstractOWS {
 
 	private void doExecute(ExecuteRequest request, HttpResponseBuffer response) throws OWSException {
 
-		LOG.trace("doExecute invoked, request: " + request.toString());
+		LOG.trace("doExecute invoked, request: {}", request.toString());
 		long start = System.currentTimeMillis();
 
 		CodeType processId = request.getProcessId();
@@ -536,14 +536,14 @@ public class WPService extends AbstractOWS {
 		}
 
 		long elapsed = System.currentTimeMillis() - start;
-		LOG.debug("doExecute took " + elapsed + " milliseconds");
+		LOG.debug("doExecute took {} milliseconds", elapsed);
 
 		LOG.trace("doExecute finished");
 	}
 
 	private void doGetOutput(String storedOutputId, HttpResponseBuffer response) {
 
-		LOG.trace("doGetOutput invoked, requested stored output: " + storedOutputId);
+		LOG.trace("doGetOutput invoked, requested stored output: {}", storedOutputId);
 		OutputStorage resource = storageManager.lookupOutputStorage(storedOutputId);
 
 		if (resource == null) {
@@ -563,7 +563,7 @@ public class WPService extends AbstractOWS {
 
 	private void doGetResponseDocument(String responseId, HttpResponseBuffer response) {
 
-		LOG.trace("doGetResponseDocument invoked, requested stored response document: " + responseId);
+		LOG.trace("doGetResponseDocument invoked, requested stored response document: {}", responseId);
 		ResponseDocumentStorage resource = storageManager.lookupResponseDocumentStorage(responseId, getHttpGetURL());
 		executeHandler.sendResponseDocument(response, resource);
 

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestKVPAdapter.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestKVPAdapter.java
@@ -119,7 +119,7 @@ public class ExecuteRequestKVPAdapter {
 
 		// IDENTIFIER (mandatory)
 		String identifierString = kvpParams.get("IDENTIFIER");
-		LOG.debug("IDENTIFIER=" + identifierString);
+		LOG.debug("IDENTIFIER={}", identifierString);
 		if (identifierString == null) {
 			throw new OWSException("MissingParameterValue: Identifier", OWSException.MISSING_PARAMETER_VALUE,
 					"IDENTIFIER");
@@ -165,7 +165,7 @@ public class ExecuteRequestKVPAdapter {
 
 		LOG.debug("DATAINPUTS=");
 		for (String encodedParameter : encodedInputs) {
-			LOG.debug("- " + encodedParameter);
+			LOG.debug("- {}", encodedParameter);
 		}
 
 		// key: id of input parameter, value: number of occurences
@@ -181,7 +181,7 @@ public class ExecuteRequestKVPAdapter {
 				throw exceptionCustomizer
 					.invalidAttributedParameter(new Pair<String, String>("DataInputs", encodedParameter));
 			}
-			LOG.debug("AttributedParameter: " + parameter);
+			LOG.debug("AttributedParameter: {}", parameter);
 			ProcessletInput input = parseDataInput(parameter, processDef, exceptionCustomizer);
 			processInputs.add(input);
 
@@ -269,7 +269,7 @@ public class ExecuteRequestKVPAdapter {
 	private static ComplexFormatType validateAndAugmentFormat(ComplexFormatType format,
 			ComplexInputDefinition definition, ExceptionCustomizer exceptionCustomizer) throws OWSException {
 
-		LOG.debug("Looking up compatible format ('" + toString(format) + "') in parameter definition.");
+		LOG.debug("Looking up compatible format ('{}') in parameter definition.", toString(format));
 		List<ComplexFormatType> equalMimeType = null;
 		if (format.getMimeType() == null) {
 			// not specified -> assume mime type from default format
@@ -339,14 +339,14 @@ public class ExecuteRequestKVPAdapter {
 		}
 
 		ComplexFormatType matchingFormat = matchingFormats.get(0);
-		LOG.debug("Augmented format: '" + toString(matchingFormat) + "'");
+		LOG.debug("Augmented format: '{}'", toString(matchingFormat));
 		return matchingFormat;
 	}
 
 	private static ComplexFormatType validateAndAugmentFormat(ComplexFormatType format,
 			ComplexOutputDefinition definition, ExceptionCustomizer exceptionCustomizer) throws OWSException {
 
-		LOG.debug("Looking up compatible format ('" + toString(format) + "') in parameter definition.");
+		LOG.debug("Looking up compatible format ('{}') in parameter definition.", toString(format));
 		List<ComplexFormatType> equalMimeType = null;
 		if (format.getMimeType() == null) {
 			// not specified -> assume mime type from default format
@@ -416,7 +416,7 @@ public class ExecuteRequestKVPAdapter {
 		}
 
 		ComplexFormatType matchingFormat = matchingFormats.get(0);
-		LOG.debug("Augmented format: '" + toString(matchingFormat) + "'");
+		LOG.debug("Augmented format: '{}'", toString(matchingFormat));
 		return matchingFormat;
 	}
 
@@ -429,7 +429,7 @@ public class ExecuteRequestKVPAdapter {
 			AttributedParameter parameter, ExceptionCustomizer exceptionCustomizer) throws OWSException {
 
 		String[] parts = parameter.getValue().split(",");
-		LOG.warn("Assuming two-dimensional coordinates in BBOX string: '" + parameter.getValue() + "'");
+		LOG.warn("Assuming two-dimensional coordinates in BBOX string: '{}'", parameter.getValue());
 		if (parts.length < 4) {
 			throw exceptionCustomizer.inputInvalidBBoxCoordinates(inputId, parts);
 		}
@@ -485,8 +485,8 @@ public class ExecuteRequestKVPAdapter {
 		// values were defined in the process
 		// description!!!).
 		if (definition.getAllowedValues() != null && !definition.getAllowedValues().getValueOrRange().isEmpty()) {
-			LOG.warn(inputId + ", validating supplied value: " + parameter.getValue()
-					+ " against the allowed values is not yet implemented.");
+			LOG.warn("{}, validating supplied value: {} against the allowed values is not yet implemented.", inputId,
+					parameter.getValue());
 		}
 		// "uom" attribute (optional)
 		String uom = parameter.getUom();
@@ -636,11 +636,11 @@ public class ExecuteRequestKVPAdapter {
 	private static ProcessletInputDefinition lookupInputDefinition(CodeType identifier, ProcessDefinition processDef,
 			ExceptionCustomizer exceptionCustomizer) throws OWSException {
 
-		LOG.trace("Looking up input type: " + identifier);
+		LOG.trace("Looking up input type: {}", identifier);
 		ProcessletInputDefinition inputType = null;
 		InputParameters inputParams = processDef.getInputParameters();
 		for (JAXBElement<? extends ProcessletInputDefinition> el : inputParams.getProcessInput()) {
-			LOG.trace("Defined input type: " + el.getValue().getIdentifier().getValue());
+			LOG.trace("Defined input type: {}", el.getValue().getIdentifier().getValue());
 			org.deegree.process.jaxb.java.CodeType inputId = el.getValue().getIdentifier();
 			if (equals(identifier, inputId)) {
 				inputType = el.getValue();

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestXMLAdapter.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteRequestXMLAdapter.java
@@ -367,8 +367,8 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 		// values were defined in the process
 		// description!!!).
 		if (definition.getAllowedValues() != null && !definition.getAllowedValues().getValueOrRange().isEmpty()) {
-			LOG.warn(identifier + ", validating supplied value: " + value
-					+ " against the allowed values is not yet implemented.");
+			LOG.warn("{}, validating supplied value: {} against the allowed values is not yet implemented.", identifier,
+					value);
 		}
 
 		// "uom" attribute (optional)
@@ -611,7 +611,7 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 	private ComplexFormatType validateAndAugmentFormat(ComplexFormatType format, ComplexInputDefinition definition,
 			ExceptionCustomizer eCustomizer) throws OWSException {
 
-		LOG.debug("Looking up compatible format ('" + toString(format) + "') in parameter definition.");
+		LOG.debug("Looking up compatible format ('{}') in parameter definition.", toString(format));
 		List<ComplexFormatType> equalMimeType = null;
 		if (format.getMimeType() == null) {
 			// not specified -> assume mime type from default format
@@ -673,14 +673,14 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 		}
 
 		ComplexFormatType matchingFormat = matchingFormats.get(0);
-		LOG.debug("Augmented format: '" + toString(matchingFormat) + "'");
+		LOG.debug("Augmented format: '{}'", toString(matchingFormat));
 		return matchingFormat;
 	}
 
 	private ComplexFormatType validateAndAugmentFormat(ComplexFormatType format, ComplexOutputDefinition definition,
 			ExceptionCustomizer eCustomizer) throws OWSException {
 
-		LOG.debug("Looking up compatible format ('" + toString(format) + "') in parameter definition.");
+		LOG.debug("Looking up compatible format ('{}') in parameter definition.", toString(format));
 		List<ComplexFormatType> equalMimeType = null;
 		if (format.getMimeType() == null) {
 			// not specified -> assume mime type from default format
@@ -742,7 +742,7 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 		}
 
 		ComplexFormatType matchingFormat = matchingFormats.get(0);
-		LOG.debug("Augmented format: '" + toString(matchingFormat) + "'");
+		LOG.debug("Augmented format: '{}'", toString(matchingFormat));
 		return matchingFormat;
 	}
 
@@ -843,7 +843,7 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 
 		// "asReference" attribute (optional)
 		boolean asReference = getNodeAsBoolean(outputElement, new XPath("@asReference", nsContext), false);
-		LOG.debug("attribute 'asReference': " + asReference);
+		LOG.debug("attribute 'asReference': {}", asReference);
 
 		// "ows:Title" element (minOccurs="0", maxOccurs="1")
 		LanguageString title = null;
@@ -874,8 +874,8 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 		String mimeType = rawDataOutputElement.getAttributeValue(new QName("mimeType"));
 		if (mimeType == null) {
 			if (outputType instanceof ComplexOutputDefinition) {
-				LOG.debug("No mime type specified. Defaulting to '"
-						+ ((ComplexOutputDefinition) outputType).getDefaultFormat().getMimeType() + "'");
+				LOG.debug("No mime type specified. Defaulting to '{}'",
+						((ComplexOutputDefinition) outputType).getDefaultFormat().getMimeType());
 				mimeType = ((ComplexOutputDefinition) outputType).getDefaultFormat().getMimeType();
 			}
 		}
@@ -923,12 +923,12 @@ public class ExecuteRequestXMLAdapter extends OWSCommonXMLAdapter {
 	private ProcessletInputDefinition lookupInputDefinition(CodeType identifier, ProcessDefinition processDef,
 			ExceptionCustomizer eCustomizer) throws OWSException {
 
-		LOG.trace("Looking up input type: " + identifier);
+		LOG.trace("Looking up input type: {}", identifier);
 		ProcessletInputDefinition inputType = null;
 		InputParameters inputParams = processDef.getInputParameters();
 		if (inputParams != null) {
 			for (JAXBElement<? extends ProcessletInputDefinition> el : inputParams.getProcessInput()) {
-				LOG.trace("Defined input type: " + el.getValue().getIdentifier().getValue());
+				LOG.trace("Defined input type: {}", el.getValue().getIdentifier().getValue());
 				org.deegree.process.jaxb.java.CodeType inputId = el.getValue().getIdentifier();
 				if (equals(identifier, inputId)) {
 					inputType = el.getValue();

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteResponseXMLWriter.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/execute/ExecuteResponseXMLWriter.java
@@ -470,7 +470,7 @@ public class ExecuteResponseXMLWriter extends XMLAdapter {
 		writer.writeStartElement(WPS_NS, "ProcessOutputs");
 
 		for (RequestedOutput requestedOutput : requestedOutputs) {
-			LOG.debug("- exporting " + requestedOutput.getIdentifier());
+			LOG.debug("- exporting {}", requestedOutput.getIdentifier());
 			ProcessletOutput output = outputs.getParameter(requestedOutput.getIdentifier());
 			exportOutput(writer, (ProcessletOutputImpl) output, requestedOutput);
 		}

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/input/EmbeddedComplexInput.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/input/EmbeddedComplexInput.java
@@ -113,11 +113,11 @@ public class EmbeddedComplexInput extends ComplexInputImpl {
 		ByteArrayInputStream is = null;
 
 		if ("base64".equals(getEncoding())) {
-			LOG.debug("Performing base64 decoding of embedded ComplexInput: " + textValue);
+			LOG.debug("Performing base64 decoding of embedded ComplexInput: {}", textValue);
 			is = new ByteArrayInputStream(Base64.decodeBase64(textValue));
 		}
 		else {
-			LOG.warn("Unsupported encoding '" + getEncoding() + "'.");
+			LOG.warn("Unsupported encoding '{}'.", getEncoding());
 			is = new ByteArrayInputStream(textValue.getBytes());
 		}
 

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/input/InputReference.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/input/InputReference.java
@@ -114,13 +114,13 @@ public class InputReference {
 	 */
 	public InputStream openStream() throws IOException {
 
-		LOG.debug("Opening HTTP stream for InputReference: " + this);
+		LOG.debug("Opening HTTP stream for InputReference: {}", this);
 		InputStream is = null;
 		if (usePostMethod) {
 			LOG.debug("POST");
 			InputStream postBodyInputStream = null;
 			if (postBodyReference != null) {
-				LOG.debug("Using post body from: URL '" + postBodyReference + "'");
+				LOG.debug("Using post body from: URL '{}'", postBodyReference);
 				// retrieve the post body (may be a file URL, so don't use HttpUtils here)
 				postBodyInputStream = postBodyReference.openStream();
 			}
@@ -129,7 +129,7 @@ public class InputReference {
 				OMElement childPostBodyElement = postBodyElement.getFirstElement();
 				if (childPostBodyElement != null) {
 					String postBodyString = childPostBodyElement.toString();
-					LOG.debug("Using post body '" + postBodyString + "'");
+					LOG.debug("Using post body '{}'", postBodyString);
 					// TODO what about the encoding here?
 					is = new ByteArrayInputStream(postBodyString.getBytes());
 					postBodyInputStream = is;

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/output/ComplexOutputImpl.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/output/ComplexOutputImpl.java
@@ -104,7 +104,7 @@ public class ComplexOutputImpl extends ProcessletOutputImpl implements ComplexOu
 			String requestedMimeType, String requestedSchema, String requestedEncoding)
 			throws FileNotFoundException, XMLStreamException {
 		super(outputType, isRequested);
-		LOG.debug("Creating sink for complex output at location '" + location + "'");
+		LOG.debug("Creating sink for complex output at location '{}'", location);
 		this.location = location;
 		os = location.getOutputStream();
 		this.requestedMimeType = requestedMimeType;
@@ -181,7 +181,7 @@ public class ComplexOutputImpl extends ProcessletOutputImpl implements ComplexOu
 	public void close() throws XMLStreamException, IOException {
 
 		if (streamWriter != null) {
-			LOG.debug("Closing sink for xml output at location '" + location + "'");
+			LOG.debug("Closing sink for xml output at location '{}'", location);
 			streamWriter.writeEndDocument();
 			streamWriter.flush();
 			streamWriter.close();
@@ -191,7 +191,7 @@ public class ComplexOutputImpl extends ProcessletOutputImpl implements ComplexOu
 		}
 		else {
 			if (location != null) {
-				LOG.debug("Closing sink for raw output at location '" + location + "'");
+				LOG.debug("Closing sink for raw output at location '{}'", location);
 				os.flush();
 				os.close();
 				is = new BufferedInputStream(location.getInputStream());

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/provider/JavaProcessProvider.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/provider/JavaProcessProvider.java
@@ -87,8 +87,8 @@ public class JavaProcessProvider implements ProcessProvider {
 					processDefinition.getIdentifier().getCodeSpace());
 			String className = processDefinition.getJavaClass();
 			try {
-				LOG.info("Initializing process with id '" + processId + "'");
-				LOG.info("- process class: " + className);
+				LOG.info("Initializing process with id '{}'", processId);
+				LOG.info("- process class: {}", className);
 				Processlet processlet = (Processlet) Class.forName(className, true, workspace.getModuleClassLoader())
 					.newInstance();
 				processlet.init();

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/storage/OutputStorage.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/storage/OutputStorage.java
@@ -70,7 +70,7 @@ public class OutputStorage extends StorageLocation {
 
 	private void storeMimeType() throws IOException {
 		File mimeInfoFile = new File(file.getPath() + ".mimeinfo");
-		LOG.debug("Storing output mime type ('" + mimeType + "') in file '" + mimeInfoFile + "'");
+		LOG.debug("Storing output mime type ('{}') in file '{}'", mimeType, mimeInfoFile);
 		BufferedWriter writer = new BufferedWriter(new FileWriter(mimeInfoFile));
 		if (mimeType == null) {
 			LOG.warn("No mimetype specified!? defaulting to text/xml...");
@@ -83,7 +83,7 @@ public class OutputStorage extends StorageLocation {
 	private String retrieveMimeType() {
 		String mimeType = null;
 		File mimeInfoFile = new File(file.getPath() + ".mimeinfo");
-		LOG.debug("Retrieving output mime type from file '" + mimeInfoFile + "'");
+		LOG.debug("Retrieving output mime type from file '{}'", mimeInfoFile);
 		BufferedReader reader;
 		try {
 			reader = new BufferedReader(new FileReader(mimeInfoFile));
@@ -93,7 +93,7 @@ public class OutputStorage extends StorageLocation {
 		catch (IOException e) {
 			e.printStackTrace();
 		}
-		LOG.debug("mimeType: " + mimeType);
+		LOG.debug("mimeType: {}", mimeType);
 		return mimeType;
 	}
 

--- a/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/storage/StorageManager.java
+++ b/deegree-services/deegree-services-wps/src/main/java/org/deegree/services/wps/storage/StorageManager.java
@@ -77,14 +77,16 @@ public class StorageManager {
 	 * in memory
 	 */
 	public StorageManager(File baseDir, int inputDiskSwitchLimit) {
-		LOG.info("Using directory '" + baseDir + "' for publishing complex outputs and response documents.");
+		LOG.info("Using directory '{}' for publishing complex outputs and response documents.", baseDir);
 		if (!baseDir.exists()) {
-			LOG.error("Configured WPS storage directory name '" + baseDir
-					+ "' does not exist. Please create this directory or adapt the WPS configuration.");
+			LOG.error(
+					"Configured WPS storage directory name '{}' does not exist. Please create this directory or adapt the WPS configuration.",
+					baseDir);
 		}
 		if (!baseDir.isDirectory()) {
-			LOG.error("Configured WPS resource directory name '" + baseDir
-					+ "' is not a directory. Please create this directory or adapt the WPS configuration.");
+			LOG.error(
+					"Configured WPS resource directory name '{}' is not a directory. Please create this directory or adapt the WPS configuration.",
+					baseDir);
 		}
 		this.baseDir = baseDir;
 		this.inputDiskSwitchLimit = inputDiskSwitchLimit;
@@ -96,7 +98,7 @@ public class StorageManager {
 		String resourceName = OUTPUT_PREFIX + outputId;
 		File resourceFile = new File(baseDir, resourceName);
 		if (resourceFile.exists()) {
-			LOG.debug("File '" + resourceFile + "' already exists. Deleting it.");
+			LOG.debug("File '{}' already exists. Deleting it.", resourceFile);
 			resourceFile.delete();
 		}
 		return new OutputStorage(resourceFile, outputId, mimeType);
@@ -108,7 +110,7 @@ public class StorageManager {
 		String resourceName = RESPONSE_PREFIX + responseId;
 		File resourceFile = new File(baseDir, resourceName);
 		if (resourceFile.exists()) {
-			LOG.debug("File '" + resourceFile + "' already exists. Deleting it.");
+			LOG.debug("File '{}' already exists. Deleting it.", resourceFile);
 			resourceFile.delete();
 		}
 		return new ResponseDocumentStorage(resourceFile, responseId, getUrl);
@@ -123,7 +125,7 @@ public class StorageManager {
 			}
 		}
 		catch (IOException e) {
-			LOG.debug("Cannot access stored output (file='" + resourceFile + "')");
+			LOG.debug("Cannot access stored output (file='{}')", resourceFile);
 		}
 		return output;
 	}
@@ -134,7 +136,7 @@ public class StorageManager {
 		String resourceName = INPUT_PREFIX + outputId;
 		File resourceFile = new File(baseDir, resourceName);
 		if (resourceFile.exists()) {
-			LOG.debug("File '" + resourceFile + "' already exists. Deleting it.");
+			LOG.debug("File '{}' already exists. Deleting it.", resourceFile);
 			resourceFile.delete();
 		}
 		return new StreamBufferStore(inputDiskSwitchLimit, resourceFile);

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/PerspectiveViewService.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/PerspectiveViewService.java
@@ -211,8 +211,7 @@ public class PerspectiveViewService {
 						}
 					}
 					catch (URISyntaxException e) {
-						LOG.error(
-								"Unable to load copyright image from: " + url + " because: " + e.getLocalizedMessage());
+						LOG.error("Unable to load copyright image from: {} because: {}", url, e.getLocalizedMessage());
 						LOG.trace("Stack trace:", e);
 					}
 
@@ -340,7 +339,7 @@ public class PerspectiveViewService {
 		}
 		catch (Throwable t) {
 			LOG.debug("Error while initializing opengl values stack track.", t);
-			LOG.error("Error while initializing opengl values (may not be important): " + t.getLocalizedMessage());
+			LOG.error("Error while initializing opengl values (may not be important): {}", t.getLocalizedMessage());
 		}
 
 	}
@@ -454,15 +453,15 @@ public class PerspectiveViewService {
 	public final BufferedImage getImage(GetView request) throws OWSException {
 
 		ViewParams viewParams = request.getViewParameters();
-		LOG.debug("Requested datasets: " + request.getDatasets());
+		LOG.debug("Requested datasets: {}", request.getDatasets());
 		updateMaxWidthAndHeight(viewParams);
 		TerrainRenderingManager demRenderer = defaultDEMRenderer;
 		List<TextureManager> textureManagers = getTextureManagers(request.getDatasets(), viewParams);
-		LOG.debug("Texturemanagers: " + textureManagers);
+		LOG.debug("Texturemanagers: {}", textureManagers);
 		List<RenderableManager<?>> buildingRenders = getBuildingRenderers(request.getDatasets(), viewParams);
-		LOG.debug("Buildings : " + buildingRenders);
+		LOG.debug("Buildings : {}", buildingRenders);
 		Colormap colormap = getColormap(request.getDatasets(), viewParams);
-		LOG.debug("Colormap: " + colormap);
+		LOG.debug("Colormap: {}", colormap);
 		PooledByteBuffer imageBuffer = this.resultImagePool.allocate(resultImageSize);
 		RenderContext context = new RenderContext(viewParams, request.getSceneParameters().getScale(),
 				this.maxTextureSize, configuredOpenGLInitValues.getCompositingTextureShaderPrograms());

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/ColormapDataset.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/ColormapDataset.java
@@ -85,8 +85,9 @@ public class ColormapDataset extends Dataset<Colormap> {
 			for (ColormapDatasetConfig dts : colormapDatsets) {
 				if (dts != null) {
 					if (isUnAmbiguous(dts.getTitle())) {
-						LOG.info("The colormap dataset with name: " + dts.getName() + " and title: " + dts.getTitle()
-								+ " had multiple definitions in your service configuration.");
+						LOG.info(
+								"The colormap dataset with name: {} and title: {} had multiple definitions in your service configuration.",
+								dts.getName(), dts.getTitle());
 					}
 					else {
 						sceneEnvelope = handleColormapDataset(dts, sceneEnvelope, toLocalCRS);
@@ -112,7 +113,7 @@ public class ColormapDataset extends Dataset<Colormap> {
 		double zMin = dts.getMinZValue() == null ? sceneEnvelope.getMin().get2() : dts.getMinZValue();
 		Colormap result = new Colormap((float) zMin, (float) zMax, minColor, maxColor, heightColor);
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Configured colormap: " + dts.getTitle() + " | " + result.toString());
+			LOG.debug("Configured colormap: {} | {}", dts.getTitle(), result.toString());
 		}
 		double[] min = Arrays.copyOf(sceneEnvelope.getMin().getAsArray(), 3);
 		double[] max = Arrays.copyOf(sceneEnvelope.getMax().getAsArray(), 3);
@@ -142,8 +143,7 @@ public class ColormapDataset extends Dataset<Colormap> {
 				}
 			}
 			catch (NumberFormatException e) {
-				LOG.warn("Invalid color: " + configColor + " using default color: " + Arrays.toString(defaultColor)
-						+ ".", e);
+				LOG.warn("Invalid color: {} using default color: {}.", configColor, Arrays.toString(defaultColor), e);
 			}
 		}
 		return Arrays.copyOf(defaultColor, 4);

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/DEMDataset.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/DEMDataset.java
@@ -131,8 +131,9 @@ public class DEMDataset extends Dataset<TerrainRenderingManager> {
 			for (DEMDatasetConfig eds : demDatsets) {
 				if (eds != null) {
 					if (isUnAmbiguous(eds.getTitle())) {
-						LOG.info("The elevation model dataset with name: " + eds.getName() + " and title: "
-								+ eds.getTitle() + " had multiple definitions in your service configuration.");
+						LOG.info(
+								"The elevation model dataset with name: {} and title: {} had multiple definitions in your service configuration.",
+								eds.getName(), eds.getTitle());
 					}
 					else {
 						clarifyInheritance(eds, parentMaxPixelError);
@@ -140,8 +141,8 @@ public class DEMDataset extends Dataset<TerrainRenderingManager> {
 							sceneEnvelope = handleDEMDataset(eds, sceneEnvelope, toLocalCRS);
 						}
 						catch (IOException e) {
-							LOG.error("Failed to initialize configured demTexture dataset: " + eds.getName() + ": "
-									+ eds.getTitle() + " because: " + e.getLocalizedMessage(), e);
+							LOG.error("Failed to initialize configured demTexture dataset: {}: {} because: {}",
+									eds.getName(), eds.getTitle(), e.getLocalizedMessage(), e);
 						}
 					}
 				}
@@ -196,13 +197,14 @@ public class DEMDataset extends Dataset<TerrainRenderingManager> {
 				addConstraint(demDataset.getTitle(), result, datasetEnv);
 			}
 			else {
-				LOG.warn("Enable to instantiate elevation model: " + demDataset.getName() + ": " + demDataset.getTitle()
-						+ " because no files (pointing to a Multiresolution Mesh file) could be resolved.");
+				LOG.warn(
+						"Enable to instantiate elevation model: {}: {} because no files (pointing to a Multiresolution Mesh file) could be resolved.",
+						demDataset.getName(), demDataset.getTitle());
 			}
 		}
 		else {
-			LOG.warn("Unable to instantiate elevation model"
-					+ " because no files (pointing to a Multiresolution Mesh file) were configured in the elevationmodel datasource element.");
+			LOG.warn(
+					"Unable to instantiate elevation model because no files (pointing to a Multiresolution Mesh file) were configured in the elevationmodel datasource element.");
 		}
 		return sceneEnvelope;
 	}

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/DEMTextureDataset.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/DEMTextureDataset.java
@@ -127,8 +127,9 @@ public class DEMTextureDataset extends Dataset<TextureManager> {
 			for (DEMTextureDatasetConfig dts : textureDatasets) {
 				if (dts != null) {
 					if (isUnAmbiguous(dts.getTitle())) {
-						LOG.info("The feature dataset with name: " + dts.getName() + " and title: " + dts.getTitle()
-								+ " had multiple definitions in your service configuration.");
+						LOG.info(
+								"The feature dataset with name: {} and title: {} had multiple definitions in your service configuration.",
+								dts.getName(), dts.getTitle());
 					}
 					else {
 						clarifyInheritance(dts, parentMaxPixelError);
@@ -136,8 +137,8 @@ public class DEMTextureDataset extends Dataset<TextureManager> {
 							sceneEnvelope = handleTextureDataset(dts, sceneEnvelope, toLocalCRS, location);
 						}
 						catch (IOException e) {
-							LOG.error("Failed to initialize configured demTexture dataset: " + dts.getName() + ": "
-									+ dts.getTitle() + " because: " + e.getLocalizedMessage(), e);
+							LOG.error("Failed to initialize configured demTexture dataset: {}: {} because: {}",
+									dts.getName(), dts.getTitle(), e.getLocalizedMessage(), e);
 						}
 					}
 				}
@@ -173,7 +174,7 @@ public class DEMTextureDataset extends Dataset<TextureManager> {
 					sceneEnvelope, toLocalCRS, location);
 		}
 		else {
-			LOG.warn("No texture dataset found for texture dataset: " + textureDataset.getTitle());
+			LOG.warn("No texture dataset found for texture dataset: {}", textureDataset.getTitle());
 			return sceneEnvelope;
 		}
 
@@ -258,8 +259,8 @@ public class DEMTextureDataset extends Dataset<TextureManager> {
 			addConstraint(textureDataset.getTitle(), result, constEnv);
 		}
 		else {
-			LOG.warn("Ignoring texture dataset: " + textureDataset.getName() + ": " + textureDataset.getTitle()
-					+ " because no texture providers could be initialized.");
+			LOG.warn("Ignoring texture dataset: {}: {} because no texture providers could be initialized.",
+					textureDataset.getName(), textureDataset.getTitle());
 		}
 		return sceneEnvelope;
 	}
@@ -271,8 +272,8 @@ public class DEMTextureDataset extends Dataset<TextureManager> {
 	private Envelope fillFromCoverage(String coverageStoreId, List<TextureTileProvider> tileProviders) {
 		Coverage coverage = workspace.getResource(CoverageProvider.class, coverageStoreId);
 		if (coverage == null) {
-			LOG.warn("The coverage builder with id: " + coverageStoreId
-					+ " could not create a coverage, ignoring dataset.");
+			LOG.warn("The coverage builder with id: {} could not create a coverage, ignoring dataset.",
+					coverageStoreId);
 			return null;
 		}
 		// JAXBElement<? extends AbstractGeospatialDataSourceType>
@@ -345,7 +346,7 @@ public class DEMTextureDataset extends Dataset<TextureManager> {
 					unitsPerPixel, cacheDir, Math.round(cacheSize * 1024 * 1024 * 1024));
 		}
 		catch (FeatureStoreException e) {
-			LOG.error("Error retrieving envelope from FeatureStore: " + e.getMessage(), e);
+			LOG.error("Error retrieving envelope from FeatureStore: {}", e.getMessage(), e);
 			throw new IOException("Error retrieving envelope from FeatureStore: " + e.getMessage(), e);
 		}
 		tileProviders.add(tProv);

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/Dataset.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/Dataset.java
@@ -129,8 +129,9 @@ public abstract class Dataset<CO> {
 		}
 		Constraint<CO> newC = new Constraint<CO>(datasourceObject, bbt);
 		if (newC.getValidEnvelope().getMin().getCoordinateDimension() != 3) {
-			LOG.warn("Given envelope of datasource: " + name
-					+ " is not 3 dimensional, please configure this datasource to be 3d.");
+			LOG.warn(
+					"Given envelope of datasource: {} is not 3 dimensional, please configure this datasource to be 3d.",
+					name);
 		}
 		if (dsConstraints == null) {
 			dsConstraints = new LinkedList<Constraint<CO>>();

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/RenderableDataset.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/config/RenderableDataset.java
@@ -111,8 +111,9 @@ public class RenderableDataset extends Dataset<RenderableManager<?>> {
 			for (RenderableDatasetConfig bds : datasets) {
 				if (bds != null) {
 					if (isUnAmbiguous(bds.getTitle())) {
-						LOG.info("The feature dataset with name: " + bds.getName() + " and title: " + bds.getTitle()
-								+ " had multiple definitions in your service configuration.");
+						LOG.info(
+								"The feature dataset with name: {} and title: {} had multiple definitions in your service configuration.",
+								bds.getName(), bds.getTitle());
 					}
 					else {
 						clarifyInheritance(bds, parentMaxPixelError);

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/controller/WPVSController.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/controller/WPVSController.java
@@ -210,7 +210,7 @@ public class WPVSController extends AbstractOWS {
 			return;
 		}
 		try {
-			LOG.debug("Incoming request was mapped as a: " + mappedRequest);
+			LOG.debug("Incoming request was mapped as a: {}", mappedRequest);
 			switch (mappedRequest) {
 				case GetCapabilities:
 					sendCapabilities(normalizedKVPParams, request, response);
@@ -253,7 +253,7 @@ public class WPVSController extends AbstractOWS {
 			// render the image
 			BufferedImage gvResponseImage = service.getImage(gvReq);
 			String ioFormat = mimeToFormat(format);
-			LOG.debug("Requested format: " + format + " was mapped to response ioformat: " + ioFormat);
+			LOG.debug("Requested format: {} was mapped to response ioformat: {}", format, ioFormat);
 			if (gvResponseImage != null) {
 				try {
 					ImageIO.write(gvResponseImage, ioFormat, response.getOutputStream());

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/db/DBBackend.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/db/DBBackend.java
@@ -283,7 +283,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			serializer.setGeometryBuffer(null);
 		}
 		catch (SQLException e) {
-			LOG.error("Could not get Prototypes because: " + e.getLocalizedMessage());
+			LOG.error("Could not get Prototypes because: {}", e.getLocalizedMessage());
 		}
 		return result;
 	}
@@ -297,7 +297,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			serializer.setGeometryBuffer(null);
 		}
 		catch (SQLException e) {
-			LOG.error("Could not get Buildings because: " + e.getLocalizedMessage());
+			LOG.error("Could not get Buildings because: {}", e.getLocalizedMessage());
 		}
 	}
 
@@ -308,7 +308,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			connection = getConnection();
 		}
 		catch (SQLException e) {
-			LOG.error("Could not get trees because: " + e.getLocalizedMessage());
+			LOG.error("Could not get trees because: {}", e.getLocalizedMessage());
 			return;
 		}
 		ResultSet rs = getResultSet(connection, Tables.TREES.getTableName());
@@ -327,7 +327,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 				}
 			}
 			catch (SQLException e) {
-				LOG.error("Error while getting the renderable objects from the result set: " + e.getLocalizedMessage(),
+				LOG.error("Error while getting the renderable objects from the result set: {}", e.getLocalizedMessage(),
 						e);
 			}
 		}
@@ -383,7 +383,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			connection.close();
 		}
 		catch (SQLException e) {
-			LOG.warn("Could not close connection, let the manager deal with it: " + e.getLocalizedMessage());
+			LOG.warn("Could not close connection, let the manager deal with it: {}", e.getLocalizedMessage());
 		}
 		return result;
 	}
@@ -432,7 +432,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			return deleteObjectsFromDB(objectType, sqlWhere);
 		}
 		catch (SQLException e) {
-			LOG.error("Could not delete id: " + uuid + " because: " + e.getLocalizedMessage(), e);
+			LOG.error("Could not delete id: {} because: {}", uuid, e.getLocalizedMessage(), e);
 			throw new IOException(e);
 		}
 	}
@@ -540,8 +540,8 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 		int r = ps.getUpdateCount();
 		if (r == 0) {
 			LOG.warn(
-					"Could not determine the number of deleted objects, does your sqlStatement delete objects from the database: "
-							+ deleteSQL);
+					"Could not determine the number of deleted objects, does your sqlStatement delete objects from the database: {}",
+					deleteSQL);
 		}
 		result.deleteCount = r;
 		ps.close();
@@ -595,8 +595,8 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 						}
 					}
 					catch (SQLException e) {
-						LOG.warn("Failed to insert object with uuid: " + dm.getUuid() + " because: "
-								+ e.getLocalizedMessage());
+						LOG.warn("Failed to insert object with uuid: {} because: {}", dm.getUuid(),
+								e.getLocalizedMessage());
 					}
 				}
 			}
@@ -604,13 +604,13 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 				updateBackendInfo(connection, info, objectType);
 			}
 			catch (SQLException e) {
-				LOG.warn("Could not update modelbackend info: " + e.getLocalizedMessage());
+				LOG.warn("Could not update modelbackend info: {}", e.getLocalizedMessage());
 			}
 			try {
 				connection.close();
 			}
 			catch (SQLException e) {
-				LOG.warn("Could not close connection, let the manager deal with it: " + e.getLocalizedMessage());
+				LOG.warn("Could not close connection, let the manager deal with it: {}", e.getLocalizedMessage());
 			}
 		}
 		return result;
@@ -665,7 +665,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			updateBillBoard((DataObjectInfo<BillBoard>) dm, connection, updateSQL);
 		}
 		else {
-			LOG.error("The object: " + newObject + " is of unknown type, could not update. ");
+			LOG.error("The object: {} is of unknown type, could not update. ", newObject);
 		}
 	}
 
@@ -694,7 +694,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 				dm.getUuid());
 
 		if (oldWRO == null) {
-			LOG.error("The id: " + dm.getUuid() + " is present in the database but no data was found, this is wrong.");
+			LOG.error("The id: {} is present in the database but no data was found, this is wrong.", dm.getUuid());
 		}
 		else {
 			updateInfoFile(oldWRO, info, true);
@@ -802,10 +802,10 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			int count = rs.getInt(1);
 			result = (count > 0);
 			if (count == 1) {
-				LOG.info("id: " + uuid + " is already present in the db, creating update statement. ");
+				LOG.info("id: {} is already present in the db, creating update statement. ", uuid);
 			}
 			if (count > 1) {
-				LOG.warn("id: " + uuid + " has multiple presents in the db, it is inconsistent. ");
+				LOG.warn("id: {} has multiple presents in the db, it is inconsistent. ", uuid);
 			}
 		}
 		rs.close();
@@ -861,7 +861,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			rs = getResultSet(connection, tableName, getRelevantColumnNames());
 		}
 		catch (SQLException e) {
-			LOG.error("Error while getting the renderable objects: " + e.getLocalizedMessage(), e);
+			LOG.error("Error while getting the renderable objects: {}", e.getLocalizedMessage(), e);
 		}
 		return rs;
 	}
@@ -920,7 +920,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 		}
 		rs1.close();
 
-		LOG.info("Getting " + total + " world renderable objects (buildings/prototyes).");
+		LOG.info("Getting {} world renderable objects (buildings/prototyes).", total);
 		ps = connection.prepareStatement("Select " + getRelevantColumnNames() + " FROM " + tableName);
 		// ps = connection.prepareStatement( "Select " + getRelevantColumnNames() + " FROM
 		// " + tableName
@@ -947,16 +947,16 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 					}
 					else {
 						LOG.error(
-								"Could not deserialize WorldRenderableObject from database because no data was found for uuid: "
-										+ rs.getString(RelevantColumns.uuid.getColumnName()));
+								"Could not deserialize WorldRenderableObject from database because no data was found for uuid: {}",
+								rs.getString(RelevantColumns.uuid.getColumnName()));
 					}
 					if (percentage != 0 && ((++loaded) % percentage == 0)) {
-						LOG.info("Loaded " + loaded + " of " + total + " objects from the database.");
+						LOG.info("Loaded {} of {} objects from the database.", loaded, total);
 					}
 				}
 			}
 			catch (SQLException e) {
-				LOG.error("Error while getting the renderable objects from the result set: " + e.getLocalizedMessage(),
+				LOG.error("Error while getting the renderable objects from the result set: {}", e.getLocalizedMessage(),
 						e);
 			}
 			rs.close();
@@ -996,8 +996,8 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			connection.close();
 		}
 		catch (SQLException e) {
-			LOG.debug("Error getting backendinfo: " + e.getLocalizedMessage(), e);
-			LOG.error("Unable to retrieve modelbackendinfo, this is wrong. Error was: " + e.getLocalizedMessage());
+			LOG.debug("Error getting backendinfo: {}", e.getLocalizedMessage(), e);
+			LOG.error("Unable to retrieve modelbackendinfo, this is wrong. Error was: {}", e.getLocalizedMessage());
 		}
 		return result;
 	}
@@ -1039,7 +1039,7 @@ public abstract class DBBackend<G> extends ModelBackend<G> {
 			}
 			else {
 				// create the type in the db;
-				LOG.info("No row for objectType: " + objectType.getModelTypeName() + " creating one.");
+				LOG.info("No row for objectType: {} creating one.", objectType.getModelTypeName());
 				try {
 					JDBCUtils.close(ps);
 					ps = connection

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/db/SqlRenderableStoreBuilder.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/db/SqlRenderableStoreBuilder.java
@@ -117,7 +117,7 @@ public class SqlRenderableStoreBuilder implements ResourceBuilder<RenderableStor
 			resolve = url.toURI();
 		}
 		catch (URISyntaxException e) {
-			LOG.warn("Error while resolving url for file: " + fileName + ".");
+			LOG.warn("Error while resolving url for file: {}.", fileName);
 		}
 		return resolve;
 	}

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/file/FileBackend.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/file/FileBackend.java
@@ -211,7 +211,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 					LOG.warn("Could not determine the envelope of the buildings, this is strange!");
 				}
 				else {
-					LOG.debug("The envelope of the buildings: " + datasetEnvelope);
+					LOG.debug("The envelope of the buildings: {}", datasetEnvelope);
 					// bm.setValidDomain( datasetEnvelope );
 					if (bm.getValidDomain() == null
 							|| (Math.abs(bm.getValidDomain().getSpan0() - RenderableDataset.DEFAULT_SPAN) < 1E-8)) {
@@ -229,7 +229,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 				}
 			}
 			catch (IOException e) {
-				LOG.error("Could not read buildings from file backend because: " + e.getLocalizedMessage(), e);
+				LOG.error("Could not read buildings from file backend because: {}", e.getLocalizedMessage(), e);
 			}
 		}
 	}
@@ -246,7 +246,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 				LOG.warn("Could not determine the envelope of the prototypes, this is strange!");
 			}
 			else {
-				LOG.debug("The envelope of the prototypes: " + datasetEnvelope);
+				LOG.debug("The envelope of the prototypes: {}", datasetEnvelope);
 			}
 			for (DataObjectInfo<RenderablePrototype> doi : readAllFromFile) {
 				RenderablePrototype rp = doi.getData();
@@ -259,7 +259,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Could not read prototypes from file backend because: " + e.getLocalizedMessage(), e);
+			LOG.error("Could not read prototypes from file backend because: {}", e.getLocalizedMessage(), e);
 		}
 		return result;
 	}
@@ -275,7 +275,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 					LOG.warn("Could not determine the envelope of the buildings, this is strange!");
 				}
 				else {
-					LOG.debug("The envelope of the trees: " + datasetEnvelope);
+					LOG.debug("The envelope of the trees: {}", datasetEnvelope);
 					if (tm.getValidDomain() == null
 							|| (Math.abs(tm.getValidDomain().getSpan0() - RenderableDataset.DEFAULT_SPAN) < 1E-8)) {
 						// no envelope was known (an old modelfile was read?)
@@ -288,7 +288,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 				}
 			}
 			catch (IOException e) {
-				LOG.error("Could not read trees from file backend because: " + e.getLocalizedMessage(), e);
+				LOG.error("Could not read trees from file backend because: {}", e.getLocalizedMessage(), e);
 			}
 		}
 	}
@@ -372,7 +372,7 @@ public class FileBackend extends ModelBackend<Envelope> {
 	public static void initFiles(File entityFile) throws IOException {
 		File[] files = mapFileType(entityFile);
 		for (File file : files) {
-			LOG.info("Ensuring that file '" + file + "' exists...");
+			LOG.info("Ensuring that file '{}' exists...", file);
 			if (!file.exists()) {
 				LOG.info("Not yet. Creating it.");
 				file.createNewFile();

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/file/FileRenderableStoreBuilder.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/file/FileRenderableStoreBuilder.java
@@ -120,7 +120,7 @@ public class FileRenderableStoreBuilder implements ResourceBuilder<RenderableSto
 			resolve = url.toURI();
 		}
 		catch (URISyntaxException e) {
-			LOG.warn("Error while resolving url for file: " + fileName + ".");
+			LOG.warn("Error while resolving url for file: {}.", fileName);
 		}
 		return resolve;
 	}

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/file/ModelFile.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/file/ModelFile.java
@@ -175,7 +175,7 @@ class ModelFile<P extends PositionableModel> {
 			}
 		}
 		else {
-			LOG.error("Updating is not supported for file backend, not adding object with id: " + object.getUuid());
+			LOG.error("Updating is not supported for file backend, not adding object with id: {}", object.getUuid());
 			result = false;
 		}
 		return result;
@@ -265,7 +265,7 @@ class ModelFile<P extends PositionableModel> {
 		boolean updateOldInfoFile = this.datasetEnvelope == null;
 		Envelope dsEnv = null;
 		for (Pair<Long, Long> pair : createBatches) {
-			LOG.info("Deserialized " + (++i) + " of " + createBatches.size() + " from file: " + data.getFileName());
+			LOG.info("Deserialized {} of {} from file: {}", (++i), createBatches.size(), data.getFileName());
 			Pair<Envelope, List<DataObjectInfo<P>>> fromFile = data.readAllFromFile(pair.first, pair.second, dsEnv,
 					baseCRS);
 			if (fromFile != null) {
@@ -273,8 +273,8 @@ class ModelFile<P extends PositionableModel> {
 				dsEnv = fromFile.first;
 			}
 			else {
-				LOG.warn("Could not retrieve data from positions: " + pair.first + " till: " + pair.second
-						+ " from file: " + data.getFileName());
+				LOG.warn("Could not retrieve data from positions: {} till: {} from file: {}", pair.first, pair.second,
+						data.getFileName());
 			}
 		}
 		if (updateOldInfoFile && dsEnv != null) {
@@ -308,8 +308,8 @@ class ModelFile<P extends PositionableModel> {
 				nextStep += step;
 			}
 			if (end > dataSize) {
-				LOG.warn("The data position: " + end + " is larger than the size of the datafile: " + dataSize
-						+ " this is strange.");
+				LOG.warn("The data position: {} is larger than the size of the datafile: {} this is strange.", end,
+						dataSize);
 			}
 		}
 		result.add(new Pair<Long, Long>(begin, dataSize));

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/serializer/ObjectSerializer.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/serializer/ObjectSerializer.java
@@ -277,7 +277,7 @@ public abstract class ObjectSerializer<T extends PositionableModel> {
 			baos.close();
 		}
 		catch (IOException e) {
-			LOG.error("Error while serializing object because: " + e.getLocalizedMessage(), e);
+			LOG.error("Error while serializing object because: {}", e.getLocalizedMessage(), e);
 		}
 		return baos.toByteArray();
 	}
@@ -296,16 +296,16 @@ public abstract class ObjectSerializer<T extends PositionableModel> {
 				result = (T) objectIn.readObject();
 			}
 			catch (ClassCastException e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 			catch (IOException e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 			catch (ClassNotFoundException e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 			catch (Throwable e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 		}
 		return result;

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/serializer/WROSerializer.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/serializer/WROSerializer.java
@@ -218,7 +218,7 @@ public class WROSerializer extends ObjectSerializer<WorldRenderableObject> {
 				baos.close();
 			}
 			catch (IOException e) {
-				LOG.error("Error while serializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while serializing object because: {}", e.getLocalizedMessage(), e);
 			}
 			result = baos.toByteArray();
 			doi.setSerializedData(result);
@@ -241,13 +241,13 @@ public class WROSerializer extends ObjectSerializer<WorldRenderableObject> {
 				result = readWRO(in);
 			}
 			catch (ClassCastException e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 			catch (IOException e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 			catch (Throwable e) {
-				LOG.error("Error while deserializing object because: " + e.getLocalizedMessage(), e);
+				LOG.error("Error while deserializing object because: {}", e.getLocalizedMessage(), e);
 			}
 		}
 		return result;
@@ -547,13 +547,13 @@ public class WROSerializer extends ObjectSerializer<WorldRenderableObject> {
 	private FloatBuffer getBuffer(FloatBuffer buffer, int position, int limit, VertexType type) {
 		if (buffer == null) {
 			if (geometryBuffer == null) {
-				LOG.warn("The given buffer is null and the geometry buffer was not set; the geometry has no " + type);
+				LOG.warn("The given buffer is null and the geometry buffer was not set; the geometry has no {}", type);
 			}
 			else {
 				if (position == -1) {
 					LOG.warn(
-							"The given geometry does not have a direct buffer position and no buffer; the geometry has no "
-									+ type);
+							"The given geometry does not have a direct buffer position and no buffer; the geometry has no {}",
+							type);
 				}
 				else {
 					buffer = geometryBuffer.getCoords(position, limit);
@@ -565,7 +565,7 @@ public class WROSerializer extends ObjectSerializer<WorldRenderableObject> {
 
 	private void writeFloatBuffer(FloatBuffer buffer, DataOutputStream out, VertexType type) throws IOException {
 		if (buffer == null) {
-			LOG.warn("The given geometry does not have a buffer to write; the geometry has no: " + type);
+			LOG.warn("The given geometry does not have a buffer to write; the geometry has no: {}", type);
 		}
 		BufferSerializer.writeBufferToStream(buffer, out);
 

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/rendering/jogl/ConfiguredOpenGLInitValues.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/rendering/jogl/ConfiguredOpenGLInitValues.java
@@ -119,7 +119,7 @@ public class ConfiguredOpenGLInitValues implements GLEventListener {
 	 * @param gl
 	 */
 	public void createCompositingTextureShaderPrograms(GL gl) {
-		LOG.debug("building " + numberOfTextureUnits + " shader programs");
+		LOG.debug("building {} shader programs", numberOfTextureUnits);
 		synchronized (LOCK) {
 			if (this.compositeTextureShaderPrograms == null) {
 				this.compositeTextureShaderPrograms = new ShaderProgram[this.numberOfTextureUnits];
@@ -131,8 +131,9 @@ public class ConfiguredOpenGLInitValues implements GLEventListener {
 						compositeTextureShaderPrograms[i].linkProgram(gl);
 					}
 					else {
-						LOG.warn("Could not attach compositing texture shader program: " + i
-								+ " error messages should have been supplied before this message.");
+						LOG.warn(
+								"Could not attach compositing texture shader program: {} error messages should have been supplied before this message.",
+								i);
 					}
 				}
 			}

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/rendering/jogl/GLPBufferPool.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/rendering/jogl/GLPBufferPool.java
@@ -88,9 +88,8 @@ public class GLPBufferPool {
 
 			double scale = ((double) maxTextureSize) / ((maxWidth > maxHeight) ? maxWidth : maxHeight);
 			LOG.warn(
-					"Configured maximum request Width/Height are larger than your graphicsboard allows, rescaling configured width: "
-							+ maxWidth + " to " + Math.floor(maxWidth * scale) + " | height: " + maxHeight + " to "
-							+ Math.floor(maxHeight * scale));
+					"Configured maximum request Width/Height are larger than your graphicsboard allows, rescaling configured width: {} to {} | height: {} to {}",
+					maxWidth, Math.floor(maxWidth * scale), maxHeight, Math.floor(maxHeight * scale));
 			maxWidth = (int) Math.floor(maxWidth * scale);
 			maxHeight = (int) Math.floor(maxHeight * scale);
 		}
@@ -121,8 +120,8 @@ public class GLPBufferPool {
 			buffer.destroy();
 		}
 		catch (Throwable t) {
-			LOG.error("Could not destroy test pbuffer, this might indicate a problem, the original message was: "
-					+ t.getLocalizedMessage(), t);
+			LOG.error("Could not destroy test pbuffer, this might indicate a problem, the original message was: {}",
+					t.getLocalizedMessage(), t);
 		}
 
 		int result = test.glTextureSize;

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/rendering/jogl/GetViewRenderer.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/rendering/jogl/GetViewRenderer.java
@@ -190,7 +190,7 @@ public class GetViewRenderer implements GLEventListener {
 
 		renderCopyright(context);
 		gl.glFinish();
-		LOG.trace("Rendering scene took: " + (System.currentTimeMillis() - begin) + " ms.");
+		LOG.trace("Rendering scene took: {} ms.", (System.currentTimeMillis() - begin));
 		writeResult(gl);
 	}
 
@@ -254,8 +254,7 @@ public class GetViewRenderer implements GLEventListener {
 	 */
 	private void reshape(GL gl) {
 		float aspect = (float) width / (float) height;
-		LOG.trace("reshape( GLAutoDrawable, " + 0 + ", " + 0 + ", " + width + ", " + height + " ) called, aspect: "
-				+ aspect);
+		LOG.trace("reshape( GLAutoDrawable, 0, 0, {}, {} ) called, aspect: {}", width, height, aspect);
 
 		gl.glMatrixMode(GL.GL_PROJECTION);
 		gl.glLoadIdentity();

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/client/RequestBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/client/RequestBean.java
@@ -384,7 +384,7 @@ public class RequestBean implements Serializable {
 		}
 
 		String targetUrl = getTargetUrl();
-		LOG.debug("Try to send the following request to " + targetUrl + " : \n" + request);
+		LOG.debug("Try to send the following request to {} : \n{}", targetUrl, request);
 		if (targetUrl != null && targetUrl.length() > 0 && request != null && request.length() > 0) {
 			InputStream is = new ByteArrayInputStream(request.getBytes("UTF-8"));
 			try {
@@ -397,7 +397,7 @@ public class RequestBean implements Serializable {
 				Header[] headers = response.getHeaders("Content-Type");
 				if (headers.length > 0) {
 					mimeType = headers[0].getValue();
-					LOG.debug("Response mime type: " + mimeType);
+					LOG.debug("Response mime type: {}", mimeType);
 					if (!mimeType.toLowerCase().contains("xml")) {
 						this.response = null;
 						FacesMessage fm = MessageUtils.getFacesMessage(FacesMessage.SEVERITY_INFO,
@@ -472,7 +472,7 @@ public class RequestBean implements Serializable {
 			requestsBaseDir = new File(realPath);
 		}
 
-		LOG.debug("Using requests directory " + requestsBaseDir);
+		LOG.debug("Using requests directory {}", requestsBaseDir);
 		String[] serviceTypes = requestsBaseDir.list();
 		if (serviceTypes != null && serviceTypes.length > 0) {
 			Arrays.sort(serviceTypes);
@@ -580,7 +580,7 @@ public class RequestBean implements Serializable {
 
 	private void loadExample() {
 		if (selectedRequest != null) {
-			LOG.debug("load request " + selectedRequest);
+			LOG.debug("load request {}", selectedRequest);
 			File file = new File(requestsBaseDir, selectedRequest);
 			if (file.exists()) {
 				XMLAdapter adapter = new XMLAdapter(file);
@@ -595,7 +595,7 @@ public class RequestBean implements Serializable {
 	public void sendKVPRequest() {
 		String targetUrl = getTargetUrl();
 
-		LOG.debug("Try to send the following request to " + targetUrl + " : \n" + kvpRequestSel);
+		LOG.debug("Try to send the following request to {} : \n{}", targetUrl, kvpRequestSel);
 		if (targetUrl != null && targetUrl.length() > 0 && kvpRequestSel != null && kvpRequestSel.length() > 0) {
 			Map<String, String> header = new HashMap<String, String>();
 			try {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/generic/XmlEditorBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/generic/XmlEditorBean.java
@@ -180,28 +180,28 @@ public class XmlEditorBean implements Serializable {
 	}
 
 	public String getContent() throws IOException, ClassNotFoundException {
-		LOG.trace("Editing file: " + getFileName() + " with ID + " + getId());
-		LOG.trace("Using schema: " + getSchemaUrl());
-		LOG.trace("Editor content: " + content);
-		LOG.trace("Related ResourceProviderClass: " + resourceProviderClass);
-		LOG.trace("Next view: " + getNextView());
+		LOG.trace("Editing file: {} with ID + {}", getFileName(), getId());
+		LOG.trace("Using schema: {}", getSchemaUrl());
+		LOG.trace("Editor content: {}", content);
+		LOG.trace("Related ResourceProviderClass: {}", resourceProviderClass);
+		LOG.trace("Next view: {}", getNextView());
 		if (content == null) {
-			LOG.trace("No content set for " + this.toString());
+			LOG.trace("No content set for {}", this.toString());
 			if (resourceProviderClass == null) {
 				File file = getFile();
 				if (fileName != null && file.exists()) {
-					LOG.trace("Loading content from file: " + file.getAbsolutePath());
+					LOG.trace("Loading content from file: {}", file.getAbsolutePath());
 					content = FileUtils.readFileToString(file);
-					LOG.trace("Setting content to: " + content);
+					LOG.trace("Setting content to: {}", content);
 					return content;
 				}
 				else if (emptyTemplate != null) {
 					// load template content if the requested file did not exists
-					LOG.trace("Loading template from " + emptyTemplate);
+					LOG.trace("Loading template from {}", emptyTemplate);
 					StringWriter sw = new StringWriter();
 					IOUtils.copy((new URL(emptyTemplate)).openStream(), sw);
 					content = sw.toString();
-					LOG.trace("Setting content to:" + content);
+					LOG.trace("Setting content to:{}", content);
 					return content;
 				}
 			}
@@ -211,18 +211,18 @@ public class XmlEditorBean implements Serializable {
 				ResourceMetadata<?> md = workspace.getResourceMetadata((Class) cls, id);
 				if (md != null) {
 					content = IOUtils.toString(md.getLocation().getAsStream());
-					LOG.trace("Loading content from resource: " + md.getLocation().getAsFile().getAbsolutePath());
+					LOG.trace("Loading content from resource: {}", md.getLocation().getAsFile().getAbsolutePath());
 				}
 				else if (emptyTemplate != null) {
-					LOG.trace("Loading template for resource provider " + this.getResourceProviderClass() + " from "
-							+ emptyTemplate);
+					LOG.trace("Loading template for resource provider {} from {}", this.getResourceProviderClass(),
+							emptyTemplate);
 					StringWriter sw = new StringWriter();
 					IOUtils.copy((new URL(emptyTemplate)).openStream(), sw);
 					content = sw.toString();
 				}
 			}
 		}
-		LOG.trace("Setting content to: " + content);
+		LOG.trace("Setting content to: {}", content);
 		return content;
 	}
 

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/metadata/ResourceManagerMetadata.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/metadata/ResourceManagerMetadata.java
@@ -93,7 +93,7 @@ public class ResourceManagerMetadata implements Comparable<ResourceManagerMetada
 		String metadataUrl = "/META-INF/console/resourcemanager/" + className;
 		URL url = ResourceManagerMetadata.class.getResource(metadataUrl);
 		if (url != null) {
-			LOG.debug("Loading resource manager metadata from '" + url + "'");
+			LOG.debug("Loading resource manager metadata from '{}'", url);
 			Properties props = new Properties();
 			InputStream is = null;
 			try {

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/metadata/ResourceProviderMetadata.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/metadata/ResourceProviderMetadata.java
@@ -67,7 +67,7 @@ public class ResourceProviderMetadata {
 		name = rp.getClass().getSimpleName();
 		URL url = rp.getClass().getResource("/META-INF/console/resourceprovider/" + className);
 		if (url != null) {
-			LOG.debug("Loading resource provider metadata from '" + url + "'");
+			LOG.debug("Loading resource provider metadata from '{}'", url);
 			Properties props = new Properties();
 			InputStream is = null;
 			try {
@@ -89,7 +89,7 @@ public class ResourceProviderMetadata {
 					exampleLocation = exampleLocation.trim();
 					final URL exampleUrl = this.getClass().getResource(exampleLocation);
 					if (exampleUrl == null) {
-						LOG.error("Configuration example file '" + exampleLocation + "' is missing on classpath.");
+						LOG.error("Configuration example file '{}' is missing on classpath.", exampleLocation);
 						continue;
 					}
 					final String exampleName = getExampleDisplayName(props, examplePrefix, exampleLocation);

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/workspace/WorkspaceBean.java
@@ -287,7 +287,7 @@ public class WorkspaceBean implements Serializable {
 			FacesContext.getCurrentInstance().addMessage(null, fm);
 			return null;
 		}
-		LOG.info("Uploaded workspace file: '" + upload.getFileName() + "'");
+		LOG.info("Uploaded workspace file: '{}'", upload.getFileName());
 		workspaceImportName = upload.getFileName();
 		if (workspaceImportName.endsWith(".deegree-workspace")) {
 			workspaceImportName = workspaceImportName.substring(0,
@@ -312,14 +312,14 @@ public class WorkspaceBean implements Serializable {
 			}
 			else {
 				Zip.unzip(in, target);
-				LOG.debug("Workspace unzipped into: '" + target.getAbsolutePath() + "'");
+				LOG.debug("Workspace unzipped into: '{}'", target.getAbsolutePath());
 			}
 		}
 		catch (Throwable t) {
 			FacesMessage fm = new FacesMessage(SEVERITY_ERROR, "Workspace could not be imported: " + t.getMessage(),
 					t.getLocalizedMessage());
 			FacesContext.getCurrentInstance().addMessage(null, fm);
-			LOG.error("Workspace could not be imported: " + t.getMessage(), t);
+			LOG.error("Workspace could not be imported: {}", t.getMessage(), t);
 			return null;
 		}
 		finally {
@@ -352,7 +352,7 @@ public class WorkspaceBean implements Serializable {
 				if (!s.trim().isEmpty()) {
 					String[] tokens = s.split(" ", 2);
 					if (tokens.length != 2) {
-						LOG.warn("Invalid workspace metadata line: '" + s + "'");
+						LOG.warn("Invalid workspace metadata line: '{}'", s);
 					}
 					res.add(tokens[1]);
 					workspaceLocations.put(tokens[1], tokens[0]);
@@ -396,8 +396,8 @@ public class WorkspaceBean implements Serializable {
 			}
 		}
 		if (version == null) {
-			LOG.warn("No valid version information from Maven deegree modules available. Defaulting to "
-					+ DEFAULT_VERSION);
+			LOG.warn("No valid version information from Maven deegree modules available. Defaulting to {}",
+					DEFAULT_VERSION);
 			version = DEFAULT_VERSION;
 		}
 		return version;

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/binding/FeatureClass.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/binding/FeatureClass.java
@@ -243,7 +243,7 @@ public class FeatureClass extends ModelClass {
 			return getFromProperty((StringOrRefPropertyType) pd);
 		}
 		else {
-			LOG.warn("Ignore import for property type: " + pd.getName());
+			LOG.warn("Ignore import for property type: {}", pd.getName());
 		}
 		return null;
 	}
@@ -314,7 +314,7 @@ public class FeatureClass extends ModelClass {
 							possibleSubstitutes.add(f);
 						}
 						else {
-							LOG.warn("Could not create a field type for the substitution property: " + p.getName());
+							LOG.warn("Could not create a field type for the substitution property: {}", p.getName());
 						}
 					}
 				}
@@ -350,7 +350,7 @@ public class FeatureClass extends ModelClass {
 				String fieldName = createFieldName(createBetterMethodName(fc.getClassName()));
 				return new Field(fieldName, fc.getClassQName(), pd.isAbstract(), pd.getName());
 			}
-			LOG.error("Could not find a feature class for the feature type: " + ft);
+			LOG.error("Could not find a feature class for the feature type: {}", ft);
 		}
 		else {
 			if (new QName("http://www.opengis.net/gml", "featureMember").equals(pd.getName())
@@ -362,7 +362,7 @@ public class FeatureClass extends ModelClass {
 				}
 			}
 			else {
-				LOG.error("Could not get feature type name for feature property type: " + pd);
+				LOG.error("Could not get feature type name for feature property type: {}", pd);
 			}
 		}
 		return null;

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/binding/FeatureTypeInstanceWriter.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/binding/FeatureTypeInstanceWriter.java
@@ -216,7 +216,7 @@ public class FeatureTypeInstanceWriter {
 			propTypeInstance.append(subVar);
 		}
 		else {
-			LOG.warn("Ignore import for property type: " + prop.getName());
+			LOG.warn("Ignore import for property type: {}", prop.getName());
 		}
 		propTypeInstance.append(")");
 		return propTypeInstance.toString();

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/i18n/Messages.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/i18n/Messages.java
@@ -85,8 +85,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			InputStream is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			is = Messages.class.getResourceAsStream(fileName);
 			defaultProps.load(is);
@@ -107,7 +107,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 	}
 
@@ -168,7 +168,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/FlightControls.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/FlightControls.java
@@ -132,7 +132,7 @@ public class FlightControls implements KeyListener, MouseMotionListener, MouseWh
 			}
 			case KeyEvent.VK_P: {
 				LOG.info(this.vf.toString());
-				LOG.info("View parameters:\n" + this.vf.toInitString());
+				LOG.info("View parameters:\n{}", this.vf.toInitString());
 				break;
 			}
 			// arrow keys
@@ -153,7 +153,7 @@ public class FlightControls implements KeyListener, MouseMotionListener, MouseWh
 				break;
 			}
 			case KeyEvent.VK_ESCAPE:
-				LOG.info("Last view:\n" + this.vf.toInitString());
+				LOG.info("Last view:\n{}", this.vf.toInitString());
 				System.exit(1);
 				break;
 		}

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/InteractiveWPVS.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/InteractiveWPVS.java
@@ -322,7 +322,7 @@ public class InteractiveWPVS extends GLCanvas implements GLEventListener, KeyLis
 	@Override
 	public void display(GLAutoDrawable drawable) {
 		LOG.trace("display( GLAutoDrawable ) called");
-		LOG.debug("view params: " + params);
+		LOG.debug("view params: {}", params);
 
 		long begin = System.currentTimeMillis();
 		GL gl = drawable.getGL();
@@ -532,9 +532,9 @@ public class InteractiveWPVS extends GLCanvas implements GLEventListener, KeyLis
 		float intens = pos.calcSunlightIntensity(ambientAndDiffuse, 0.5f);
 
 		// LOG.info( "Sun pos for time: " + cal.getTime().toGMTString() );
-		LOG.debug("Using sun's direction: " + Vectors3f.asString(light_position));
-		LOG.debug("Using sun's color: " + Vectors3f.asString(ambientAndDiffuse));
-		LOG.debug("Using sun's intensity: " + intens);
+		LOG.debug("Using sun's direction: {}", Vectors3f.asString(light_position));
+		LOG.debug("Using sun's color: {}", Vectors3f.asString(ambientAndDiffuse));
+		LOG.debug("Using sun's intensity: {}", intens);
 		// light_position[0] += 15000;
 		// light_position[1] += 15000;
 		// light_position[2] += 550;
@@ -612,8 +612,7 @@ public class InteractiveWPVS extends GLCanvas implements GLEventListener, KeyLis
 	@Override
 	public void reshape(GLAutoDrawable drawable, int x, int y, int width, int height) {
 		float aspect = (float) width / (float) height;
-		LOG.info("reshape( GLAutoDrawable, " + x + ", " + y + ", " + width + ", " + height + " ) called, aspect: "
-				+ aspect);
+		LOG.info("reshape( GLAutoDrawable, {}, {}, {}, {} ) called, aspect: {}", x, y, width, height, aspect);
 
 		params.setProjectionPlaneDimensions(width, height);
 

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/dem/filtering/DEMRasterFilterer.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/dem/filtering/DEMRasterFilterer.java
@@ -216,9 +216,8 @@ public class DEMRasterFilterer {
 			double rPT = Math.round((Math.round((currentTimeMillis() - currentTime) / 10d) / 100d));
 			if (row + 1 < rows) {
 				double remain = rPT * (rows - (row + 1));
-				LOG.info(
-						"Filtering row: {}, took approximately: {} seconds, estimated remaining time: {} seconds "
-								+ ((remain > 60) ? "( {} minutes)." : "."),
+				LOG.info("Filtering row: {}, took approximately: {} seconds, estimated remaining time: {} seconds {}",
+						((remain > 60) ? "( {} minutes)." : "."),
 						new Object[] { (row + 1), rPT, remain, Math.round(remain / 60d) });
 			}
 			System.gc();
@@ -233,7 +232,7 @@ public class DEMRasterFilterer {
 						lock.wait();
 					}
 					catch (InterruptedException e) {
-						LOG.error("Could not wait for all filter threads to end because: " + e.getLocalizedMessage(),
+						LOG.error("Could not wait for all filter threads to end because: {}", e.getLocalizedMessage(),
 								e);
 					}
 				}
@@ -590,7 +589,8 @@ public class DEMRasterFilterer {
 					outputStack.put(new Pair<String, SimpleRaster>(Thread.currentThread().getName(), filteredResult));
 				}
 				catch (InterruptedException e) {
-					LOG.error("Could not add the filtered result to the writer because: " + e.getLocalizedMessage(), e);
+					LOG.error("Could not add the filtered result to the writer because: {}", e.getLocalizedMessage(),
+							e);
 				}
 			}
 		}
@@ -608,13 +608,13 @@ public class DEMRasterFilterer {
 				}
 				catch (InterruptedException e) {
 					doRun = false;
-					LOG.error("Could not write the filtered result to the temporary file because: "
-							+ e.getLocalizedMessage(), e);
+					LOG.error("Could not write the filtered result to the temporary file because: {}",
+							e.getLocalizedMessage(), e);
 				}
 				catch (IOException e) {
 					doRun = false;
-					LOG.error("Could not write the filtered result to the temporary file because: "
-							+ e.getLocalizedMessage(), e);
+					LOG.error("Could not write the filtered result to the temporary file because: {}",
+							e.getLocalizedMessage(), e);
 				}
 			}
 			// empty the queue
@@ -628,8 +628,8 @@ public class DEMRasterFilterer {
 					}
 				}
 				catch (IOException e) {
-					LOG.error("Could not write the filtered result to the temporary file because: "
-							+ e.getLocalizedMessage(), e);
+					LOG.error("Could not write the filtered result to the temporary file because: {}",
+							e.getLocalizedMessage(), e);
 				}
 			}
 

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/BuildingManager.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/BuildingManager.java
@@ -201,7 +201,7 @@ public class BuildingManager extends ModelManager<WorldRenderableObject> {
 	 * @throws IOException
 	 */
 	private List<WorldRenderableObject> readGML(String fileName, CommandLine commandLine) throws IOException {
-		LOG.debug("Reading buildings from file: " + fileName);
+		LOG.debug("Reading buildings from file: {}", fileName);
 		String schemaLocation = commandLine.getOptionValue(DataManager.OPT_CITY_GML_SCHEMA);
 
 		String color = commandLine.getOptionValue(DataManager.OPT_CITY_GML_COLOR);
@@ -215,7 +215,7 @@ public class BuildingManager extends ModelManager<WorldRenderableObject> {
 				style.setSpecularColor(diffuseColor);
 			}
 			catch (NumberFormatException e) {
-				LOG.warn("Could not decode color into an integer: " + color + " using white instead.");
+				LOG.warn("Could not decode color into an integer: {} using white instead.", color);
 			}
 		}
 

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/PrototypeManager.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/PrototypeManager.java
@@ -122,7 +122,7 @@ public class PrototypeManager extends BuildingManager {
 
 		RenderableQualityModel rqm = building.getQualityLevel(0);
 		if (rqm == null) {
-			LOG.info("Could not extract the quality level of the RenderablePrototype with id:" + building.getId());
+			LOG.info("Could not extract the quality level of the RenderablePrototype with id:{}", building.getId());
 			return null;
 		}
 		rqm = createScaledQualityModel(rqm);

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/importers/CityGMLImporter.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/importers/CityGMLImporter.java
@@ -163,7 +163,7 @@ public class CityGMLImporter implements ModelImporter {
 
 		GMLAppSchemaReader adapter = null;
 		try {
-			LOG.info("Using schemalocation: " + schemaLoc);
+			LOG.info("Using schemalocation: {}", schemaLoc);
 			adapter = new GMLAppSchemaReader(GMLVersion.GML_31, null, schemaLoc);
 		}
 		catch (Exception e) {
@@ -259,7 +259,7 @@ public class CityGMLImporter implements ModelImporter {
 				LOG.error("Could not map the geometry which was not instantiated");
 			}
 			else {
-				LOG.error("Could not map the geometry: " + geom.getClass().getName());
+				LOG.error("Could not map the geometry: {}", geom.getClass().getName());
 			}
 		}
 	}
@@ -508,7 +508,7 @@ public class CityGMLImporter implements ModelImporter {
 			rqm = tesselator.createRenderableQM(id, qm);
 		}
 		catch (Exception e) {
-			LOG.error("Could not tesselate building with id: " + id + " because: " + e.getLocalizedMessage(), e);
+			LOG.error("Could not tesselate building with id: {} because: {}", id, e.getLocalizedMessage(), e);
 		}
 		if (rqm != null) {
 			rwo.setQualityLevel(qualityLevel, rqm);
@@ -533,7 +533,7 @@ public class CityGMLImporter implements ModelImporter {
 			}
 		}
 		catch (FilterEvaluationException e) {
-			LOG.error("Retrieving of information system property failed: " + e.getMessage());
+			LOG.error("Retrieving of information system property failed: {}", e.getMessage());
 		}
 		return result;
 	}
@@ -542,8 +542,8 @@ public class CityGMLImporter implements ModelImporter {
 		String result = building.getId();
 		if (result == null || "".equals(result.trim())) {
 			result = "Building_" + UUID.randomUUID().toString();
-			LOG.warn("Created id: " + result + " for building with envelope: " + building.getEnvelope() + " and name: "
-					+ building.getName() + " because it did not supply a gml:id.");
+			LOG.warn("Created id: {} for building with envelope: {} and name: {} because it did not supply a gml:id.",
+					result, building.getEnvelope(), building.getName());
 		}
 		return result;
 	}
@@ -569,13 +569,13 @@ public class CityGMLImporter implements ModelImporter {
 						bMap.put(wro.getId(), wro);
 					}
 					else {
-						LOG.warn("Duplicate building with id: " + wro.getId() + " using first building with envelope: "
-								+ wro.getBbox().toString());
+						LOG.warn("Duplicate building with id: {} using first building with envelope: {}", wro.getId(),
+								wro.getBbox().toString());
 					}
 				}
 			}
 			else {
-				LOG.warn("Unhandled feature type '" + f.getName() + "' -- skipping.");
+				LOG.warn("Unhandled feature type '{}' -- skipping.", f.getName());
 			}
 		}
 		List<WorldRenderableObject> result = new ArrayList<WorldRenderableObject>(bMap.size());

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/importers/VRMLImporter.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/importers/VRMLImporter.java
@@ -176,7 +176,7 @@ public class VRMLImporter implements ModelImporter {
 	public VRMLImporter(Map<String, String> params) throws IOException {
 		String texDir = params.get(TEX_DIR);
 		if (texDir == null || "".equals(texDir.trim())) {
-			LOG.info("Setting tex dir to " + System.getProperty("user.home") + "/j3dTextures/");
+			LOG.info("Setting tex dir to {}/j3dTextures/", System.getProperty("user.home"));
 			texDir = System.getProperty("user.home") + "/j3dTextures/";
 			File t = new File(texDir);
 			t.mkdir();
@@ -239,8 +239,8 @@ public class VRMLImporter implements ModelImporter {
 				}
 				catch (NumberFormatException e) {
 					LOG.error(
-							"The rotation axis values were not correctly defined, please use a comma separated list: x,y,z,a: "
-									+ e.getLocalizedMessage());
+							"The rotation axis values were not correctly defined, please use a comma separated list: x,y,z,a: {}",
+							e.getLocalizedMessage());
 				}
 
 			}
@@ -387,7 +387,7 @@ public class VRMLImporter implements ModelImporter {
 					importGroup(result, (Group) n, transformation, lower, upper);
 					if (tmpTrans != null) {
 						transformation.mulInverse(tmpTrans);
-						LOG.debug("After undoing the inverse of transformGroup transform:\n" + transformation);
+						LOG.debug("After undoing the inverse of transformGroup transform:\n{}", transformation);
 					}
 				}
 				else if (n instanceof Leaf) {
@@ -401,14 +401,14 @@ public class VRMLImporter implements ModelImporter {
 		Transform3D tmpTrans = new Transform3D();
 		tg.getTransform(tmpTrans);
 		if (tmpTrans.getBestType() != Transform3D.IDENTITY && tmpTrans.getBestType() != Transform3D.ZERO) {
-			LOG.debug("A transform group with transform:\n" + tmpTrans);
+			LOG.debug("A transform group with transform:\n{}", tmpTrans);
 			// Matrix3d mat = new Matrix3d();
 			// tmpTrans.getRotationScale( mat );
 			// transformation.set( mat );
 
 			transformation.mul(tmpTrans);
 
-			LOG.debug("Resulting transform:\n" + transformation);
+			LOG.debug("Resulting transform:\n{}", transformation);
 		}
 		return tmpTrans;
 	}
@@ -434,7 +434,7 @@ public class VRMLImporter implements ModelImporter {
 				importBackground(result, (Background) l);
 			}
 			else {
-				LOG.info("Don't know howto import object of instance: " + l.getClass().getName());
+				LOG.info("Don't know howto import object of instance: {}", l.getClass().getName());
 			}
 		}
 	}
@@ -489,7 +489,7 @@ public class VRMLImporter implements ModelImporter {
 					// TRIANGLE_FANS are not supported.
 					if (!(glType == GL.GL_TRIANGLE_STRIP || glType == GL.GL_QUADS || glType == GL.GL_LINE_STRIP)) {
 						if (!(ga instanceof TriangleArray)) {
-							LOG.info("Not a triangle Array geometry -> convert to triangles, original type is: " + ga);
+							LOG.info("Not a triangle Array geometry -> convert to triangles, original type is: {}", ga);
 							try {
 								GeometryInfo inf = new GeometryInfo(ga);
 								inf.recomputeIndices();
@@ -503,10 +503,10 @@ public class VRMLImporter implements ModelImporter {
 
 								ga = inf.getGeometryArray();
 								glType = getGLType(ga);
-								LOG.info("The converted type is: " + ga);
+								LOG.info("The converted type is: {}", ga);
 							}
 							catch (IllegalArgumentException e) {
-								LOG.info("Could not create a triangle array of the: " + ga);
+								LOG.info("Could not create a triangle array of the: {}", ga);
 								doImport = false;
 							}
 						}
@@ -519,7 +519,7 @@ public class VRMLImporter implements ModelImporter {
 							LOG.error("No coordinates found in the geometryArray, this may not be.");
 						}
 						else {
-							LOG.debug("Number of vertices in shape3d: " + vertexCount);
+							LOG.debug("Number of vertices in shape3d: {}", vertexCount);
 
 							float[] coords = exportCoords(ga, transformation, lower, upper);
 
@@ -528,7 +528,7 @@ public class VRMLImporter implements ModelImporter {
 							 */
 							float[] normals = exportNormals(ga, transformation);
 							if (normals == null) {
-								LOG.debug("VRML file: " + id + " has no normals");
+								LOG.debug("VRML file: {} has no normals", id);
 							}
 
 							/**
@@ -722,7 +722,7 @@ public class VRMLImporter implements ModelImporter {
 								}
 								else {
 									texName = cache.second;
-									LOG.debug("Using old texture reference: " + texName);
+									LOG.debug("Using old texture reference: {}", texName);
 								}
 							}
 						}
@@ -770,10 +770,10 @@ public class VRMLImporter implements ModelImporter {
 		try {
 			File f = new File(textureimportDir, texName);
 			ImageIO.write(scaledImage, "png", f);
-			LOG.debug("Wrote texture to: " + f.getAbsolutePath());
+			LOG.debug("Wrote texture to: {}", f.getAbsolutePath());
 		}
 		catch (IOException e) {
-			LOG.error("Failed to write texture: " + texName, e);
+			LOG.error("Failed to write texture: {}", texName, e);
 		}
 		cachedTextures.put(image, texName);
 		return texName;

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/stage/StageManager.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/stage/StageManager.java
@@ -182,7 +182,7 @@ public class StageManager extends ModelManager<WorldRenderableObject> {
 			maxLength = Math.max(maxLength, i);
 		}
 		BackendResult result = readAndImportStages(reader, mappedColumns, maxLength);
-		LOG.info("Number of referenced textures: " + usedTextures.size());
+		LOG.info("Number of referenced textures: {}", usedTextures.size());
 		// if ( LOG.isTraceEnabled() ) {
 		StringBuilder sb = new StringBuilder("Following textures were referenced:\n");
 		for (String s : usedTextures) {
@@ -223,7 +223,7 @@ public class StageManager extends ModelManager<WorldRenderableObject> {
 					wro = createWRO(mappedColumns, values);
 				}
 				catch (IllegalArgumentException e) {
-					LOG.error("Line( " + reader.getLineNumber() + "):  " + e.getLocalizedMessage());
+					LOG.error("Line( {}):  {}", reader.getLineNumber(), e.getLocalizedMessage());
 				}
 				if (wro != null) {
 					inserts.add(createDataObjectInfo(uuid, values[mappedColumns.get(Column.TYPE)],
@@ -231,8 +231,7 @@ public class StageManager extends ModelManager<WorldRenderableObject> {
 				}
 			}
 			else {
-				LOG.warn("Line( " + reader.getLineNumber() + "): not enough elements parsed: "
-						+ Arrays.toString(values));
+				LOG.warn("Line( {}): not enough elements parsed: {}", reader.getLineNumber(), Arrays.toString(values));
 				if (fw != null) {
 					fw.write("Line( " + reader.getLineNumber() + "): not enough elements parsed: "
 							+ Arrays.toString(values) + "\n");
@@ -328,14 +327,14 @@ public class StageManager extends ModelManager<WorldRenderableObject> {
 				result.put(c, i);
 			}
 			catch (Exception e) {
-				LOG.warn("Could not map: " + s + " to a known column name, column names must be one of: "
-						+ Arrays.toString(Column.values()));
+				LOG.warn("Could not map: {} to a known column name, column names must be one of: {}", s,
+						Arrays.toString(Column.values()));
 			}
 		}
 		boolean columnsCheckout = true;
 		for (Column c : Column.values()) {
 			if (!result.containsKey(c)) {
-				LOG.warn("Missing column: " + c.name().toLowerCase() + ", " + c.getDescription());
+				LOG.warn("Missing column: {}, {}", c.name().toLowerCase(), c.getDescription());
 				columnsCheckout = false;
 			}
 

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/trees/TreeManager.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/trees/TreeManager.java
@@ -164,7 +164,7 @@ public class TreeManager extends ModelManager<BillBoard> {
 			maxLength = Math.max(maxLength, i);
 		}
 		BackendResult result = readAndImportBillboards(reader, mappedColumns, maxLength);
-		LOG.info("Number of referenced textures: " + usedTextures.size());
+		LOG.info("Number of referenced textures: {}", usedTextures.size());
 		StringBuilder sb = new StringBuilder("Following textures were referenced:\n");
 		for (String s : usedTextures) {
 			sb.append((invalidTextures.contains(s) ? "Not Found: " : "")).append(s).append("\n");
@@ -193,7 +193,7 @@ public class TreeManager extends ModelManager<BillBoard> {
 					b = createBillBoard(mappedColumns, values);
 				}
 				catch (IllegalArgumentException e) {
-					LOG.error("Line( " + reader.getLineNumber() + "):  " + e.getLocalizedMessage());
+					LOG.error("Line( {}):  {}", reader.getLineNumber(), e.getLocalizedMessage());
 				}
 				if (b != null) {
 					inserts.add(createDataObjectInfo(uuid, values[mappedColumns.get(Column.TYPE)],
@@ -201,8 +201,7 @@ public class TreeManager extends ModelManager<BillBoard> {
 				}
 			}
 			else {
-				LOG.warn("Line( " + reader.getLineNumber() + "): not enough elements parsed: "
-						+ Arrays.toString(values));
+				LOG.warn("Line( {}): not enough elements parsed: {}", reader.getLineNumber(), Arrays.toString(values));
 			}
 			values = reader.parseLine();
 		}
@@ -254,8 +253,8 @@ public class TreeManager extends ModelManager<BillBoard> {
 		if (!usedTextures.contains(texture)) {
 			if (!checkTextureReference(texture)) {
 				invalidTextures.add(texture);
-				LOG.warn("Texture: " + texture + " does not denote an image in the textureDir: "
-						+ textureDir.getAbsolutePath() + " is this correct?.");
+				LOG.warn("Texture: {} does not denote an image in the textureDir: {} is this correct?.", texture,
+						textureDir.getAbsolutePath());
 			}
 			usedTextures.add(texture);
 		}
@@ -299,14 +298,14 @@ public class TreeManager extends ModelManager<BillBoard> {
 				result.put(c, i);
 			}
 			catch (Exception e) {
-				LOG.warn("Could not map: " + s + " to a known column name, column names must be one of: "
-						+ Arrays.toString(Column.values()));
+				LOG.warn("Could not map: {} to a known column name, column names must be one of: {}", s,
+						Arrays.toString(Column.values()));
 			}
 		}
 		boolean columnsCheckout = true;
 		for (Column c : Column.values()) {
 			if (!result.containsKey(c)) {
-				LOG.warn("Missing column: " + c.name().toLowerCase() + ", " + c.getDescription());
+				LOG.warn("Missing column: {}, {}", c.name().toLowerCase(), c.getDescription());
 				columnsCheckout = false;
 			}
 

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/commons/utils/ScanEncoding.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/commons/utils/ScanEncoding.java
@@ -72,7 +72,7 @@ public class ScanEncoding {
 			}
 		}
 
-		LOG.info("Encoding for '" + s + "': " + guess(in));
+		LOG.info("Encoding for '{}': {}", s, guess(in));
 	}
 
 	/**

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/coverage/gridifier/RasterTreeGridifier.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/coverage/gridifier/RasterTreeGridifier.java
@@ -204,14 +204,14 @@ public class RasterTreeGridifier {
 		domainWidth = (int) (maxX - minX);
 		domainHeight = (int) (maxY - minY);
 		LOG.info("\nInitializing RasterTreeGridifier\n");
-		LOG.info("- domain width: " + domainWidth);
-		LOG.info("- domain height: " + domainHeight);
+		LOG.info("- domain width: {}", domainWidth);
+		LOG.info("- domain height: {}", domainHeight);
 
 		this.tileIndex = tileIndex;
 
 		this.levels = tileIndex.getRasterLevels();
 		for (RasterLevel level : levels) {
-			LOG.info("Raster level: " + level);
+			LOG.info("Raster level: {}", level);
 		}
 		this.originLocation = originLocation;
 
@@ -238,15 +238,15 @@ public class RasterTreeGridifier {
 			}
 		}
 
-		LOG.info("\nGridifying level: " + level.getLevel() + "\n");
-		LOG.info("- meters per pixel: " + metersPerPixel);
-		LOG.info("- cell width (world units): " + cellWidth);
-		LOG.info("- cell height (world units): " + cellHeight);
-		LOG.info("- number of columns: " + columns);
-		LOG.info("- number of rows: " + rows);
-		LOG.info("- output directory: " + currentOutputDir);
-		LOG.info("- total amount of data: " + dataSize);
-		LOG.info("- number of blobs: " + numberOfBlobs);
+		LOG.info("\nGridifying level: {}\n", level.getLevel());
+		LOG.info("- meters per pixel: {}", metersPerPixel);
+		LOG.info("- cell width (world units): {}", cellWidth);
+		LOG.info("- cell height (world units): {}", cellHeight);
+		LOG.info("- number of columns: {}", columns);
+		LOG.info("- number of rows: {}", rows);
+		LOG.info("- output directory: {}", currentOutputDir);
+		LOG.info("- total amount of data: {}", dataSize);
+		LOG.info("- number of blobs: {}", numberOfBlobs);
 
 		Envelope env = geomFactory.createEnvelope(minX, minY, minX + columns * cellWidth, minY + rows * cellHeight,
 				null);
@@ -726,10 +726,10 @@ public class RasterTreeGridifier {
 					if (cellId % 100 == 0) {
 						long elapsed = System.currentTimeMillis() - begin;
 						double rate = cellId / (elapsed / 1000d);
-						LOG.info("Tile generation rate: " + rate + " tiles / second");
-						LOG.info("cached tiles: " + tileIdToRaster.size());
-						LOG.info("total mem: " + Runtime.getRuntime().totalMemory());
-						LOG.info("free mem: " + Runtime.getRuntime().freeMemory());
+						LOG.info("Tile generation rate: {} tiles / second", rate);
+						LOG.info("cached tiles: {}", tileIdToRaster.size());
+						LOG.info("total mem: {}", Runtime.getRuntime().totalMemory());
+						LOG.info("free mem: {}", Runtime.getRuntime().freeMemory());
 						// call garbage collector explicitly
 						System.gc();
 					}
@@ -754,7 +754,7 @@ public class RasterTreeGridifier {
 				File blob = new File(currentOutputDir, "blob_" + currentBlobNo + ".bin");
 				currentBlobChannel = new FileOutputStream(blob).getChannel();
 				bytesInCurrentBlob = 0;
-				LOG.info("beginning with new blob: '" + blob + "'");
+				LOG.info("beginning with new blob: '{}'", blob);
 			}
 
 			buffer.rewind();

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/CRSExporter.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/CRSExporter.java
@@ -164,7 +164,7 @@ public class CRSExporter extends CRSExporterBase {
 	public void export(List<ICRS> crsToExport, XMLStreamWriter xmlWriter) throws XMLStreamException {
 		if (crsToExport != null) {
 			if (crsToExport.size() != 0) {
-				LOG.debug("Trying to export: " + crsToExport.size() + " coordinate systems.");
+				LOG.debug("Trying to export: {} coordinate systems.", crsToExport.size());
 
 				// LinkedList<String> exportedIDs = new LinkedList<String>();
 				Set<IEllipsoid> ellipsoids = new TreeSet<IEllipsoid>(new IdComparer());
@@ -211,12 +211,11 @@ public class CRSExporter extends CRSExporterBase {
 									// rb: those values were set as 'pseudo ids' in pre
 									// 0.3 parser, add projected crs id
 									// try to get it from the epsg database :-)
-									LOG.debug("Updating projection id: " + id + " because it was black listed.");
+									LOG.debug("Updating projection id: {} because it was black listed.", id);
 									updateProjectionId(proj, projection);
 								}
 								else {
-									LOG.debug(
-											"Not updating projection id: " + id + " because it was not black listed.");
+									LOG.debug("Not updating projection id: {} because it was not black listed.", id);
 								}
 
 								projecteds.add(proj);
@@ -257,7 +256,7 @@ public class CRSExporter extends CRSExporterBase {
 										transformations.add(t);
 									}
 									else {
-										LOG.warn("Transformation: " + t + " has no target crs, this may not be.");
+										LOG.warn("Transformation: {} has no target crs, this may not be.", t);
 									}
 								}
 							}
@@ -368,9 +367,9 @@ public class CRSExporter extends CRSExporterBase {
 									d.setDefaultVersion(dVersion, true);
 									d.setDefaultDescription(datumRemark, true);
 									if (ellipsId != -1 && eId == ellipsId) {
-										LOG.debug("The ellipsoid (" + ellips.getCode() + ") of the datum ("
-												+ d.getCodeAndName()
-												+ ") is the same as the ellipsoid in the epsg database (" + eId + ").");
+										LOG.debug(
+												"The ellipsoid ({}) of the datum ({}) is the same as the ellipsoid in the epsg database ({}).",
+												ellips.getCode(), d.getCodeAndName(), eId);
 
 									}
 									else {
@@ -385,7 +384,7 @@ public class CRSExporter extends CRSExporterBase {
 											if (ef != 0 || eb != 0) {
 												IUnit u = Unit.createUnitFromString("epsg:" + uom);
 												if (u == null) {
-													LOG.warn("Could not determine unit of measure of epsg:" + uom);
+													LOG.warn("Could not determine unit of measure of epsg:{}", uom);
 												}
 												else {
 													ea = u.convert(ea, Unit.METRE);
@@ -394,8 +393,9 @@ public class CRSExporter extends CRSExporterBase {
 												boolean otherMatch = (ef == 0) ? (Math.abs(b - eb) < 1E-6)
 														: (Math.abs(f - ef) < 1E-6);
 												if ((Math.abs(a - ea) < 1E-6) && otherMatch) {
-													LOG.info("The ellipsoid of datum: " + d.getCodeAndName()
-															+ " did not have an epsg code, but the values match, updating ellipsoid epsg code as well.");
+													LOG.info(
+															"The ellipsoid of datum: {} did not have an epsg code, but the values match, updating ellipsoid epsg code as well.",
+															d.getCodeAndName());
 													ellips.setDefaultId(new EPSGCode(eId), true);
 													ellips.setDefaultName(ellpsName, true);
 													ellips.setDefaultVersion(eVersion, true);
@@ -406,29 +406,30 @@ public class CRSExporter extends CRSExporterBase {
 													d.setDefaultDescription(datumRemark, true);
 												}
 												else {
-													LOG.warn("The ellipsoid (" + ellips.getCode() + ") of the datum ("
-															+ d.getCodeAndName() + ") is not an epsg ellipsoid.");
+													LOG.warn(
+															"The ellipsoid ({}) of the datum ({}) is not an epsg ellipsoid.",
+															ellips.getCode(), d.getCodeAndName());
 												}
 											}
 										}
 									}
 								}
 								else {
-									LOG.warn("No epsg ellipsoid found for datum (" + d.getCodeAndName() + ".");
+									LOG.warn("No epsg ellipsoid found for datum ({}.", d.getCodeAndName());
 								}
 							}
 							else {
-								LOG.info("Not updating datum: " + d.getCodeAndName()
-										+ " because no code was found in epsg database.");
+								LOG.info("Not updating datum: {} because no code was found in epsg database.",
+										d.getCodeAndName());
 							}
 						}
 						else {
-							LOG.warn("No epsg id was found for datum: " + d.getCodeAndName());
+							LOG.warn("No epsg id was found for datum: {}", d.getCodeAndName());
 						}
 					}
 					catch (SQLException e) {
-						LOG.warn("Could not update epsg code for datum : " + d.getCodeAndName() + " because: "
-								+ e.getLocalizedMessage());
+						LOG.warn("Could not update epsg code for datum : {} because: {}", d.getCodeAndName(),
+								e.getLocalizedMessage());
 					}
 					finally {
 						if (connection != null) {
@@ -443,12 +444,12 @@ public class CRSExporter extends CRSExporterBase {
 					}
 				}
 				else {
-					LOG.warn("Could not determine epsg code for crs: " + bCRS.getCodeAndName() + " not updating datum: "
-							+ d.getCodeAndName());
+					LOG.warn("Could not determine epsg code for crs: {} not updating datum: {}", bCRS.getCodeAndName(),
+							d.getCodeAndName());
 				}
 			}
 			else {
-				LOG.debug("No need to determine epsg code for datum: " + d.getCodeAndName());
+				LOG.debug("No need to determine epsg code for datum: {}", d.getCodeAndName());
 			}
 		}
 	}
@@ -476,12 +477,12 @@ public class CRSExporter extends CRSExporterBase {
 								pm.addName(name);
 							}
 							else {
-								LOG.debug("Not updating name of prime meridian, because it already has the name: "
-										+ name);
+								LOG.debug("Not updating name of prime meridian, because it already has the name: {}",
+										name);
 							}
-							LOG.debug("Updating longitude (" + pm.getLongitude(Unit.DEGREE) + "°) of prime meridian ("
-									+ pm.getCodeAndName() + ") to (" + lon
-									+ "°), because it was not consistent with the epsg database.");
+							LOG.debug(
+									"Updating longitude ({}°) of prime meridian ({}) to ({}°), because it was not consistent with the epsg database.",
+									pm.getLongitude(Unit.DEGREE), pm.getCodeAndName(), lon);
 							pm.setLongitude(lon, Unit.DEGREE);
 							// result = new PrimeMeridian( Unit.DEGREE, lon,
 							// pm.getCodes(), pm.getNames(),
@@ -489,18 +490,18 @@ public class CRSExporter extends CRSExporterBase {
 							// pm.getDescriptions(), pm.getAreasOfUse() );
 						}
 						else {
-							LOG.debug("Not updating pm: " + pm.getCodeAndName()
-									+ " because the longitude is consistent with the epsg database.");
+							LOG.debug("Not updating pm: {} because the longitude is consistent with the epsg database.",
+									pm.getCodeAndName());
 						}
 					}
 					else {
-						LOG.warn("No prime meridian was found for id: " + pm.getCodeAndName());
+						LOG.warn("No prime meridian was found for id: {}", pm.getCodeAndName());
 					}
 
 				}
 				catch (SQLException e) {
-					LOG.warn("Could not update longitude for prime meridian: " + pm.getCodeAndName() + " because: "
-							+ e.getLocalizedMessage());
+					LOG.warn("Could not update longitude for prime meridian: {} because: {}", pm.getCodeAndName(),
+							e.getLocalizedMessage());
 				}
 				finally {
 					if (connection != null) {
@@ -515,8 +516,9 @@ public class CRSExporter extends CRSExporterBase {
 				}
 			}
 			else {
-				LOG.warn("Could not determine epsg code for prime meridian: " + pm.getCodeAndName()
-						+ " please check if longitude: " + pm.getLongitude(Unit.DEGREE) + "° is correct!");
+				LOG.warn(
+						"Could not determine epsg code for prime meridian: {} please check if longitude: {}° is correct!",
+						pm.getCodeAndName(), pm.getLongitude(Unit.DEGREE));
 			}
 		}
 	}
@@ -531,7 +533,7 @@ public class CRSExporter extends CRSExporterBase {
 					epsgCode = Integer.parseInt(pCode.getCode());
 				}
 				catch (NumberFormatException e) {
-					LOG.warn("Given epsg code is not an int, ignoring it: " + pCode.getCode());
+					LOG.warn("Given epsg code is not an int, ignoring it: {}", pCode.getCode());
 				}
 			}
 		}
@@ -565,13 +567,13 @@ public class CRSExporter extends CRSExporterBase {
 
 						}
 						else {
-							LOG.warn("No geographic bbox was found for crs: " + crs.getCodeAndName());
+							LOG.warn("No geographic bbox was found for crs: {}", crs.getCodeAndName());
 						}
 
 					}
 					catch (SQLException e) {
-						LOG.warn("Could not update area of use for crs: " + crs.getCodeAndName() + " because: "
-								+ e.getLocalizedMessage());
+						LOG.warn("Could not update area of use for crs: {} because: {}", crs.getCodeAndName(),
+								e.getLocalizedMessage());
 					}
 					finally {
 						if (connection != null) {
@@ -614,7 +616,7 @@ public class CRSExporter extends CRSExporterBase {
 						}
 					}
 					else {
-						LOG.warn("No conversion code was found for crs: " + proj.getCodeAndName());
+						LOG.warn("No conversion code was found for crs: {}", proj.getCodeAndName());
 					}
 
 					ps = connection.prepareStatement(
@@ -628,13 +630,13 @@ public class CRSExporter extends CRSExporterBase {
 						}
 					}
 					else {
-						LOG.warn("No conversion code was found for crs: " + proj.getCodeAndName());
+						LOG.warn("No conversion code was found for crs: {}", proj.getCodeAndName());
 					}
 
 				}
 				catch (SQLException e) {
-					LOG.warn("Could not get conversion / projection code for crs: " + proj.getCodeAndName()
-							+ " because: " + e.getLocalizedMessage());
+					LOG.warn("Could not get conversion / projection code for crs: {} because: {}",
+							proj.getCodeAndName(), e.getLocalizedMessage());
 				}
 				finally {
 					if (connection != null) {

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/CRSExporterBase.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/CRSExporterBase.java
@@ -107,7 +107,7 @@ public class CRSExporterBase {
 			LOG.error(e.getLocalizedMessage(), e);
 		}
 		catch (XMLStreamException e) {
-			LOG.error("Error while exporting the coordinates: " + e.getLocalizedMessage(), e);
+			LOG.error("Error while exporting the coordinates: {}", e.getLocalizedMessage(), e);
 		}
 
 	}
@@ -121,7 +121,7 @@ public class CRSExporterBase {
 	public void export(List<ICRS> crsToExport, XMLStreamWriter xmlWriter) throws XMLStreamException {
 		if (crsToExport != null) {
 			if (crsToExport.size() != 0) {
-				LOG.debug("Trying to export: " + crsToExport.size() + " coordinate systems.");
+				LOG.debug("Trying to export: {} coordinate systems.", crsToExport.size());
 
 				// LinkedList<String> exportedIDs = new LinkedList<String>();
 				Set<IEllipsoid> ellipsoids = new HashSet<IEllipsoid>();

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/CoordinateTransform.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/CoordinateTransform.java
@@ -227,9 +227,9 @@ public class CoordinateTransform {
 					if (!coords.startsWith("#")) {
 						String[] coordinates = coords.split(coordSep);
 						if (coordinates.length != sourceDim) {
-							LOG.error(lineCount
-									+ ") Each line must contain the number of coordinates fitting the dimension of the source crs ("
-									+ sourceDim + ") seperated by a '" + coordSep + "'.");
+							LOG.error(
+									"{}) Each line must contain the number of coordinates fitting the dimension of the source crs ({}) seperated by a '{}'.",
+									lineCount, sourceDim, coordSep);
 						}
 						else {
 							double[] from = new double[3];

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/EPSGDBSynchronizer.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/EPSGDBSynchronizer.java
@@ -180,8 +180,8 @@ public class EPSGDBSynchronizer {
 									&& tmProjection.getFalseEasting() == falseEasting
 									&& tmProjection.getFalseNorthing() == falseNorthing) {
 								LOG.info(
-										"The two Transverse Mercator projections attributes match. Updating the projection with Code: "
-												+ projectionCode);
+										"The two Transverse Mercator projections attributes match. Updating the projection with Code: {}",
+										projectionCode);
 
 								// do the UPDATE
 								// int pInternalID = dbProvider.getInternalID(
@@ -210,8 +210,8 @@ public class EPSGDBSynchronizer {
 									// scale attribute
 									laeaProjection.getFalseNorthing() == falseNorthing) {
 								LOG.info(
-										"The two Lambert Azimuthal projections attributes match. Updating the projection with Code: "
-												+ projectionCode);
+										"The two Lambert Azimuthal projections attributes match. Updating the projection with Code: {}",
+										projectionCode);
 
 								// do the UPDATE
 								// int pInternalID = dbProvider.getInternalID(
@@ -236,8 +236,8 @@ public class EPSGDBSynchronizer {
 									&& lccProjection.getFalseEasting() == falseEasting
 									&& lccProjection.getFalseNorthing() == falseNorthing) {
 								LOG.info(
-										"The two Lambert Conic Conformal projections attributes match. Updating the projection with the Code "
-												+ projectionCode);
+										"The two Lambert Conic Conformal projections attributes match. Updating the projection with the Code {}",
+										projectionCode);
 
 								// do the UPDATE
 								// int pInternalID = dbProvider.getInternalID(
@@ -264,8 +264,8 @@ public class EPSGDBSynchronizer {
 										&& salProjection.getFalseEasting() == falseEasting
 										&& salProjection.getFalseNorthing() == falseNorthing) {
 									LOG.info(
-											"The two StereographicAlternative projections attributes match. Updating the projection with the Code: "
-													+ projectionCode);
+											"The two StereographicAlternative projections attributes match. Updating the projection with the Code: {}",
+											projectionCode);
 
 									// do the UPDATE
 									// int pInternalID = dbProvider.getInternalID(
@@ -287,8 +287,8 @@ public class EPSGDBSynchronizer {
 										&& sazProjection.getFalseEasting() == falseEasting
 										&& sazProjection.getFalseNorthing() == falseNorthing) {
 									LOG.info(
-											"The two StereographicAzimuthal projections attributes match. Updating the projectio with the Code: "
-													+ projectionCode);
+											"The two StereographicAzimuthal projections attributes match. Updating the projectio with the Code: {}",
+											projectionCode);
 
 									// do the UPDATE
 									// int pInternalID = dbProvider.getInternalID(
@@ -392,7 +392,7 @@ public class EPSGDBSynchronizer {
 
 			if (sync.epsgPath == null || sync.epsgPath.trim().length() == 0) {
 				sync.epsgPath = JDBC_CONNECTION_PATH;
-				LOG.info("Using the default JDBC_CONNECTION_PATH: " + JDBC_CONNECTION_PATH);
+				LOG.info("Using the default JDBC_CONNECTION_PATH: {}", JDBC_CONNECTION_PATH);
 			}
 
 			sync.connectToEPSGdatabase();

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/PolynomialParameterCreator.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/PolynomialParameterCreator.java
@@ -83,8 +83,9 @@ public class PolynomialParameterCreator {
 		List<Point3d> from = readFromFile(sourceFile, source.getDimension(), seperator);
 		List<Point3d> to = readFromFile(targetFile, target.getDimension(), seperator);
 		if (from.size() != to.size()) {
-			log.error("The number of coordinates in the from file( " + from.size() + ") differ from the targetFile ("
-					+ to.size() + ") , this maynot be!");
+			log.error(
+					"The number of coordinates in the from file( {}) differ from the targetFile ({}) , this maynot be!",
+					from.size(), to.size());
 			System.exit(1);
 		}
 		if (transformationClass == null || "".equals(transformationClass.trim())) {
@@ -118,12 +119,12 @@ public class PolynomialParameterCreator {
 				}
 				sb.append("</").append(t).append("\n");
 			}
-			log.info("Resulted params:\n" + sb.toString());
+			log.info("Resulted params:\n{}", sb.toString());
 		}
 	}
 
 	private List<Point3d> readFromFile(File f, int dim, String seperator) throws IOException {
-		log.info("Trying to read reference points from file: " + f);
+		log.info("Trying to read reference points from file: {}", f);
 		List<Point3d> result = new ArrayList<Point3d>();
 		BufferedReader br = new BufferedReader(new FileReader(f));
 		String coords = br.readLine();
@@ -132,9 +133,9 @@ public class PolynomialParameterCreator {
 			if (!coords.startsWith("#")) {
 				String[] coordinates = coords.split(seperator);
 				if (coordinates.length != dim) {
-					log.warn(lineCount
-							+ ") Each line must contain the number of coordinates fitting the dimension of crs (" + dim
-							+ ") seperated by a '" + seperator + "'.");
+					log.warn(
+							"{}) Each line must contain the number of coordinates fitting the dimension of crs ({}) seperated by a '{}'.",
+							lineCount, dim, seperator);
 				}
 				else {
 					Point3d coord = new Point3d();
@@ -230,7 +231,7 @@ public class PolynomialParameterCreator {
 			coordSep = " ";
 		}
 
-		log.info("Trying to convert coordinates from: " + sourceCRS + " to: " + targetCRS);
+		log.info("Trying to convert coordinates from: {} to: {}", sourceCRS, targetCRS);
 
 		try {
 			ICRS source = CRSManager.lookup(sourceCRS);

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/i18n/Messages.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/i18n/Messages.java
@@ -85,8 +85,8 @@ public class Messages {
 			String fileName = "messages_en.properties";
 			InputStream is = Messages.class.getResourceAsStream(fileName);
 			if (is == null) {
-				LOG.error("Error while initializing " + Messages.class.getName() + " : " + " default message file: '"
-						+ fileName + " not found.");
+				LOG.error("Error while initializing {} :  default message file: '{} not found.",
+						Messages.class.getName(), fileName);
 			}
 			is = Messages.class.getResourceAsStream(fileName);
 			defaultProps.load(is);
@@ -107,7 +107,7 @@ public class Messages {
 			}
 		}
 		catch (IOException e) {
-			LOG.error("Error while initializing " + Messages.class.getName() + " : " + e.getMessage(), e);
+			LOG.error("Error while initializing {} : {}", Messages.class.getName(), e.getMessage(), e);
 		}
 	}
 
@@ -168,7 +168,7 @@ public class Messages {
 					overrideMessages(fileName, p);
 				}
 				catch (IOException e) {
-					LOG.error("Error loading language file for language '" + l + "': ", e);
+					LOG.error("Error loading language file for language '{}': ", l, e);
 				}
 			}
 

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
@@ -108,7 +108,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
 		String[] createStmts = DDLCreator.newInstance(mappedSchema, sqlDialect).getDDL();
 		String sqlOutputFilename = fileName + ".sql";
 		Path pathToSqlOutputFile = Paths.get(sqlOutputFilename);
-		LOG.info("Writing SQL DDL into file: " + pathToSqlOutputFile.toUri());
+		LOG.info("Writing SQL DDL into file: {}", pathToSqlOutputFile.toUri());
 		try (BufferedWriter writer = Files.newBufferedWriter(pathToSqlOutputFile)) {
 			for (String sqlStatement : createStmts) {
 				writer.write(sqlStatement + ";" + System.getProperty("line.separator"));
@@ -121,7 +121,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
 		List<String> configUrls = Collections.singletonList(loadParameter.getSchemaUrl());
 		String xmlOutputFilename = fileName + ".xml";
 		Path pathToXmlOutputFile = Paths.get(xmlOutputFilename);
-		LOG.info("Writing deegree SQLFeatureStore configuration into file: " + pathToXmlOutputFile.toUri());
+		LOG.info("Writing deegree SQLFeatureStore configuration into file: {}", pathToXmlOutputFile.toUri());
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(bos);
 		xmlWriter = new IndentingXMLStreamWriter(xmlWriter);

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/PropertyNameParser.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/PropertyNameParser.java
@@ -84,8 +84,8 @@ public class PropertyNameParser {
 			LOG.error("Referenced listOfPropertiesWithPrimitiveHref cannot be found and is ignored! ");
 		}
 		catch (IOException i) {
-			LOG.error("Referenced listOfPropertiesWithPrimitiveHref cannot be parsed and is ignored! Exception: "
-					+ i.getMessage());
+			LOG.error("Referenced listOfPropertiesWithPrimitiveHref cannot be parsed and is ignored! Exception: {}",
+					i.getMessage());
 		}
 		return null;
 	}
@@ -100,8 +100,8 @@ public class PropertyNameParser {
 				}
 				catch (IllegalArgumentException e) {
 					LOG.error(
-							"One line of referenced listOfPropertiesWithPrimitiveHref cannot be parsed and is ignored: "
-									+ entry);
+							"One line of referenced listOfPropertiesWithPrimitiveHref cannot be parsed and is ignored: {}",
+							entry);
 				}
 			}
 		}

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfiguration.java
@@ -161,11 +161,11 @@ public class GmlLoaderConfiguration {
 			@Value("#{jobParameters[sqlFeatureStoreId]}") String sqlFeatureStoreId) throws Exception {
 		DeegreeWorkspace workspace = DeegreeWorkspace.getInstance(workspaceName);
 		workspace.initAll();
-		LOG.info("deegree workspace directory: [" + workspace.getLocation() + "] initialized");
+		LOG.info("deegree workspace directory: [{}] initialized", workspace.getLocation());
 		Workspace newWorkspace = workspace.getNewWorkspace();
 		SQLFeatureStore featureStore = (SQLFeatureStore) newWorkspace.getResource(FeatureStoreProvider.class,
 				sqlFeatureStoreId);
-		LOG.info("SQLFeatureStore: [" + sqlFeatureStoreId + "] requested.");
+		LOG.info("SQLFeatureStore: [{}] requested.", sqlFeatureStoreId);
 		if (featureStore == null)
 			throw new IllegalArgumentException("SQLFeatureStore with ID " + sqlFeatureStoreId + " in workspace "
 					+ workspaceName + " does not exist or could not be initialised successful.");

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlReader.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/GmlReader.java
@@ -118,7 +118,7 @@ public class GmlReader extends AbstractItemStreamItemReader<Feature>
 			return null;
 		Feature feature = this.featureIterator.next();
 		if (feature != null)
-			LOG.info("Read feature with id " + feature.getId() + " (number " + ++noOfFeaturesRead + ") ");
+			LOG.info("Read feature with id {} (number {}) ", feature.getId(), ++noOfFeaturesRead);
 		return feature;
 	}
 
@@ -291,7 +291,7 @@ public class GmlReader extends AbstractItemStreamItemReader<Feature>
 					return feature;
 				}
 				else {
-					LOG.debug("Ignoring element '" + elName + "'");
+					LOG.debug("Ignoring element '{}'", elName);
 					XMLStreamUtils.skipElement(xmlStream);
 				}
 			}
@@ -306,7 +306,7 @@ public class GmlReader extends AbstractItemStreamItemReader<Feature>
 		if (disabledResources != null && !disabledResources.isEmpty()) {
 			MultipleReferencePatternMatcher matcher = new MultipleReferencePatternMatcher();
 			for (String disabledResource : disabledResources) {
-				LOG.debug("Added disabled resource pattern " + disabledResource);
+				LOG.debug("Added disabled resource pattern {}", disabledResource);
 				BaseUrlReferencePatternMatcher baseUrlMatcher = new BaseUrlReferencePatternMatcher(disabledResource);
 				matcher.addMatcherToApply(baseUrlMatcher);
 			}

--- a/deegree-workspaces/deegree-workspace-wcts/src/main/java/org/deegree/services/wps/ap/wcts/TransformCoordinates.java
+++ b/deegree-workspaces/deegree-workspace-wcts/src/main/java/org/deegree/services/wps/ap/wcts/TransformCoordinates.java
@@ -117,17 +117,17 @@ public class TransformCoordinates implements ExceptionAwareProcesslet {
 						configuredVersion = GMLVersion.valueOf(gmlVersion.toUpperCase());
 					}
 					catch (Exception e) {
-						LOG.debug("Your gml version: " + gmlVersion + " could not be mapped, it should be one of: "
-								+ Arrays.toString(GMLVersion.values()));
+						LOG.debug("Your gml version: {} could not be mapped, it should be one of: {}", gmlVersion,
+								Arrays.toString(GMLVersion.values()));
 					}
 				}
 			}
 			catch (IOException e) {
 				if (LOG.isDebugEnabled()) {
-					LOG.debug("Could not load configuration: " + e.getMessage(), e);
+					LOG.debug("Could not load configuration: {}", e.getMessage(), e);
 				}
 				else {
-					LOG.error("Could not load configuration: " + e.getMessage());
+					LOG.error("Could not load configuration: {}", e.getMessage());
 				}
 			}
 		}
@@ -159,26 +159,26 @@ public class TransformCoordinates implements ExceptionAwareProcesslet {
 		}
 		catch (IOException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception while getting stream from input data: " + e.getMessage(), e);
+				LOG.debug("Exception while getting stream from input data: {}", e.getMessage(), e);
 			}
 			else {
-				LOG.error("Exception while getting stream from input data: " + e.getMessage());
+				LOG.error("Exception while getting stream from input data: {}", e.getMessage());
 			}
 		}
 		catch (XMLStreamException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception while getting stream from input data: " + e.getMessage(), e);
+				LOG.debug("Exception while getting stream from input data: {}", e.getMessage(), e);
 			}
 			else {
-				LOG.error("Exception while getting stream from input data: " + e.getMessage());
+				LOG.error("Exception while getting stream from input data: {}", e.getMessage());
 			}
 		}
 		catch (NullPointerException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception (no next element) while getting stream from input data: " + e.getMessage(), e);
+				LOG.debug("Exception (no next element) while getting stream from input data: {}", e.getMessage(), e);
 			}
 			else {
-				LOG.error("Exception (no next element) while getting stream from input data: " + e.getMessage());
+				LOG.error("Exception (no next element) while getting stream from input data: {}", e.getMessage());
 			}
 		}
 
@@ -205,7 +205,7 @@ public class TransformCoordinates implements ExceptionAwareProcesslet {
 									+ ") and the output schema (" + outSchema + ") must be equal.",
 							OWSException.INVALID_PARAMETER_VALUE));
 		}
-		LOG.debug("Setting XML output (requested=" + xmlOutput.isRequested() + ")");
+		LOG.debug("Setting XML output (requested={})", xmlOutput.isRequested());
 		XMLStreamWriter writer = null;
 		try {
 			writer = xmlOutput.getXMLStreamWriter();
@@ -225,7 +225,7 @@ public class TransformCoordinates implements ExceptionAwareProcesslet {
 		}
 		catch (XMLStreamException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(e.getLocalizedMessage());
 		}
@@ -244,41 +244,41 @@ public class TransformCoordinates implements ExceptionAwareProcesslet {
 		}
 		catch (XMLParsingException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(e.getLocalizedMessage());
 		}
 		catch (IllegalArgumentException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(
 					new OWSException(e.getLocalizedMessage(), OWSException.INVALID_PARAMETER_VALUE));
 		}
 		catch (XMLStreamException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(
 					new OWSException(e.getLocalizedMessage(), OWSException.INVALID_PARAMETER_VALUE));
 		}
 		catch (UnknownCRSException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(
 					new OWSException(e.getLocalizedMessage(), OWSException.INVALID_PARAMETER_VALUE));
 		}
 		catch (TransformationException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(
 					new OWSException(e.getLocalizedMessage(), WCTSConstants.ExceptionCodes.NotTransformable.name()));
 		}
 		catch (OutsideCRSDomainException e) {
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Exception message: " + e.getMessage(), e);
+				LOG.debug("Exception message: {}", e.getMessage(), e);
 			}
 			throw new ProcessletException(
 					new OWSException(e.getLocalizedMessage(), WCTSConstants.ExceptionCodes.InvalidArea.name()));

--- a/deegree-workspaces/deegree-workspace-wps/src/main/java/org/deegree/wps/ParameterDemoProcesslet.java
+++ b/deegree-workspaces/deegree-workspace-wps/src/main/java/org/deegree/wps/ParameterDemoProcesslet.java
@@ -114,7 +114,7 @@ public class ParameterDemoProcesslet implements Processlet {
 		 */
 
 		LiteralInput li = (LiteralInput) in.getParameter("LiteralInput");
-		LOG.debug("- LiteratlInput: " + li);
+		LOG.debug("- LiteratlInput: {}", li);
 
 		/**
 		 *
@@ -124,7 +124,7 @@ public class ParameterDemoProcesslet implements Processlet {
 		 */
 
 		BoundingBoxInput bboxInput = (BoundingBoxInput) in.getParameter("BBOXInput");
-		LOG.debug("- BBOXInput: " + bboxInput);
+		LOG.debug("- BBOXInput: {}", bboxInput);
 
 		/**
 		 *
@@ -137,10 +137,10 @@ public class ParameterDemoProcesslet implements Processlet {
 		 */
 
 		ComplexInput xmlInput = (ComplexInput) in.getParameter("XMLInput");
-		LOG.debug("- XMLInput: " + xmlInput);
+		LOG.debug("- XMLInput: {}", xmlInput);
 
 		ComplexInput binaryInput = (ComplexInput) in.getParameter("BinaryInput");
-		LOG.debug("- BinaryInput: " + binaryInput);
+		LOG.debug("- BinaryInput: {}", binaryInput);
 
 		/**
 		 *
@@ -157,9 +157,9 @@ public class ParameterDemoProcesslet implements Processlet {
 		try {
 			float sleepMillis = sleepSeconds * 1000;
 			int sleepStep = (int) (sleepMillis / 99.0f);
-			LOG.debug("Sleep step (millis): " + sleepStep);
+			LOG.debug("Sleep step (millis): {}", sleepStep);
 			for (int percentCompleted = 0; percentCompleted <= 99; percentCompleted++) {
-				LOG.debug("Setting percent completed: " + percentCompleted);
+				LOG.debug("Setting percent completed: {}", percentCompleted);
 				info.setPercentCompleted(percentCompleted);
 				Thread.sleep(sleepStep);
 			}
@@ -194,13 +194,13 @@ public class ParameterDemoProcesslet implements Processlet {
 
 		// Literal outputs will just be retrieved from the ProcessletOutput object...
 		LiteralOutput literalOutput = (LiteralOutput) out.getParameter("LiteralOutput");
-		LOG.debug("Setting literal output (requested=" + literalOutput.isRequested() + ")");
+		LOG.debug("Setting literal output (requested={})", literalOutput.isRequested());
 		// ...and set to the required result
 		literalOutput.setValue("" + sleepSeconds);
 
 		// BoundingBoxOutput will just be retrieved from the ProcessletOutput object...
 		BoundingBoxOutput bboxOutput = (BoundingBoxOutput) out.getParameter("BBOXOutput");
-		LOG.debug("Setting bbox output (requested=" + bboxOutput.isRequested() + ")");
+		LOG.debug("Setting bbox output (requested={})", bboxOutput.isRequested());
 		// ...and set to the required result
 		bboxOutput.setValue(bboxInput.getValue());
 
@@ -209,7 +209,7 @@ public class ParameterDemoProcesslet implements Processlet {
 		// result.
 		// Initially we have to get a ComplexOutput object from the ProcessletOutput...
 		ComplexOutput xmlOutput = (ComplexOutput) out.getParameter("XMLOutput");
-		LOG.debug("Setting XML output (requested=" + xmlOutput.isRequested() + ")");
+		LOG.debug("Setting XML output (requested={})", xmlOutput.isRequested());
 
 		// .. and use the XMLStreamWriter to write the results to. This case handles XML
 		// based data.
@@ -226,7 +226,7 @@ public class ParameterDemoProcesslet implements Processlet {
 
 		// Another ComplexOutput is binary, e.g. an image...
 		ComplexOutput binaryOutput = (ComplexOutput) out.getParameter("BinaryOutput");
-		LOG.debug("Setting binary output (requested=" + binaryOutput.isRequested() + ")");
+		LOG.debug("Setting binary output (requested={})", binaryOutput.isRequested());
 
 		// which is streamed using a binary stream.
 		try {
@@ -261,7 +261,7 @@ public class ParameterDemoProcesslet implements Processlet {
 		int seconds = -1;
 		String uom = input.getUOM();
 
-		LOG.debug("dataType: " + input.getDataType() + ", uom: " + input.getUOM());
+		LOG.debug("dataType: {}, uom: {}", input.getDataType(), input.getUOM());
 
 		// NOTE: it is guaranteed (by the deegree WPS) that the UOM is always
 		// one of the UOMs specified in the process definition


### PR DESCRIPTION
The current codebase does not follow the recommendation way of using SLF4J parametrized logging.

This was done, as it is good practice and also boosts performance when the log statement is called often and is not configured to be logged.

With the help of automated rewriting, this was corrected for all cases that could be changed automatically.
The folder `deegree-core/deegree-core-geometry/src/test/java/org/deegree/geometry/linearization` was reviewed and fixed manually, as the automated tool had problems with the test cases.

Besides this PR, I would also suggest extending the chapter "Logging" in the wiki (https://github.com/deegree/deegree3/wiki/Developer-Guidelines#logging)

---

Following good practices, we would like to encourage deegree developers to use parametrized logging whenever possible.
```java
LOG.debug("The new entry is {}. It replaces {}.", entry, oldEntry);
```

This speeds up logging when the requested level is turned off, for example. It also makes it easier to find messages in the source tree or to filter logging during runtime.

For more details, see https://www.slf4j.org/faq.html#logging_performance

---
