### PR TITLE
Upgrade dependencies gson, commons-collections4 and maven plugins (3.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.15.1</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -549,7 +549,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.3</version>
+        <version>4.4</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
@@ -1155,7 +1155,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.9</version>
+        <version>2.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1222,7 +1222,7 @@
     <java.version>11</java.version>
     <antlr.version>3.5.3</antlr.version>
     <oracle.version>19.9.0.0</oracle.version>
-    <log4j.version>2.17.2</log4j.version>
+    <log4j.version>2.23.0</log4j.version>
     <slf4j.version>1.7.36</slf4j.version>
     <spring-boot.version>2.7.18</spring-boot.version>
     <spring-batch.version>4.3.10</spring-batch.version>
@@ -1258,7 +1258,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.4.2</version>
+            <version>4.8.3.1</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <spotbugsXmlOutput>true</spotbugsXmlOutput>
@@ -1313,7 +1313,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>8.4.3</version>
+            <version>9.0.9</version>
             <configuration>
               <cveValidForHours>24</cveValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades dependencies and maven plugins to latest version including `gson` and `commons-collections` for `main` branch.

PR for `3.5-main` #1663