### PR TITLE
Fix regression with SVG that would be rendered smaller than one pixel

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/SvgRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/SvgRenderer.java
@@ -40,6 +40,7 @@
 
 package org.deegree.rendering.r2d;
 
+import static java.lang.Math.max;
 import static org.apache.batik.transcoder.SVGAbstractTranscoder.KEY_HEIGHT;
 import static org.apache.batik.transcoder.SVGAbstractTranscoder.KEY_WIDTH;
 import static org.deegree.commons.utils.math.MathUtils.round;
@@ -49,7 +50,6 @@ import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import org.apache.batik.transcoder.TranscoderException;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.deegree.commons.utils.TunableParameter;
@@ -86,10 +86,10 @@ class SvgRenderer {
 			SvgImageTranscoder t = new SvgImageTranscoder();
 
 			if (rect.width > 0.0d) {
-				t.addTranscodingHint(KEY_WIDTH, new Float(rect.width));
+				t.addTranscodingHint(KEY_WIDTH, max(1.0f, (float) rect.width));
 			}
 			if (rect.height > 0.0d) {
-				t.addTranscodingHint(KEY_HEIGHT, new Float(rect.height));
+				t.addTranscodingHint(KEY_HEIGHT, max(1.0f, (float) rect.height));
 			}
 
 			TranscoderInput input = new TranscoderInput(g.imageURL);
@@ -101,14 +101,15 @@ class SvgRenderer {
 				svgCache.put(cacheKey, img);
 			}
 			catch (TranscoderException e) {
-				LOG.warn("Could not rasterize svg '{}': {}", g.imageURL, e.getLocalizedMessage());
+				LOG.warn("Could not create image from svg '{}': {}", g.imageURL, e.getLocalizedMessage());
+				LOG.trace("Exception", e);
 			}
 		}
 		return img;
 	}
 
 	String createCacheKey(String url, double width, double height) {
-		return String.format("%s_%d_%d", url, round(width), round(height));
+		return String.format("%s_%d_%d", url, max(1, round(width)), max(1, round(height)));
 	}
 
 }

--- a/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/SvgRendererTests.java
+++ b/deegree-core/deegree-core-rendering-2d/src/test/java/org/deegree/rendering/r2d/SvgRendererTests.java
@@ -8,7 +8,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.deegree.style.styling.components.Graphic;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,20 +24,32 @@ public class SvgRendererTests {
 
 	@Parameters(name = "{index}: {4} {2}x{3} => {0}x{1}")
 	public static Collection<Object[]> data() {
-		// target width, height, rectWidth, rectHeight, file
+
 		return Arrays.asList(new Object[][] {
+				// target width, height, rectWidth, rectHeight, file
 				//
-				{ 183, 100, 0, 100, "svg_w200_h100_border10.svg" }, { 100, 55, 100, 0, "svg_w200_h100_border10.svg" },
-				{ 100, 100, 100, 100, "svg_w200_h100_border10.svg" }, { 220, 120, 0, 0, "svg_w200_h100_border10.svg" },
-				{ 200, 100, 0, 100, "svg_w200_h100_no_border.svg" }, { 100, 50, 100, 0, "svg_w200_h100_no_border.svg" },
-				{ 100, 100, 100, 100, "svg_w200_h100_no_border.svg" },
-				{ 200, 100, 0, 0, "svg_w200_h100_no_border.svg" },
+				{ 183, 100, 0, 100, "svg_w200_h100_border10.svg" }, //
+				{ 100, 55, 100, 0, "svg_w200_h100_border10.svg" }, //
+				{ 100, 100, 100, 100, "svg_w200_h100_border10.svg" }, //
+				{ 220, 120, 0, 0, "svg_w200_h100_border10.svg" }, //
+				{ 200, 100, 0, 100, "svg_w200_h100_no_border.svg" }, //
+				{ 100, 50, 100, 0, "svg_w200_h100_no_border.svg" }, //
+				{ 100, 100, 100, 100, "svg_w200_h100_no_border.svg" }, //
+				{ 200, 100, 0, 0, "svg_w200_h100_no_border.svg" }, //
 				//
-				{ 100, 183, 100, 0, "svg_w100_h200_border10.svg" }, { 55, 100, 0, 100, "svg_w100_h200_border10.svg" },
-				{ 100, 100, 100, 100, "svg_w100_h200_border10.svg" }, { 120, 220, 0, 0, "svg_w100_h200_border10.svg" },
-				{ 100, 200, 100, 0, "svg_w100_h200_no_border.svg" }, { 50, 100, 0, 100, "svg_w100_h200_no_border.svg" },
-				{ 100, 100, 100, 100, "svg_w100_h200_no_border.svg" },
-				{ 100, 200, 0, 0, "svg_w100_h200_no_border.svg" }, });
+				{ 100, 183, 100, 0, "svg_w100_h200_border10.svg" }, //
+				{ 55, 100, 0, 100, "svg_w100_h200_border10.svg" }, //
+				{ 100, 100, 100, 100, "svg_w100_h200_border10.svg" }, //
+				{ 120, 220, 0, 0, "svg_w100_h200_border10.svg" }, //
+				{ 100, 200, 100, 0, "svg_w100_h200_no_border.svg" }, //
+				{ 50, 100, 0, 100, "svg_w100_h200_no_border.svg" }, //
+				{ 100, 100, 100, 100, "svg_w100_h200_no_border.svg" }, //
+				{ 100, 200, 0, 0, "svg_w100_h200_no_border.svg" }, //
+				// prevent error with sizes that could get 0x0 pixels
+				{ 1, 1, 0.51, 0.51, "svg_w100_h200_no_border.svg" },
+				{ 1, 1, 0.50, 0.50, "svg_w100_h200_no_border.svg" },
+				{ 1, 1, 0.49, 0.49, "svg_w100_h200_no_border.svg" },
+				{ 1, 1, 0.2, 0.2, "svg_w100_h200_no_border.svg" }, });
 	}
 
 	@Parameter(0)
@@ -48,10 +59,10 @@ public class SvgRendererTests {
 	public int requiredHeight;
 
 	@Parameter(2)
-	public int requestedWidth;
+	public double requestedWidth;
 
 	@Parameter(3)
-	public int requestedHeight;
+	public double requestedHeight;
 
 	@Parameter(4)
 	public String fileName;


### PR DESCRIPTION
This PR prevents errors when SVG should be rendered to a size smaller than one pixel.
Probably one of the last batik version updates introduced this issue.

Without this workaround, the following exception occurs:
```
org.apache.batik.transcoder.TranscoderException: null
Enclosed Exception: 
negative or zero width
```

Manual tests on existing workspaces showed that even a sub pixel image won't turn into rendering problems as 1×1 images are ignored or rendered correctly scaled (smaller).

References:
* #1575 
* #1267
* #1263