### PR TITLE
Enhanced GmlTool to support multiple namespaces with same prefix in one application schema (3.5)

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XMLSchemaInfoSet.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/XMLSchemaInfoSet.java
@@ -54,7 +54,9 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
@@ -223,9 +225,20 @@ public class XMLSchemaInfoSet {
 									if (prefix != null && !prefix.equals(XMLConstants.DEFAULT_NS_PREFIX)) {
 										String nsUri = xmlStream.getNamespaceURI(i);
 										String oldPrefix = nsToPrefix.get(nsUri);
+										Optional<String> oldNsUri = nsToPrefix.entrySet()
+											.stream()
+											.filter(entry -> prefix.equals(entry.getValue()))
+											.map(Map.Entry::getKey)
+											.findFirst();
 										if (oldPrefix != null && !oldPrefix.equals(prefix)) {
 											LOG.debug("Multiple prefices for namespace '" + nsUri + "': " + prefix
 													+ " / " + oldPrefix);
+										}
+										else if (oldNsUri.isPresent() && !oldNsUri.get().equals(nsUri)) {
+											String newPrefix = prefix + UUID.randomUUID();
+											LOG.warn("Multiple nsUrls for prefix '" + prefix + "': " + nsUri
+													+ ". Created new prefix: " + newPrefix);
+											nsToPrefix.put(nsUri, newPrefix);
 										}
 										else {
 											nsToPrefix.put(nsUri, prefix);


### PR DESCRIPTION
The updated [INSPIRE schemas](https://github.com/INSPIRE-MIF/application-schemas/releases) references schemas in different versions. The namespace urls are bound to the same prefix. E.g: https://inspire.ec.europa.eu/schemas/us-govserv/5.0/GovernmentalServices.xsd

contains
```
<schema  xmlns:au="http://inspire.ec.europa.eu/schemas/au/5.0" ...>
...
  <import namespace="http://inspire.ec.europa.eu/schemas/ad/4.0" schemaLocation="https://inspire.ec.europa.eu/schemas/ad/4.0/Addresses.xsd"/>
  <import namespace="http://inspire.ec.europa.eu/schemas/au/5.0" schemaLocation="https://inspire.ec.europa.eu/schemas/au/5.0/AdministrativeUnits.xsd"/>
```


The referenced https://inspire.ec.europa.eu/schemas/ad/4.0/Addresses.xsd uses  version 4.0 of AdministrativeUnits:
```
<schema xmlns:au="http://inspire.ec.europa.eu/schemas/au/4.0" ...>
...
<import namespace="http://inspire.ec.europa.eu/schemas/au/4.0" schemaLocation="https://inspire.ec.europa.eu/schemas/au/4.0/AdministrativeUnits.xsd"/>
```


Creating the SqlFeatureStore configuration with
`SqlFeatureStoreConfigCreator -format=all -srid=25833 -idtype=uuid -mapping=relational -dialect=postgis -schemaUrl=https://inspire.ec.europa.eu/schemas/us-govserv/5.0/GovernmentalServices.xsd`
 results in multiple namespaces bindings with the same prefix but different namespace urls:
```
<SQLFeatureStore xmlns="http://www.deegree.org/datasource/feature/sql"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/core/3.5/datasource/feature/sql/sql.xsd"
                 xmlns:ad="http://inspire.ec.europa.eu/schemas/ad/4.0"
                 xmlns:au="http://inspire.ec.europa.eu/schemas/au/4.0"
                 xmlns:au="http://inspire.ec.europa.eu/schemas/au/5.0"
                 xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3"
                 xmlns:base="http://inspire.ec.europa.eu/schemas/base/4.0"
                 xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0"
                 xmlns:cp="http://inspire.ec.europa.eu/schemas/cp/4.0"
                 xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0"
                 xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
                 xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
                 xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0"
                 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2">
```

Startup fails with:
```
deegree-1   | com.ctc.wstx.exc.WstxParsingException: Duplicate declaration for namespace prefix 'au'.
deegree-1   |  at [row,col {unknown-source}]: [1,444]
```
and the generated SQL cannot be executed without failure because it contains multiple duplicated create table statements.

This PR fixes the problem by the prefixes of namespaces to ensure unique nsUrl/prefix combinations.
