### PR TITLE
Ensure mapping for inline features (deegree 3.6)

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceData.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceData.java
@@ -7,6 +7,7 @@ import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.feature.Feature;
 import org.deegree.feature.FeatureCollection;
+import org.deegree.feature.GenericFeature;
 import org.deegree.gml.GMLInputFactory;
 import org.deegree.gml.GMLStreamReader;
 import org.deegree.gml.GMLVersion;
@@ -16,10 +17,10 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.deegree.commons.xml.CommonNamespaces.XSI_PREFIX;
@@ -29,12 +30,36 @@ import static org.deegree.commons.xml.CommonNamespaces.XSI_PREFIX;
  */
 public class GmlReferenceData implements ReferenceData {
 
-	private Map<QName, List<Feature>> features;
+	private Map<QName, List<Feature>> features = new HashMap<>();
 
 	public GmlReferenceData(URL referenceData) throws IOException, XMLStreamException, UnknownCRSException {
 		GMLStreamReader gmlStreamReader = GMLInputFactory.createGMLStreamReader(GMLVersion.GML_32, referenceData);
 		FeatureCollection featureCollection = gmlStreamReader.readFeatureCollection();
-		this.features = featureCollection.stream().collect(Collectors.groupingBy(Feature::getName));
+		addFeatures(featureCollection);
+	}
+
+	private void addFeatures(FeatureCollection featureCollection) {
+		Iterator<Feature> iterator = featureCollection.iterator();
+		while (iterator.hasNext()) {
+			Feature feature = iterator.next();
+			addFeature(feature);
+			List<Property> properties = feature.getProperties();
+			for (Property prop : properties) {
+				// add inline features
+				if (prop.getValue() instanceof GenericFeature) {
+					Feature inlineFeature = (Feature) prop.getValue();
+					addFeature(inlineFeature);
+				}
+			}
+		}
+	}
+
+	private void addFeature(Feature feature) {
+		QName name = feature.getName();
+		if (!features.containsKey(name)) {
+			features.put(name, new ArrayList<>());
+		}
+		features.get(name).add(feature);
 	}
 
 	@Override

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceDataTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/GmlReferenceDataTest.java
@@ -138,7 +138,7 @@ public class GmlReferenceDataTest {
 
 		boolean hasMaxOneA3 = gmlReferenceData.hasZeroOrOneProperty(FEATURETYPE_A_NAME,
 				Collections.singletonList(PROP_A3_NAME));
-		assertThat(hasMaxOneA3, is(false));
+		assertThat(hasMaxOneA3, is(true));
 	}
 
 	@Test
@@ -233,6 +233,23 @@ public class GmlReferenceDataTest {
 		boolean propertyIsNilledStatus = gmlReferenceData.isPropertyNilled(adressFeatureTypeName,
 				Collections.singletonList(status));
 		assertThat(propertyIsNilledStatus, is(true));
+	}
+
+	@Test
+	public void test_Inspire_shouldFeatureTypeMapped_withInlinedFeture() throws Exception {
+		URL resource = getClass().getResource("data/Inspire-Adress_withInlineFeature.xml");
+		GmlReferenceData gmlReferenceData = new GmlReferenceData(resource);
+
+		QName AdressFeatureTypeName = new QName("http://inspire.ec.europa.eu/schemas/ad/4.0", "Address", "ad");
+		QName AdminUnitNameFeatureTypeName = new QName("http://inspire.ec.europa.eu/schemas/ad/4.0", "AdminUnitName",
+				"ad");
+
+		boolean explicitFeatureTypeShouldBeMapped = gmlReferenceData.shouldFeatureTypeMapped(AdressFeatureTypeName);
+		assertThat(explicitFeatureTypeShouldBeMapped, is(true));
+
+		boolean referencedFeatureTypeShouldBeMapped = gmlReferenceData
+			.shouldFeatureTypeMapped(AdminUnitNameFeatureTypeName);
+		assertThat(referencedFeatureTypeShouldBeMapped, is(true));
 	}
 
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/resources/org/deegree/feature/persistence/sql/mapper/data/Inspire-Adress_withInlineFeature.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/resources/org/deegree/feature/persistence/sql/mapper/data/Inspire-Adress_withInlineFeature.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml/3.2"
+                       xmlns:ad="http://inspire.ec.europa.eu/schemas/ad/4.0"
+                       xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3"
+                       xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://inspire.ec.europa.eu/schemas/ad/4.0 https://inspire.ec.europa.eu/schemas/ad/4.0/Addresses.xsd">
+  <gml:featureMember>
+    <ad:Address gml:id="Address_1">
+      <ad:inspireId>
+        <base:Identifier>
+          <base:localId>Address_1</base:localId>
+          <base:namespace>https://registry.gdi-de.org/id</base:namespace>
+          <base:versionId xsi:nil="true" nilReason="Unpopulated"/>
+        </base:Identifier>
+      </ad:inspireId>
+      <ad:position>
+        <ad:GeographicPosition>
+          <ad:geometry>
+            <gml:Point gml:id="Address_pos_0" srsName="urn:ogc:def:crs:EPSG::4258">
+              <gml:pos>49.119752 7.046397</gml:pos>
+            </gml:Point>
+          </ad:geometry>
+          <ad:specification xlink:href="http://inspire.ec.europa.eu/codelist/GeometrySpecificationValue/building"/>
+          <ad:method xlink:href="http://inspire.ec.europa.eu/codelist/GeometryMethodValue/byOtherParty"/>
+          <ad:default>true</ad:default>
+        </ad:GeographicPosition>
+      </ad:position>
+      <ad:status xsi:nil="true" nilReason="other:unpopulated"/>
+      <ad:locator>
+        <ad:AddressLocator>
+          <ad:designator>
+            <ad:LocatorDesignator>
+              <ad:designator>1</ad:designator>
+              <ad:type xlink:href="buildingIdentifier"/>
+            </ad:LocatorDesignator>
+          </ad:designator>
+          <ad:level xlink:href="http://inspire.ec.europa.eu/codelist/LocatorLevelValue/postalDeliveryPoint"/>
+        </ad:AddressLocator>
+      </ad:locator>
+      <ad:validFrom xsi:nil="true" nilReason="other:unpopulated"/>
+      <ad:beginLifespanVersion xsi:nil="true" nilReason="other:unpopulated"/>
+      <ad:component>
+        <ad:AdminUnitName>
+          <ad:beginLifespanVersion xsi:nil="true" nilReason="other:unpopulated"/>
+          <ad:validFrom xsi:nil="true" nilReason="other:unpopulated"/>
+          <ad:name>
+            <gn:GeographicalName>
+              <gn:language>deu</gn:language>
+              <gn:nativeness xlink:href="http://inspire.ec.europa.eu/codelist/NativenessValue/endonym"/>
+              <gn:nameStatus xlink:href="http://inspire.ec.europa.eu/codelist/NameStatusValue/official"/>
+              <gn:sourceOfName xsi:nil="true" nilReason="unknown"/>
+              <gn:pronunciation xsi:nil="true" nilReason="other:unpopulated"/>
+              <gn:spelling>
+                <gn:SpellingOfName>
+                  <gn:text>Test</gn:text>
+                  <gn:script xsi:nil="true" nilReason="other:unpopulated"/>
+                </gn:SpellingOfName>
+              </gn:spelling>
+            </gn:GeographicalName>
+          </ad:name>
+          <ad:level xlink:href="http://inspire.ec.europa.eu/codelist/AdministrativeHierarchyLevel/4thOrder"/>
+          <ad:adminUnit xsi:nil="true"/>
+        </ad:AdminUnitName>
+      </ad:component>
+      <ad:component xlink:href="http://localhost:8088/C_2"/>
+    </ad:Address>
+  </gml:featureMember>
+</gml:FeatureCollection>


### PR DESCRIPTION
Currently the SQLFeatureStoreCreator considers only feature type with features explicitly configured as featureMembers in the referenceData. This PRs ensures that mapping is written also for inline features.
 