### PR TITLE
Set maven version to 3.6.0-SNAPSHOT on main branch

### DIFF
--- a/deegree-client/deegree-jsf-core/pom.xml
+++ b/deegree-client/deegree-jsf-core/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-client/deegree-wps-webclient/pom.xml
+++ b/deegree-client/deegree-wps-webclient/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-client/deegree-wpsprinter-webclient/pom.xml
+++ b/deegree-client/deegree-wpsprinter-webclient/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-client/pom.xml
+++ b/deegree-client/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-core/deegree-connectionprovider-datasource/pom.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-3d/pom.xml
+++ b/deegree-core/deegree-core-3d/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-annotations/pom.xml
+++ b/deegree-core/deegree-core-annotations/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-base/pom.xml
+++ b/deegree-core/deegree-core-base/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-coverage/pom.xml
+++ b/deegree-core/deegree-core-coverage/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-cs/pom.xml
+++ b/deegree-core/deegree-core-cs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-db/pom.xml
+++ b/deegree-core/deegree-core-db/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-featureinfo/pom.xml
+++ b/deegree-core/deegree-core-featureinfo/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-filterfunctions/pom.xml
+++ b/deegree-core/deegree-core-filterfunctions/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-gdal/pom.xml
+++ b/deegree-core/deegree-core-gdal/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-layer/pom.xml
+++ b/deegree-core/deegree-core-layer/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-metadata/pom.xml
+++ b/deegree-core/deegree-core-metadata/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-csw/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-csw/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wmts/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wmts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-protocol/pom.xml
+++ b/deegree-core/deegree-core-protocol/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-commons/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-remoteows/pom.xml
+++ b/deegree-core/deegree-core-remoteows/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-core/deegree-core-rendering-2d/pom.xml
+++ b/deegree-core/deegree-core-rendering-2d/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-schema/pom.xml
+++ b/deegree-core/deegree-core-schema/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-sqldialect/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-core/deegree-core-style/pom.xml
+++ b/deegree-core/deegree-core-style/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-theme/pom.xml
+++ b/deegree-core/deegree-core-theme/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-core/deegree-core-tile/pom.xml
+++ b/deegree-core/deegree-core-tile/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/deegree-core-workspace/pom.xml
+++ b/deegree-core/deegree-core-workspace/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-core/pom.xml
+++ b/deegree-core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-coveragestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-coveragestores/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-remotewfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-featurestores/pom.xml
+++ b/deegree-datastores/deegree-featurestores/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso-memory/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-mdstores/pom.xml
+++ b/deegree-datastores/deegree-mdstores/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-cache/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-gdal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-merge/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-remotewmts/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-datastores/deegree-tilestores/pom.xml
+++ b/deegree-datastores/deegree-tilestores/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-datastores</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-datastores/pom.xml
+++ b/deegree-datastores/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-layers/deegree-layers-coverage/pom.xml
+++ b/deegree-layers/deegree-layers-coverage/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-layers/deegree-layers-feature/pom.xml
+++ b/deegree-layers/deegree-layers-feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-layers/deegree-layers-gdal/pom.xml
+++ b/deegree-layers/deegree-layers-gdal/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-layers/deegree-layers-remotewms/pom.xml
+++ b/deegree-layers/deegree-layers-remotewms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-layers/deegree-layers-tile/pom.xml
+++ b/deegree-layers/deegree-layers-tile/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-layers/pom.xml
+++ b/deegree-layers/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-processproviders/deegree-processprovider-example/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-example/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-processproviders</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-processproviders/deegree-processprovider-fme/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-fme/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-processproviders</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-processproviders/deegree-processprovider-style/pom.xml
+++ b/deegree-processproviders/deegree-processprovider-style/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-processproviders</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-processproviders/pom.xml
+++ b/deegree-processproviders/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-config/pom.xml
+++ b/deegree-services/deegree-services-config/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-services/deegree-services-csw/pom.xml
+++ b/deegree-services/deegree-services-csw/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-wcs/pom.xml
+++ b/deegree-services/deegree-services-wcs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-wms/pom.xml
+++ b/deegree-services/deegree-services-wms/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-wmts/pom.xml
+++ b/deegree-services/deegree-services-wmts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-wps/pom.xml
+++ b/deegree-services/deegree-services-wps/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-services-wpvs/pom.xml
+++ b/deegree-services/deegree-services-wpvs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-services/deegree-webservices-handbook/pom.xml
+++ b/deegree-services/deegree-webservices-handbook/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/deegree-services/pom.xml
+++ b/deegree-services/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-compliance-tests/pom.xml
+++ b/deegree-tests/deegree-compliance-tests/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-integration-tests/pom.xml
+++ b/deegree-tests/deegree-integration-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-resource-deps-tests/pom.xml
+++ b/deegree-tests/deegree-resource-deps-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-tests/deegree-testservice/pom.xml
+++ b/deegree-tests/deegree-testservice/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <relativePath>../../deegree-client</relativePath>
   </parent>
   <build>

