### PR TITLE
Enhanced SqlFeatureStoreConfigCreator to support new parameter dbschema (3.5)

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/DDLCreator.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/DDLCreator.java
@@ -174,7 +174,7 @@ public abstract class DDLCreator {
 
 	protected void appendCreateSchema(String schema, StringBuffer sql) {
 		if (schema != null && !createdSchemas.contains(schema)) {
-			sql.append("CREATE SCHEMA ").append(schema).append(";\n");
+			createSchemaSnippet(schema, sql);
 			createdSchemas.add(schema);
 		}
 	}
@@ -189,6 +189,10 @@ public abstract class DDLCreator {
 			s = table + "_pkey";
 		}
 		return s;
+	}
+
+	protected void createSchemaSnippet(String schema, StringBuffer sql) {
+		sql.append("CREATE SCHEMA ").append(schema).append(";\n");
 	}
 
 	protected abstract void primitiveMappingSnippet(StringBuffer sql, PrimitiveMapping mapping);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/DDLCreator.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/DDLCreator.java
@@ -73,6 +73,8 @@ public abstract class DDLCreator {
 
 	protected TableName currentFtTable;
 
+	protected List<String> createdSchemas = new ArrayList<>();
+
 	/**
 	 * Creates a new {@link DDLCreator} instance for the given {@link MappedAppSchema}.
 	 * @param schema mapped application schema, must not be <code>null</code>
@@ -121,7 +123,9 @@ public abstract class DDLCreator {
 
 		currentFtTable = ftMapping.getFtTable();
 
-		StringBuffer sql = new StringBuffer("CREATE TABLE ");
+		StringBuffer sql = new StringBuffer();
+		appendCreateSchema(currentFtTable.getSchema(), sql);
+		sql.append("CREATE TABLE ");
 		ddls.add(sql);
 		sql.append(currentFtTable);
 		sql.append(" (");
@@ -166,6 +170,13 @@ public abstract class DDLCreator {
 		}
 		sql.append(")\n)");
 		return ddls;
+	}
+
+	protected void appendCreateSchema(String schema, StringBuffer sql) {
+		if (schema != null && !createdSchemas.contains(schema)) {
+			sql.append("CREATE SCHEMA ").append(schema).append(";\n");
+			createdSchemas.add(schema);
+		}
 	}
 
 	private String getPkConstraintName(TableName ftTable) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/PostGISDDLCreator.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/PostGISDDLCreator.java
@@ -241,6 +241,10 @@ public class PostGISDDLCreator extends DDLCreator {
 		return postgresqlType;
 	}
 
+	protected void createSchemaSnippet(String schema, StringBuffer sql) {
+		sql.append("CREATE SCHEMA IF NOT EXISTS ").append(schema).append(";\n");
+	}
+
 	private String retrieveTypeOfPrimaryKey(TableName fromTable, SQLIdentifier toColumn, FIDMapping fidMapping) {
 		if (fidMapping != null) {
 			for (Pair<SQLIdentifier, BaseType> column : fidMapping.getColumns()) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/PostGISDDLCreator.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/ddl/PostGISDDLCreator.java
@@ -138,7 +138,8 @@ public class PostGISDDLCreator extends DDLCreator {
 		StringBuffer indexSql = new StringBuffer("CREATE INDEX ");
 		String idxName = createIdxName(table.getTable(), column);
 		indexSql.append(idxName);
-		indexSql.append(" ON ").append(table.getTable().toLowerCase());
+		indexSql.append(" ON ");
+		indexSql.append(table.toString().toLowerCase());
 		indexSql.append(" USING GIST (").append(column).append(" ); ");
 		ddls.add(indexSql);
 		return ddls;
@@ -187,7 +188,9 @@ public class PostGISDDLCreator extends DDLCreator {
 	@Override
 	protected StringBuffer createJoinedTable(TableName fromTable, TableJoin jc, List<StringBuffer> ddls,
 			FIDMapping fidMapping) {
-		StringBuffer sb = new StringBuffer("CREATE TABLE ");
+		StringBuffer sb = new StringBuffer();
+		appendCreateSchema(jc.getToTable().getSchema(), sb);
+		sb.append("CREATE TABLE ");
 		sb.append(jc.getToTable());
 		sb.append(" (\n    ");
 		sb.append("id serial PRIMARY KEY,\n    ");

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
@@ -140,6 +140,8 @@ public class AppSchemaMapper {
 
 	private final boolean useRefDataProps;
 
+	private final String dbSchema;
+
 	/**
 	 * Creates a new {@link AppSchemaMapper} instance for the given schema.
 	 * @param appSchema application schema to be mapped, must not be <code>null</code>
@@ -180,7 +182,7 @@ public class AppSchemaMapper {
 			GeometryStorageParams geometryParams, int maxLength, boolean usePrefixedSQLIdentifiers,
 			boolean useIntegerFids, int allowedCycleDepth) {
 		this(appSchema, createBlobMapping, createRelationalMapping, geometryParams, maxLength,
-				usePrefixedSQLIdentifiers, useIntegerFids, allowedCycleDepth, null, false);
+				usePrefixedSQLIdentifiers, useIntegerFids, allowedCycleDepth, null, false, null);
 	}
 
 	/**
@@ -203,7 +205,8 @@ public class AppSchemaMapper {
 	 */
 	public AppSchemaMapper(AppSchema appSchema, boolean createBlobMapping, boolean createRelationalMapping,
 			GeometryStorageParams geometryParams, int maxLength, boolean usePrefixedSQLIdentifiers,
-			boolean useIntegerFids, int allowedCycleDepth, ReferenceData referenceData, boolean useRefDataProps) {
+			boolean useIntegerFids, int allowedCycleDepth, ReferenceData referenceData, boolean useRefDataProps,
+			String dbSchema) {
 		this.appSchema = appSchema;
 		this.geometryParams = geometryParams;
 		this.useIntegerFids = useIntegerFids;
@@ -211,6 +214,7 @@ public class AppSchemaMapper {
 		this.maxComplexityIndex = DEFAULT_COMPLEXITY_INDEX * (allowedCycleDepth + 1);
 		this.referenceData = referenceData;
 		this.useRefDataProps = useRefDataProps;
+		this.dbSchema = dbSchema;
 
 		List<FeatureType> ftList = appSchema.getFeatureTypes(null, false, false);
 		List<FeatureType> blackList = new ArrayList<FeatureType>();
@@ -285,10 +289,7 @@ public class AppSchemaMapper {
 		LOG.info("Mapping feature type '" + ft.getName() + "'");
 		MappingContext mc = mcManager.newContext(ft.getName(), detectPrimaryKeyColumnName());
 
-		// TODO
-		TableName table = new TableName(mc.getTable());
-		// TODO
-
+		TableName table = new TableName(mc.getTable(), dbSchema);
 		FIDMapping fidMapping = generateFidMapping(ft);
 
 		List<Mapping> mappings = new ArrayList<>();

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
@@ -564,8 +564,8 @@ public class AppSchemaMapper {
 	}
 
 	private List<TableJoin> generateJoinChain(MappingContext from, MappingContext to) {
-		TableName fromTable = new TableName(from.getTable());
-		TableName toTable = new TableName(to.getTable());
+		TableName fromTable = new TableName(from.getTable(), dbSchema);
+		TableName toTable = new TableName(to.getTable(), dbSchema);
 		List<String> fromColumns = Collections.singletonList(from.getIdColumn());
 		List<String> toColumns = Collections.singletonList("parentfk");
 		List<String> orderColumns = Collections.singletonList("num");
@@ -580,7 +580,7 @@ public class AppSchemaMapper {
 		if (valueFt != null && valueFt.getSchema().getSubtypes(valueFt).length == 1) {
 			LOG.warn("Ambiguous feature join.");
 		}
-		TableName fromTable = new TableName(from.getTable());
+		TableName fromTable = new TableName(from.getTable(), dbSchema);
 		TableName toTable = new TableName("?");
 		List<String> fromColumns = Collections.singletonList(from.getColumn());
 		List<String> toColumns = Collections.singletonList(detectPrimaryKeyColumnName());

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapperTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapperTest.java
@@ -466,7 +466,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0, null,
-				false);
+				false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -497,7 +497,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, false);
+				referenceData, false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -539,7 +539,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, false);
+				referenceData, false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -587,7 +587,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, false);
+				referenceData, false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -634,7 +634,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, false);
+				referenceData, false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -683,7 +683,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, false);
+				referenceData, false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -722,7 +722,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, true);
+				referenceData, true, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -755,7 +755,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0,
-				referenceData, true);
+				referenceData, true, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -778,7 +778,7 @@ public class AppSchemaMapperTest {
 		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
 		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0, null,
-				false);
+				false, null);
 
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 
@@ -818,6 +818,27 @@ public class AppSchemaMapperTest {
 		assertThat(getPrimitive(timePeriodOfTimeObject.getParticles(), "beginPosition"), is(notNullValue()));
 		assertThat(getPrimitive(timePeriodOfTimeObject.getParticles(), "endPosition"), is(notNullValue()));
 		assertThat(getPrimitive(timePeriodOfTimeObject.getParticles(), "@gml:id"), is(notNullValue()));
+	}
+
+	@Test
+	public void testWithoutDbSchema() throws Exception {
+		GMLAppSchemaReader xsdDecoder = new GMLAppSchemaReader(null, null, schemaForSampleValues);
+		AppSchema appSchema = xsdDecoder.extractAppSchema();
+
+		CRSRef storageCrs = CRSManager.getCRSRef("EPSG:4326");
+		GeometryStorageParams geometryParams = new GeometryStorageParams(storageCrs, "0", DIM_2);
+		String dbSchema = "test";
+		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, false, true, geometryParams, 63, true, true, 0, null,
+				false, dbSchema);
+
+		MappedAppSchema mappedSchema = mapper.getMappedSchema();
+
+		Map<QName, FeatureTypeMapping> ftMappings = mappedSchema.getFtMappings();
+		assertThat(ftMappings.size(), is(2));
+
+		FeatureTypeMapping featureA = mappedSchema.getFtMapping(FEATURE_A);
+
+		assertThat(featureA.getFtTable().getSchema(), is(dbSchema));
 	}
 
 	private CompoundMapping getFeatureC(List<Mapping> mappings) {

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
@@ -82,7 +82,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
 		AppSchemaMapper mapper = new AppSchemaMapper(appSchema, !loadParameter.isRelationalMapping(),
 				loadParameter.isRelationalMapping(), geometryParams, sqlDialect.getMaxColumnNameLength(), true,
 				loadParameter.isUseIntegerFids(), loadParameter.getDepth(), loadParameter.getReferenceData(),
-				loadParameter.isUseRefDataProps());
+				loadParameter.isUseRefDataProps(), loadParameter.getDbSchema());
 		MappedAppSchema mappedSchema = mapper.getMappedSchema();
 		SQLFeatureStoreConfigWriter configWriter = new SQLFeatureStoreConfigWriter(mappedSchema,
 				loadParameter.getPropertiesWithPrimitiveHref());

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameter.java
@@ -23,9 +23,8 @@ package org.deegree.tools.featurestoresql.config;
 
 import org.deegree.feature.persistence.sql.mapper.ReferenceData;
 
