### PR TITLE
Upgrade dependencies of Apache commons pool, and dbcp2 to latest version

### DIFF
--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_mssql.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_mssql.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource https://schemas.deegree.org/core/3.5/connectionprovider/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="com.mysql.jdbc.Driver" />

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_oracle.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_oracle.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource https://schemas.deegree.org/core/3.5/connectionprovider/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="oracle.jdbc.OracleDriver" />

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_postgres.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/resources/META-INF/schemas/connectionprovider/datasource/example_dbcp_postgres.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource https://schemas.deegree.org/core/3.5/connectionprovider/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" />
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close" />
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />

--- a/pom.xml
+++ b/pom.xml
@@ -583,12 +583,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.9.0</version>
+        <version>2.12.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1231,8 +1231,8 @@
     <java.version>11</java.version>
     <antlr.version>3.5.3</antlr.version>
     <oracle.version>19.9.0.0</oracle.version>
-    <log4j.version>2.17.2</log4j.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <log4j.version>2.23.1</log4j.version>
+    <slf4j.version>2.0.12</slf4j.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <spring-batch.version>4.3.10</spring-batch.version>
     <spring-framework.version>5.3.32</spring-framework.version>


### PR DESCRIPTION
This PR upgrades the dependencies of Apache commons pool, Apache DBCP2 and the related logging APIs slf4j and log4j2 to latest versions.
The [slf4j 2.0 migration guide](https://www.slf4j.org/faq.html#changesInVersion200) indicates no API changes and upgrading to 2.0.x shoud be a drop-in replacement. 
Also the PR adds the close method to all JDBC connection templates to avoid incomplete configurations.