--- a/deegree-tests/deegree-wms-remoteows-tests/pom.xml
+++ b/deegree-tests/deegree-wms-remoteows-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-wms-similarity-tests/pom.xml
+++ b/deegree-tests/deegree-wms-similarity-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-wms-tiling-tests/pom.xml
+++ b/deegree-tests/deegree-wms-tiling-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-wmts-tests/pom.xml
+++ b/deegree-tests/deegree-wmts-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/deegree-workspace-tests/pom.xml
+++ b/deegree-tests/deegree-workspace-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tests</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-tests/pom.xml
+++ b/deegree-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-themes/deegree-themes-remotewms/pom.xml
+++ b/deegree-themes/deegree-themes-remotewms/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-themes-remotewms</artifactId>
   <packaging>jar</packaging>
-  <version>3.5.6-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <name>deegree-themes-remotewms</name>
   <description>Map layer theme implementation for remote Web Map Services</description>
 
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-themes</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-themes/deegree-themes-remotewms/pom.xml
+++ b/deegree-themes/deegree-themes-remotewms/pom.xml
@@ -2,7 +2,6 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>deegree-themes-remotewms</artifactId>
   <packaging>jar</packaging>
-  <version>3.6.0-SNAPSHOT</version>
   <name>deegree-themes-remotewms</name>
   <description>Map layer theme implementation for remote Web Map Services</description>
 

--- a/deegree-themes/pom.xml
+++ b/deegree-themes/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/deegree-tools/deegree-tools-3d/pom.xml
+++ b/deegree-tools/deegree-tools-3d/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-tools/deegree-tools-alkis/pom.xml
+++ b/deegree-tools/deegree-tools-alkis/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-tools/deegree-tools-base/pom.xml
+++ b/deegree-tools/deegree-tools-base/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <inceptionYear>2016</inceptionYear>

--- a/deegree-tools/deegree-tools-migration/pom.xml
+++ b/deegree-tools/deegree-tools-migration/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tools</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/deegree-tools/pom.xml
+++ b/deegree-tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-aixm/pom.xml
+++ b/deegree-workspaces/deegree-workspace-aixm/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-compliance-tests/pom.xml
+++ b/deegree-workspaces/deegree-workspace-compliance-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-csw-memory-tests/pom.xml
+++ b/deegree-workspaces/deegree-workspace-csw-memory-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-csw/pom.xml
+++ b/deegree-workspaces/deegree-workspace-csw/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-fme/pom.xml
+++ b/deegree-workspaces/deegree-workspace-fme/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-geosciml/pom.xml
+++ b/deegree-workspaces/deegree-workspace-geosciml/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-utah/pom.xml
+++ b/deegree-workspaces/deegree-workspace-utah/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-wcts/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wcts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/deegree-workspace-wps/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wps/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/deegree-workspaces/pom.xml
+++ b/deegree-workspaces/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree</artifactId>
-    <version>3.5.6-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.deegree</groupId>
   <artifactId>deegree</artifactId>
   <packaging>pom</packaging>
-  <version>3.5.6-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <name>deegree</name>
   <description>Framework for OGC Web Service implementations and geospatial applications</description>
   <url>http://www.deegree.org/</url>


### PR DESCRIPTION
Sets the version to 3.6.0-SNAPSHOT for all active sub-modules.

Performed with:
` mvn org.codehaus.mojo:versions-maven-plugin:2.16.2:set -DnewVersion=3.6.0-SNAPSHOT -DprocessAllModules=true -Dversion='*' -Poracle,handbook,integration-tests`

This prepares the release 3.6 as described in #1464.