-import java.util.List;
-
 import javax.xml.namespace.QName;
+import java.util.List;
 
 /**
  * Load parameter.
@@ -53,6 +52,8 @@ public class LoadParameter {
 	private int depth;
 
 	private boolean useRefDataProps;
+
+	private String dbSchema;
 
 	LoadParameter() {
 	}
@@ -119,6 +120,14 @@ public class LoadParameter {
 
 	public void setDialect(String dialect) {
 		this.dialect = dialect;
+	}
+
+	public void setDbSchema(String dbSchema) {
+		this.dbSchema = dbSchema;
+	}
+
+	public String getDbSchema() {
+		return dbSchema;
 	}
 
 	public void setDepth(int depth) {

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameterBuilder.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/LoadParameterBuilder.java
@@ -83,6 +83,14 @@ public class LoadParameterBuilder {
 		return this;
 	}
 
+	public LoadParameterBuilder setDbSchema(String dbSchema) {
+		if (dbSchema != null && dbSchema.isEmpty())
+			loadParameter.setDbSchema(null);
+		else
+			loadParameter.setDbSchema(dbSchema);
+		return this;
+	}
+
 	public LoadParameterBuilder setSrid(String srid) {
 		if (srid == null)
 			loadParameter.setSrid(DEFAULT_SRID);

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorConfiguration.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorConfiguration.java
@@ -54,7 +54,8 @@ public class SqlFeatureStoreConfigCreatorConfiguration {
 	public LoadParameter parseJobParameter(@Value("#{jobParameters[schemaUrl]}") String schemaUrl,
 			@Value("#{jobParameters[format]}") String format, @Value("#{jobParameters[srid]}") String srid,
 			@Value("#{jobParameters[idtype]}") String idtype, @Value("#{jobParameters[mapping]}") String mapping,
-			@Value("#{jobParameters[dialect]}") String dialect, @Value("#{jobParameters[cycledepth]}") String depth,
+			@Value("#{jobParameters[dialect]}") String dialect, @Value("#{jobParameters[dbschema]}") String dbSchema,
+			@Value("#{jobParameters[cycledepth]}") String depth,
 			@Value("#{jobParameters[listOfPropertiesWithPrimitiveHref]}") String listOfPropertiesWithPrimitiveHref,
 			@Value("#{jobParameters[referenceData]}") String referenceData,
 			@Value("#{jobParameters[useRefDataProps]}") String useRefDataProps) {
@@ -64,6 +65,7 @@ public class SqlFeatureStoreConfigCreatorConfiguration {
 			.setIdType(idtype)
 			.setMappingType(mapping)
 			.setDialect(dialect)
+			.setDbSchema(dbSchema)
 			.setDepth(depth)
 			.setListOfPropertiesWithPrimitiveHref(listOfPropertiesWithPrimitiveHref)
 			.setReferenceData(referenceData)

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorUsagePrinter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/SqlFeatureStoreConfigCreatorUsagePrinter.java
@@ -42,6 +42,7 @@ public class SqlFeatureStoreConfigCreatorUsagePrinter {
 		System.out.println(" -idtype={int|uuid}, default=int");
 		System.out.println(" -mapping={relational|blob}, default=relational");
 		System.out.println(" -dialect={postgis|oracle}, default=postgis");
+		System.out.println(" -dbschema=STRING, name of the db schema to use, default: no schema");
 		System.out.println(" -cycledepth=INT, positive integer value to specify the depth of cycles, default=0");
 		System.out.println(" -listOfPropertiesWithPrimitiveHref=<path/to/file>, not set by default");
 		System.out.println(


### PR DESCRIPTION
This PR extends the SqlFeatureStoreConfigCreator by the new Parameter `-dbschema=test`. The passed db schema is written into the SQLFeatureStore configuration as well as the generated SQL Statements.