### PR TITLE
Re-enable logging when running tests in maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,17 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.2.2</version>
           <configuration>
+            <!-- provide simple logging for unit tests -->
+            <additionalClasspathDependencies>
+              <additionalClasspathDependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+              </additionalClasspathDependency>
+            </additionalClasspathDependencies>
+            <systemProperties>
+              <org.slf4j.simpleLogger.defaultLogLevel>warn</org.slf4j.simpleLogger.defaultLogLevel>
+            </systemProperties>
             <!-- Travis build workaround -->
             <argLine>-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xms1024m -Xmx2048m --illegal-access=permit
               --add-opens java.base/java.lang=ALL-UNNAMED
@@ -662,6 +673,11 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
       <!-- 3d -->


### PR DESCRIPTION
This is the “sledgehammer” method to provide a logger while running JUnit tests.
Needs to be discussed in a TMC meeting because of possible side efects.

pro
* does not require modification of every module

con
* does not work when running tests in IDE 
* may interfere with modules which have a logger configured

Probably the only alternative in my opinion is to create a module like `deegree-core-test` with a `src/main/ressources/simplelogger.properties` and a compile-time dependency to `org.slf4j:slf4j-simple` which is manually added to each module (see #1606). 

References 
- #1587 
- #1606 

closes #1587