### PR TITLE
Upgrade oracle driver to 23

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc8</artifactId>
+      <artifactId>ojdbc11</artifactId>
     </dependency>
     <dependency>
       <groupId>org.locationtech.jts</groupId>

--- a/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
+++ b/deegree-datastores/deegree-coveragestores/deegree-coveragestore-oracle-georaster/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc8</artifactId>
+      <artifactId>ojdbc11</artifactId>
     </dependency>
     <dependency>
       <groupId>com.oracle</groupId>
@@ -88,7 +88,7 @@
       <artifactId>xdb</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.oracle</groupId>
+      <groupId>com.oracle.database.xml</groupId>
       <artifactId>xmlparserv2_sans_jaxp_services</artifactId>
     </dependency>
   </dependencies>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/javamodules.adoc
@@ -125,20 +125,15 @@ add the following JAR files (see <<anchor-adding-jars>>):
 ** sdogr.jar
 ** sdotype.jar
 ** sdoutl.jar
-** xdb6.jar
+** xdb.jar
 ** xmlparserv2_sans_jaxp_services.jar
 
 NOTE: The Oracle Spatial and GeoRaster libraries can be found, without version
 number in filename, inside the Oracle Database installation directory.
-The _sdo*_ files can be found at _ORACLE_HOME/md/jlib_, xdb6.jar at
-_ORACLE_HOME/rdbms/jlib_ and xmlparserv2_sans_jaxp_services or
-xmlparserv2 at _ORACLE_HOME/xdk/lib_.
-
-NOTE: The _xmlparserv2_sans_jaxp_services_ is the recommended library, as it
-does not contain _META-INF/services/_ entries. But if this library is
-not available the _xmlparserv2_ can be used instead. (In rare
-conditions this could set the oracle library as default XML parser,
-which could lead to unexpected behavior).
+The _sdo*_ files can be found at _ORACLE_HOME/md/jlib_, xdb.jar and
+xmlparserv2_sans_jaxp_services.jar are available at maven central 
+xdb:[https://repo1.maven.org/maven2/com/oracle/database/xml/xdb/] and
+xmlparserv2_sans_jaxp_services:[https://repo1.maven.org/maven2/com/oracle/database/xml/xmlparserv2_sans_jaxp_services/].
 
 [[anchor-sqlserverjars]]
 ==== Adding Microsoft SQL server support

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -32,7 +32,7 @@ deegree currently supports the following backends:
 
 * PostgreSQL 12+ with PostGIS extension 3.0+
 * Oracle Spatial 19.x, 21.x and 23.3  
-** https://www.oracle.com/de/database/technologies/faq-jdbc.html[See compatibility matrix of driver version 23.3]
+** https://www.oracle.com/database/technologies/faq-jdbc.html[See compatibility matrix of driver version 23.3]
 * Microsoft SQL Server 2012, 2014, 2016, 2017 and 2019 
 ** https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix[See compatibility matrix of driver version 10.2]
 

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/serverconnections.adoc
@@ -31,8 +31,8 @@ PostgreSQL/PostGIS, Oracle Spatial or Microsoft SQL Server.
 deegree currently supports the following backends:
 
 * PostgreSQL 12+ with PostGIS extension 3.0+
-* Oracle Spatial 18.3, 19.x and 21.1  
-** https://www.oracle.com/de/database/technologies/faq-jdbc.html[See compatibility matrix of driver version 19.9]
+* Oracle Spatial 19.x, 21.x and 23.3  
+** https://www.oracle.com/de/database/technologies/faq-jdbc.html[See compatibility matrix of driver version 23.3]
 * Microsoft SQL Server 2012, 2014, 2016, 2017 and 2019 
 ** https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix[See compatibility matrix of driver version 10.2]
 

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -170,7 +170,7 @@
       <exclusions>
         <exclusion>
           <groupId>com.oracle.database.jdbc</groupId>
-          <artifactId>ojdbc8</artifactId>
+          <artifactId>ojdbc11</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -866,7 +866,7 @@
       <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
-        <artifactId>ojdbc8</artifactId>
+        <artifactId>ojdbc11</artifactId>
         <version>${oracle.version}</version>
       </dependency>
       <!-- Oracle GeoRaster -->
@@ -890,8 +890,9 @@
         <artifactId>sdoutl</artifactId>
         <version>${oracle.version}</version>
       </dependency>
+      <!-- Oracle GeoRaster (Official provided driver from repo1.maven.org) -->
       <dependency>
-        <groupId>com.oracle</groupId>
+        <groupId>com.oracle.database.xml</groupId>
         <artifactId>xmlparserv2_sans_jaxp_services</artifactId>
         <version>${oracle.version}</version>
       </dependency>
@@ -1235,7 +1236,7 @@
     <site.dir>${user.home}/Sites</site.dir>
     <java.version>11</java.version>
     <antlr.version>3.5.3</antlr.version>
-    <oracle.version>19.9.0.0</oracle.version>
+    <oracle.version>23.4.0.24.05</oracle.version>
     <log4j.version>2.23.1</log4j.version>
     <slf4j.version>2.0.12</slf4j.version>
     <spring-boot.version>2.7.18</spring-boot.version>


### PR DESCRIPTION
This PR upgrades the oracle libraries to a recent version.
The required private libraries have been uploaded to the private repository.
Tests have been made with a docker setup using the container `tomcat:10-jdk11` and `container-registry.oracle.com/database/free:23.4.0.0` as the database.
Vector and raster (GeoRaster) access has been tested against a sample dataset.

fixes #1475

References:
  - #1475