### PR TITLE
Add support of srsName in StoredQueries

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/QueryAnalyzer.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/query/QueryAnalyzer.java
@@ -42,7 +42,6 @@ import static org.deegree.services.wfs.query.StoredQueryHandler.GET_FEATURE_BY_T
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.math.BigInteger;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -260,10 +259,11 @@ public class QueryAnalyzer {
 		try {
 			String templ = IOUtils.toString(u.openStream());
 			for (Entry<String, OMElement> e : query.getParams().entrySet()) {
-				String val = e.getValue().getText();
-				Pattern p = Pattern.compile("[$][{]" + e.getKey() + "[}]", Pattern.CASE_INSENSITIVE);
-				templ = p.matcher(templ).replaceAll(val);
+				String key = e.getKey();
+				templ = replaceParam(key, e.getValue().getText(), templ);
 			}
+			String defaultSrsName = controller.getDefaultQueryCrs().getAlias();
+			templ = replaceParam("srsName", defaultSrsName, templ);
 
 			LOG.debug("Stored query template after replacement: {}", templ);
 
@@ -285,6 +285,11 @@ public class QueryAnalyzer {
 					+ e.getLocalizedMessage() + "'.";
 			throw new OWSException(msg, INVALID_PARAMETER_VALUE, "storedQueryId");
 		}
+	}
+
+	private static String replaceParam(String key, String val, String templ) {
+		Pattern p = Pattern.compile("[$][{]" + key + "[}]", Pattern.CASE_INSENSITIVE);
+		return p.matcher(templ).replaceAll(val);
 	}
 
 	private List<Pair<AdHocQuery, org.deegree.protocol.wfs.query.Query>> convertStoredQueries(

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -798,7 +798,7 @@ Query-Elements should be used. An exception is thrown as
 DescribeStoredQueries response, if the configured feature type is not
 served by the WFS.
 
-The optional attribute _srsName="${srsName}"_ can be set to support the parameter _srsName_ in the GetFeature request to determine the CRS of the returned geometries. If the paramater is missing in the request the default CRS of the WFS is assumed.
+The optional attribute _srsName="${srsName}"_ can be set to support the parameter _srsName_ in the GetFeature request to determine the CRS of the returned geometries. If the paramater is missing in the request, the default CRS of the WFS is returned.
 
 To enable support for the Manage Stored Queries conformance class for WFS 2.0.0 it is required to create a directory storedqueries/managed in your workspace. The stored queries created with _CreateStoredQuery_ requests are stored in this directory. They are loaded during startup of deegree automatically. It is not recommend to put the StoredQueries configured in the WFS configuration with the StoredQuery element into this folder. If the directory is missing the _CreateStoredQuery_ request returns an exception.
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/webservices.adoc
@@ -764,7 +764,7 @@ StoredQueryDefinition file. Here's an example:
   </Parameter>
   <QueryExpressionText returnFeatureTypes="ad:Address"
    language="urn:ogc:def:queryLanguage:OGC-:WFSQueryExpression">
-    <Query typeNames="ad:Address">
+    <Query srsName="${srsName}" typeNames="ad:Address">
       <Filter xmlns="http://www.opengis.net/fes/2.0">
         <PropertyIsEqualTo>
           <ValueReference>
@@ -797,6 +797,8 @@ configure it as expected: Usually values of the typeNames of the
 Query-Elements should be used. An exception is thrown as
 DescribeStoredQueries response, if the configured feature type is not
 served by the WFS.
+
+The optional attribute _srsName="${srsName}"_ can be set to support the parameter _srsName_ in the GetFeature request to determine the CRS of the returned geometries. If the paramater is missing in the request the default CRS of the WFS is assumed.
 
 To enable support for the Manage Stored Queries conformance class for WFS 2.0.0 it is required to create a directory storedqueries/managed in your workspace. The stored queries created with _CreateStoredQuery_ requests are stored in this directory. They are loaded during startup of deegree automatically. It is not recommend to put the StoredQueries configured in the WFS configuration with the StoredQuery element into this folder. If the directory is missing the _CreateStoredQuery_ request returns an exception.
 


### PR DESCRIPTION
If a StoredQuery with `srsName` is configured
```
<wfs:Query srsName="${srsName}" >
```
the GetFeature-StoredQueries works fine if the srsName is passed but fails if not. 

This PR replaces ${srsName} with the default CRS if no srsName is provided by the request.
By that, optional WFS Parameter srsName is usable in StoredQueries.