### PR TITLE
Replace String.replaceAll and String.replaceFirst with precompiled java.util.regex.Pattern to speed up String replacements

### DIFF
--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
@@ -35,6 +35,7 @@
 
 package org.deegree.gml.feature;
 
+import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
 import org.deegree.commons.tom.ResolveMode;
 import org.deegree.commons.tom.ResolveParams;
@@ -107,6 +108,8 @@ import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
  * @author <a href="mailto:ionita@lat-lon.de">Andrei Ionita</a>
  */
 public class GMLFeatureWriterTest {
+
+	private static final Pattern NEWLINE_PATTERN = Pattern.compile("\n");
 
 	private final String SOURCE_FILE_31 = "../misc/feature/Philosopher_FeatureCollection.xml";
 
@@ -596,8 +599,8 @@ public class GMLFeatureWriterTest {
 				Object controlValue = comparison.getControlDetails().getValue();
 				if (testValue instanceof String && controlValue instanceof String && testValue != null
 						&& testValue != null) {
-					String control = ((String) controlValue).replaceAll("\n", "").replace(" ", "");
-					String test = ((String) testValue).replaceAll("\n", "").replace(" ", "");
+					String control = NEWLINE_PATTERN.matcher(((String) controlValue)).replaceAll("").replace(" ", "");
+					String test = NEWLINE_PATTERN.matcher(((String) testValue)).replaceAll("").replace(" ", "");
 					return control.equals(test) ? EQUAL : DIFFERENT;
 				}
 				return comparisonResult;

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/StringUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/StringUtils.java
@@ -106,9 +106,26 @@ public class StringUtils {
 	 * @param from is the string to be replaced
 	 * @param to is the string which will used to replace
 	 * @return the changed target string
+	 * @deprecated use {@link StringUtils#replaceAll(String, Pattern, String)} instead,
+	 * with a static precompiled Pattern for performance.
 	 */
+	@Deprecated
 	public static String replaceAll(String target, String from, String to) {
 		return target.replaceAll(Pattern.quote(from), Matcher.quoteReplacement(to));
+	}
+
+	/**
+	 * Replaces the all substrings of this string that matches the given from string with
+	 * the given replacement. Works like {@link String#replaceAll(String, String)} but
+	 * doesn't use regular expressions. All occurences of special chars will be escaped.
+	 * @param target is the original string
+	 * @param pattern the pattern to match what should be replaced. (Static compiled for
+	 * performance if possible)
+	 * @param to is the string which will used to replace
+	 * @return the changed target string
+	 */
+	public static String replaceAll(String target, Pattern pattern, String to) {
+		return pattern.matcher(target).replaceAll(Matcher.quoteReplacement(to));
 	}
 
 	/**

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/StringUtils.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/StringUtils.java
@@ -107,17 +107,17 @@ public class StringUtils {
 	 * @param to is the string which will used to replace
 	 * @return the changed target string
 	 * @deprecated use {@link StringUtils#replaceAll(String, Pattern, String)} instead,
-	 * with a static precompiled Pattern for performance.
+	 * with a static precompiled Pattern for better performance.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.6.0", forRemoval = false)
 	public static String replaceAll(String target, String from, String to) {
 		return target.replaceAll(Pattern.quote(from), Matcher.quoteReplacement(to));
 	}
 
 	/**
-	 * Replaces the all substrings of this string that matches the given from string with
-	 * the given replacement. Works like {@link String#replaceAll(String, String)} but
-	 * doesn't use regular expressions. All occurences of special chars will be escaped.
+	 * Replaces the all substrings of this string that matches the given pattern with the
+	 * given replacement. Works like {@link String#replaceAll(String, String)} but doesn't
+	 * compile the pattern on every invocation.
 	 * @param target is the original string
 	 * @param pattern the pattern to match what should be replaced. (Static compiled for
 	 * performance if possible)

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
@@ -37,6 +37,7 @@ package org.deegree.commons.xml.schema;
 import java.io.IOException;
 import java.net.URL;
 
+import java.util.regex.Pattern;
 import org.apache.xerces.xni.XMLResourceIdentifier;
 import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLEntityResolver;
@@ -61,6 +62,8 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 	private static final String ROOT = "/META-INF/SCHEMAS_OPENGIS_NET/";
 
 	private static final URL baseURL;
+
+	private static final Pattern HTTP_PATTERN = Pattern.compile("http://");
 
 	static {
 		baseURL = RedirectingEntityResolver.class.getResource(ROOT);
@@ -87,7 +90,7 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 			}
 		}
 		else if (systemId.startsWith(INSPIRE_SCHEMAS_URL)) {
-			return systemId.replaceFirst("http://", "https://");
+			return HTTP_PATTERN.matcher(systemId).replaceFirst("https://");
 		}
 		else if (systemId.equals("http://www.w3.org/2001/xml.xsd")) {
 			// workaround for schemas that include the xml base schema...

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/utils/StringToolsTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/utils/StringToolsTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 /**
@@ -49,25 +50,27 @@ import org.junit.Test;
  */
 public class StringToolsTest {
 
+	private static final Pattern QUOTE_PATTERN = Pattern.compile(Pattern.quote("*"));
+
 	/**
 	 * Test method for
-	 * {@link org.deegree.commons.utils.StringUtils#replaceAll(java.lang.String, java.lang.String, java.lang.String)}.
+	 * {@link org.deegree.commons.utils.StringUtils#replaceAll(java.lang.String, java.util.regex.Pattern, java.lang.String)}.
 	 */
 	@Test
 	public void testReplaceAll() {
-		assertEquals("foo|bar||baz", StringUtils.replaceAll("foo*bar**baz", "*", "|"));
-		assertEquals("foo$1bar$1baz", StringUtils.replaceAll("foo*bar*baz", "*", "$1"));
-		assertEquals("", StringUtils.replaceAll("", "*", "$1"));
+		assertEquals("foo|bar||baz", StringUtils.replaceAll("foo*bar**baz", QUOTE_PATTERN, "|"));
+		assertEquals("foo$1bar$1baz", StringUtils.replaceAll("foo*bar*baz", QUOTE_PATTERN, "$1"));
+		assertEquals("", StringUtils.replaceAll("", QUOTE_PATTERN, "$1"));
 	}
 
 	/**
 	 * Test method for
-	 * {@link org.deegree.commons.utils.StringUtils#replaceAll(java.lang.String, java.lang.String, java.lang.String)}.
+	 * {@link org.deegree.commons.utils.StringUtils#replaceAll(java.lang.String, java.util.regex.Pattern, java.lang.String)}.
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testReplaceAllNull() {
 		// should that be the correct behaviour? or should it return an empty string?
-		StringUtils.replaceAll(null, "*", "$1");
+		StringUtils.replaceAll(null, QUOTE_PATTERN, "$1");
 	}
 
 	/**

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/rangeset/Interval.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/rangeset/Interval.java
@@ -37,6 +37,8 @@
 
 package org.deegree.coverage.rangeset;
 
+import java.util.regex.Pattern;
+
 /**
  * The <code>Interval</code> an intervall.
  *
@@ -86,6 +88,9 @@ public class Interval<T extends Comparable<T>, R extends Comparable<R>> {
 		/** simple boundary representation of the end of an interval */
 		public final String end;
 
+		/** precompiled pattern for matching the character - */
+		private static final Pattern DASH_PATTERN = Pattern.compile("-");
+
 		private Closure(String begin, String end) {
 			this.begin = begin;
 			this.end = end;
@@ -98,7 +103,7 @@ public class Interval<T extends Comparable<T>, R extends Comparable<R>> {
 		public static Closure fromString(String closureValue) {
 			Closure result = Closure.closed;
 			if (closureValue != null && !"".equals(closureValue)) {
-				String mapped = closureValue.replaceAll("-", "_");
+				String mapped = DASH_PATTERN.matcher(closureValue).replaceAll("_");
 				try {
 					result = Closure.valueOf(mapped.toLowerCase());
 				}

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/CacheRasterReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/cache/CacheRasterReader.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import java.util.regex.Pattern;
 import org.deegree.commons.utils.FileUtils;
 import org.deegree.coverage.raster.AbstractRaster;
 import org.deegree.coverage.raster.data.container.BufferResult;
@@ -77,6 +78,14 @@ public class CacheRasterReader extends GridFileReader {
 	private static final Logger LOG = getLogger(CacheRasterReader.class);
 
 	private static final int TILE_SIZE = 500;
+
+	private static final Pattern CURLY_BRACKET_OPEN_PATTERN = Pattern.compile("\\{");
+
+	private static final Pattern CURLY_BRACKET_CLOSE_PATTERN = Pattern.compile("\\}");
+
+	private static final Pattern SEMICOLON_PATTERN = Pattern.compile("\\:");
+
+	private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
 
 	private final Object LOCK = new Object();
 
@@ -498,10 +507,10 @@ public class CacheRasterReader extends GridFileReader {
 		sb.append("_w_").append(width);
 		sb.append("_h_").append(height);
 		String result = sb.toString();
-		result = result.replaceAll("\\{", "_");
-		result = result.replaceAll("\\}", "_");
-		result = result.replaceAll("\\:", "_");
-		result = result.replaceAll("\\s", "_");
+		result = CURLY_BRACKET_OPEN_PATTERN.matcher(result).replaceAll("_");
+		result = CURLY_BRACKET_CLOSE_PATTERN.matcher(result).replaceAll("_");
+		result = SEMICOLON_PATTERN.matcher(result).replaceAll("_");
+		result = WHITESPACE_PATTERN.matcher(result).replaceAll("_");
 		return result;
 	}
 

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/info/BandType.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/data/info/BandType.java
@@ -40,6 +40,7 @@ import java.awt.image.DataBuffer;
 import java.awt.image.PixelInterleavedSampleModel;
 import java.awt.image.SampleModel;
 
+import java.util.regex.Pattern;
 import org.deegree.coverage.raster.data.RasterData;
 
 /**
@@ -121,6 +122,10 @@ public enum BandType {
 	 */
 	public final static BandType[] RGBA = new BandType[] { RED, GREEN, BLUE, ALPHA };
 
+	private static final Pattern DASH_PATTERN = Pattern.compile("-");
+
+	private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
+
 	private final String info;
 
 	BandType(String info) {
@@ -195,8 +200,8 @@ public enum BandType {
 	 */
 	public static BandType fromString(String band) {
 		String key = band.toUpperCase();
-		key = key.replaceAll("-", "_");
-		key = key.replaceAll("\\s", "_");
+		key = DASH_PATTERN.matcher(key).replaceAll("_");
+		key = WHITESPACE_PATTERN.matcher(key).replaceAll("_");
 		BandType bt = null;
 		try {
 			bt = BandType.valueOf(key);

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/interpolation/InterpolationType.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/interpolation/InterpolationType.java
@@ -34,6 +34,8 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.coverage.raster.interpolation;
 
+import java.util.regex.Pattern;
+
 /**
  * Enum for all implemented interpolation types.
  *
@@ -48,6 +50,10 @@ public enum InterpolationType {
 	/** No interpolation */
 	NONE;
 
+	private static final Pattern DASH_PATTERN = Pattern.compile("-");
+
+	private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
+
 	/**
 	 * Get interpolation for the given string. This method is case insensitive, words can
 	 * be separated with a whitespace, minus or underscore.
@@ -56,8 +62,8 @@ public enum InterpolationType {
 	 */
 	public static InterpolationType fromString(String interpolation) {
 		String key = interpolation.toUpperCase();
-		key = key.replaceAll("-", "_");
-		key = key.replaceAll("\\s", "_");
+		key = DASH_PATTERN.matcher(key).replaceAll("_");
+		key = WHITESPACE_PATTERN.matcher(key).replaceAll("_");
 		return InterpolationType.valueOf(key);
 	}
 

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/configuration/wkt/WKTParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/configuration/wkt/WKTParser.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.regex.Pattern;
 import javax.vecmath.Point2d;
 
 import org.deegree.cs.CRSCodeType;
@@ -102,6 +103,8 @@ public class WKTParser {
 
 	private static final Logger LOG = getLogger(WKTParser.class);
 
+	private static final Pattern DASH_PATTERN = Pattern.compile("_");
+
 	private StreamTokenizer tokenizer;
 
 	private Reader buff;
@@ -114,7 +117,7 @@ public class WKTParser {
 	 */
 	protected boolean equalsParameterVariants(String candidate, String paramName) {
 		String candidateVariant = candidate.replace("_", "");
-		String paramVariant = paramName.replaceAll("_", "");
+		String paramVariant = DASH_PATTERN.matcher(paramName).replaceAll("");
 		if (candidateVariant.equalsIgnoreCase(paramVariant)) {
 			return true;
 		}
@@ -122,7 +125,7 @@ public class WKTParser {
 	}
 
 	protected String makeInvariantKey(String candidate) {
-		return candidate.replaceAll("_", "").toLowerCase();
+		return DASH_PATTERN.matcher(candidate).replaceAll("").toLowerCase();
 	}
 
 	/**

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/configuration/wkt/WKTParser.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/configuration/wkt/WKTParser.java
@@ -103,7 +103,7 @@ public class WKTParser {
 
 	private static final Logger LOG = getLogger(WKTParser.class);
 
-	private static final Pattern DASH_PATTERN = Pattern.compile("_");
+	private static final Pattern UNDERSCORE_PATTERN = Pattern.compile("_");
 
 	private StreamTokenizer tokenizer;
 
@@ -117,7 +117,7 @@ public class WKTParser {
 	 */
 	protected boolean equalsParameterVariants(String candidate, String paramName) {
 		String candidateVariant = candidate.replace("_", "");
-		String paramVariant = DASH_PATTERN.matcher(paramName).replaceAll("");
+		String paramVariant = UNDERSCORE_PATTERN.matcher(paramName).replaceAll("");
 		if (candidateVariant.equalsIgnoreCase(paramVariant)) {
 			return true;
 		}
@@ -125,7 +125,7 @@ public class WKTParser {
 	}
 
 	protected String makeInvariantKey(String candidate) {
-		return DASH_PATTERN.matcher(candidate).replaceAll("").toLowerCase();
+		return UNDERSCORE_PATTERN.matcher(candidate).replaceAll("").toLowerCase();
 	}
 
 	/**

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -43,6 +43,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.regex.Pattern;
 import org.deegree.commons.tom.TypedObjectNode;
 import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
@@ -116,6 +117,18 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractWhereBuilder {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractWhereBuilder.class);
+
+	private static final String WILDCARD = "*";
+
+	private static final String SINGLECHAR = "?";
+
+	private static final String ESCAPECHAR = "\\";
+
+	private static final Pattern ESCAPE_CHAR_PATTERN = Pattern.compile(Pattern.quote(ESCAPECHAR));
+
+	private static final Pattern SINGLE_CHAR_PATTERN = Pattern.compile(Pattern.quote(SINGLECHAR));
+
+	private static final Pattern WILDCARD_PATTERN = Pattern.compile(Pattern.quote(WILDCARD));
 
 	protected final SQLDialect dialect;
 
@@ -540,15 +553,12 @@ public abstract class AbstractWhereBuilder {
 			throw new UnmappableException(msg);
 		}
 
-		String wildCard = "*";
-		String singleChar = "?";
-		String escapeChar = "\\";
 		String s = ((Literal<?>) literal).getValue().toString();
-		s = StringUtils.replaceAll(s, escapeChar, escapeChar + escapeChar);
-		s = StringUtils.replaceAll(s, singleChar, escapeChar + singleChar);
-		s = StringUtils.replaceAll(s, wildCard, escapeChar + wildCard);
+		s = StringUtils.replaceAll(s, ESCAPE_CHAR_PATTERN, ESCAPECHAR + ESCAPECHAR);
+		s = StringUtils.replaceAll(s, SINGLE_CHAR_PATTERN, ESCAPECHAR + SINGLECHAR);
+		s = StringUtils.replaceAll(s, WILDCARD_PATTERN, ESCAPECHAR + WILDCARD);
 		Literal<PrimitiveValue> escapedLiteral = new Literal<PrimitiveValue>(new PrimitiveValue(s), null);
-		return new PropertyIsLike((ValueReference) propName, escapedLiteral, wildCard, singleChar, escapeChar,
+		return new PropertyIsLike((ValueReference) propName, escapedLiteral, WILDCARD, SINGLECHAR, ESCAPECHAR,
 				matchCase, null);
 	}
 

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/wkn/TrueTypeFontLoader.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/styling/wkn/TrueTypeFontLoader.java
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory;
 
 public class TrueTypeFontLoader implements WellKnownNameLoader {
 
+	private static final Pattern FONT_PREFIX_PATTERN = Pattern.compile("[tT][tT][fF]://(.*)#(.*)");
+
 	private static final Logger LOG = LoggerFactory.getLogger(TrueTypeFontLoader.class);
 
 	private static final String PREFIX = "ttf://";
@@ -52,7 +54,7 @@ public class TrueTypeFontLoader implements WellKnownNameLoader {
 		if (wellKnownName == null || !wellKnownName.startsWith(PREFIX))
 			return null;
 
-		Matcher m = Pattern.compile("[tT][tT][fF]://(.*)#(.*)").matcher(wellKnownName);
+		Matcher m = FONT_PREFIX_PATTERN.matcher(wellKnownName);
 		if (!m.matches()) {
 			throw new IllegalArgumentException("Invalid WellKnownName, use syntax ttf://<fontName>#<charCode>");
 		}

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/IdUtils.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/inspectors/IdUtils.java
@@ -62,6 +62,8 @@ class IdUtils {
 
 	private static final Logger LOG = getLogger(IdUtils.class);
 
+	private static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]");
+
 	private final Connection conn;
 
 	private String mainTable;
@@ -96,8 +98,7 @@ class IdUtils {
 
 			uuid = UUID.randomUUID().toString();
 			char firstChar = uuid.charAt(0);
-			Pattern p = Pattern.compile("[0-9]");
-			Matcher m = p.matcher("" + firstChar);
+			Matcher m = NUMBER_PATTERN.matcher("" + firstChar);
 			if (m.matches()) {
 				int i;
 				double ma = Math.random();
@@ -110,7 +111,7 @@ class IdUtils {
 				}
 
 				firstChar = (char) ((int) (i + ma * 26));
-				uuid = uuid.replaceFirst("[0-9]", String.valueOf(firstChar));
+				uuid = NUMBER_PATTERN.matcher(uuid).replaceFirst(String.valueOf(firstChar));
 			}
 			boolean uuidIsEqual = false;
 
@@ -146,12 +147,8 @@ class IdUtils {
 	boolean checkUUIDCompliance(String uuid) {
 
 		char firstChar = uuid.charAt(0);
-		Pattern p = Pattern.compile("[0-9]");
-		Matcher m = p.matcher("" + firstChar);
-		if (m.matches()) {
-			return false;
-		}
-		return true;
+		Matcher m = NUMBER_PATTERN.matcher("" + firstChar);
+		return !m.matches();
 	}
 
 	boolean checkUUIDCompliance(List<String> list) {

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/sql/AbstractSqlHelper.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/sql/AbstractSqlHelper.java
@@ -36,6 +36,7 @@ package org.deegree.metadata.iso.persistence.sql;
 
 import java.util.List;
 
+import java.util.regex.Pattern;
 import org.deegree.metadata.iso.persistence.ISOPropertyNameMapper;
 import org.deegree.metadata.iso.persistence.queryable.Queryable;
 import org.deegree.sqldialect.SQLDialect;
@@ -50,6 +51,8 @@ import org.deegree.sqldialect.filter.PropertyNameMapping;
  * @author <a href="mailto:goltz@lat-lon.org">Lyn Goltz</a>
  */
 abstract class AbstractSqlHelper {
+
+	private static final Pattern ASC_DESC_PATTERN = Pattern.compile(" ASC| DESC");
 
 	protected String idColumn;
 
@@ -102,7 +105,7 @@ abstract class AbstractSqlHelper {
 			String orderColList = builder.getOrderBy().getSQL().toString();
 			int i = 1;
 			while (orderColList.contains(" ASC") || orderColList.contains("DESC")) {
-				orderColList = orderColList.replaceFirst(" ASC| DESC", " AS crit" + (i++));
+				orderColList = ASC_DESC_PATTERN.matcher(orderColList).replaceFirst(" AS crit" + (i++));
 			}
 			getDatasetIDs.append(',');
 			getDatasetIDs.append(orderColList);

--- a/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOwsMetadataProviderBuilder.java
+++ b/deegree-services/deegree-services-commons/src/main/java/org/deegree/services/metadata/provider/DefaultOwsMetadataProviderBuilder.java
@@ -34,8 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.regex.Pattern;
 
 import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
@@ -74,7 +73,6 @@ import org.deegree.services.metadata.OWSMetadataProvider;
 import org.deegree.workspace.ResourceBuilder;
 import org.deegree.workspace.ResourceInitException;
 import org.deegree.workspace.ResourceMetadata;
-import org.w3c.dom.Element;
 
 /**
  * This class is responsible for building web service metadata providers.
@@ -83,6 +81,8 @@ import org.w3c.dom.Element;
  * @since 3.4
  */
 public class DefaultOwsMetadataProviderBuilder implements ResourceBuilder<OWSMetadataProvider> {
+
+	private static final Pattern METADATA_SET_ID_PATTERN = Pattern.compile(Pattern.quote("${metadataSetId}"));
 
 	private final JAXBElement<DeegreeServicesMetadataType> md;
 
@@ -203,7 +203,7 @@ public class DefaultOwsMetadataProviderBuilder implements ResourceBuilder<OWSMet
 		if (template == null || template.getValue() == null || datasetId == null) {
 			return null;
 		}
-		return StringUtils.replaceAll(template.getValue(), "${metadataSetId}", datasetId);
+		return StringUtils.replaceAll(template.getValue(), METADATA_SET_ID_PATTERN, datasetId);
 	}
 
 	private String parseFormat(DeegreeServicesMetadataType.DatasetMetadata.MetadataUrlTemplate template) {

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/capabilities/Capabilities100XMLAdapter.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/capabilities/Capabilities100XMLAdapter.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -74,6 +75,8 @@ public class Capabilities100XMLAdapter extends XMLAdapter {
 	private static final String GML_PREFIX = "gml";
 
 	private static final String GML_NS = "http://www.opengis.net/gml";
+
+	private static final Pattern NON_WORD_PATTERN = Pattern.compile("\\W");
 
 	/**
 	 * The sections of the Capabilities document.
@@ -260,7 +263,7 @@ public class Capabilities100XMLAdapter extends XMLAdapter {
 				fees = identification.getFees();
 
 			}
-			fees = fees.replaceAll("\\W", " ");
+			fees = NON_WORD_PATTERN.matcher(fees).replaceAll(" ");
 			writeElement(writer, WCS_100_NS, "fees", fees);
 
 			// accessConstraints [1, n]

--- a/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/describecoverage/CoverageDescription100XMLAdapter.java
+++ b/deegree-services/deegree-services-wcs/src/main/java/org/deegree/services/wcs/describecoverage/CoverageDescription100XMLAdapter.java
@@ -44,6 +44,7 @@ import static org.deegree.protocol.wcs.WCSConstants.WCS_100_SCHEMA;
 
 import java.util.List;
 
+import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -81,6 +82,8 @@ public class CoverageDescription100XMLAdapter extends XMLAdapter {
 	private static final String GML_PREFIX = "gml";
 
 	private static final String GML_NS = "http://www.opengis.net/gml";
+
+	private static final Pattern UNDERSCORE_PATTERN = Pattern.compile("_");
 
 	/**
 	 * @param writer
@@ -308,7 +311,8 @@ public class CoverageDescription100XMLAdapter extends XMLAdapter {
 
 			writer.writeAttribute("atomic", interval.isAtomic() ? "true" : "false");
 			Closure closure = interval.getClosure();
-			writer.writeAttribute(WCS_100_PRE, WCS_100_NS, "closure", closure.name().replaceAll("_", "-"));
+			writer.writeAttribute(WCS_100_PRE, WCS_100_NS, "closure",
+					UNDERSCORE_PATTERN.matcher(closure.name()).replaceAll("-"));
 
 			exportSingleValueType(writer, interval.getMin(), "min");
 			exportSingleValueType(writer, interval.getMax(), "max");

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -239,6 +239,8 @@ public class WebFeatureService extends AbstractOWS {
 
 	private static final int DEFAULT_MAX_FEATURES = 15000;
 
+	private static final Pattern METADATA_SET_ID_PATTERN = Pattern.compile(Pattern.quote("${metadataSetId}"));
+
 	private WfsFeatureStoreManager service;
 
 	private LockFeatureHandler lockFeatureHandler;
@@ -510,7 +512,7 @@ public class WebFeatureService extends AbstractOWS {
 		if (metadataUrlTemplate == null || ftMd == null || ftMd.getMetadataSetId() == null) {
 			return null;
 		}
-		return StringUtils.replaceAll(metadataUrlTemplate, "${metadataSetId}", ftMd.getMetadataSetId());
+		return StringUtils.replaceAll(metadataUrlTemplate, METADATA_SET_ID_PATTERN, ftMd.getMetadataSetId());
 	}
 
 	private void initOfferedVersions(SupportedVersions supportedVersions) {
@@ -562,7 +564,7 @@ public class WebFeatureService extends AbstractOWS {
 				GML_31);
 		org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat(this,
 
-				GML_32);
+					GML_32);
 		formats.put("application/gml+xml; version=2.1", gml21);
 		formats.put("application/gml+xml; version=3.0", gml30);
 		formats.put("application/gml+xml; version=3.1", gml31);
@@ -584,8 +586,8 @@ public class WebFeatureService extends AbstractOWS {
 		formats.forEach((mimeType, format) -> {
 			if (excludePatterns.stream().anyMatch(p -> p.matcher(mimeType).matches())) {
 				LOG.debug("The format '{}' was configured to be excluded.", mimeType);
-			}
-			else {
+		}
+		else {
 				mimeTypeToFormat.put(mimeType, format);
 			}
 		});
@@ -1612,7 +1614,7 @@ public class WebFeatureService extends AbstractOWS {
 				.replace("*", "\\E.*\\Q") //
 				.replace("?", "\\E.\\Q") //
 					+ "$");
-		}
+}
 		catch (PatternSyntaxException pse) {
 			throw new ResourceInitException("Unable to parse glob pattern '" + glob + "': " + pse.getMessage(), pse);
 		}

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -564,7 +564,7 @@ public class WebFeatureService extends AbstractOWS {
 				GML_31);
 		org.deegree.services.wfs.format.gml.GmlFormat gml32 = new org.deegree.services.wfs.format.gml.GmlFormat(this,
 
-					GML_32);
+				GML_32);
 		formats.put("application/gml+xml; version=2.1", gml21);
 		formats.put("application/gml+xml; version=3.0", gml30);
 		formats.put("application/gml+xml; version=3.1", gml31);
@@ -586,8 +586,8 @@ public class WebFeatureService extends AbstractOWS {
 		formats.forEach((mimeType, format) -> {
 			if (excludePatterns.stream().anyMatch(p -> p.matcher(mimeType).matches())) {
 				LOG.debug("The format '{}' was configured to be excluded.", mimeType);
-		}
-		else {
+			}
+			else {
 				mimeTypeToFormat.put(mimeType, format);
 			}
 		});
@@ -1614,7 +1614,7 @@ public class WebFeatureService extends AbstractOWS {
 				.replace("*", "\\E.*\\Q") //
 				.replace("?", "\\E.\\Q") //
 					+ "$");
-}
+		}
 		catch (PatternSyntaxException pse) {
 			throw new ResourceInitException("Unable to parse glob pattern '" + glob + "': " + pse.getMessage(), pse);
 		}

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/DatasetMetadataFactory.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/theme/DatasetMetadataFactory.java
@@ -46,9 +46,9 @@ import static org.deegree.theme.Themes.getAllLayers;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.regex.Pattern;
 import javax.xml.namespace.QName;
 
-import org.apache.axiom.om.OMElement;
 import org.deegree.commons.ows.metadata.DatasetMetadata;
 import org.deegree.commons.ows.metadata.Description;
 import org.deegree.commons.ows.metadata.ExtendedDescription;
@@ -70,6 +70,8 @@ import org.deegree.theme.Theme;
  * @since 3.3
  */
 class DatasetMetadataFactory {
+
+	private static final Pattern METADATA_SET_ID_PATTERN = Pattern.compile(Pattern.quote("${metadataSetId}"));
 
 	DatasetMetadata buildDatasetMetadata(final LayerMetadata layerMetadata, final Theme theme,
 			final String mdUrlTemplate) {
@@ -127,7 +129,7 @@ class DatasetMetadataFactory {
 		if (id == null || mdUrlTemplate == null) {
 			return null;
 		}
-		return replaceAll(mdUrlTemplate, "${metadataSetId}", id);
+		return replaceAll(mdUrlTemplate, METADATA_SET_ID_PATTERN, id);
 	}
 
 }

--- a/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/BuildingManager.java
+++ b/deegree-tools/deegree-tools-3d/src/main/java/org/deegree/tools/rendering/manager/buildings/BuildingManager.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.regex.Pattern;
 import org.apache.commons.cli.CommandLine;
 import org.deegree.commons.utils.FileUtils;
 import org.deegree.rendering.r3d.model.geometry.SimpleGeometryStyle;
@@ -68,7 +69,9 @@ import org.deegree.tools.rendering.manager.buildings.importers.VRMLImporter;
  */
 public class BuildingManager extends ModelManager<WorldRenderableObject> {
 
-	private final static org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(BuildingManager.class);
+	private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(BuildingManager.class);
+
+	private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
 
 	private final String buildingID;
 
@@ -231,7 +234,7 @@ public class BuildingManager extends ModelManager<WorldRenderableObject> {
 		String id = buildingID;
 		if (buildingID == null) {
 			id = FileUtils.getFilename(new File(fileName));
-			id = id.replaceAll("\\s", "_");
+			id = WHITESPACE_PATTERN.matcher(id).replaceAll("_");
 		}
 		params.put("id", id);
 		if (textureDir != null) {

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/config/FeatureStoreConfigWriter.java
@@ -21,6 +21,7 @@
  */
 package org.deegree.tools.featurestoresql.config;
 
+import java.util.regex.Pattern;
 import org.deegree.commons.xml.stax.IndentingXMLStreamWriter;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.cs.refs.coordinatesystem.CRSRef;
@@ -63,6 +64,8 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
 
 	private static final Logger LOG = getLogger(FeatureStoreConfigWriter.class);
 
+	private static final Pattern FILEXTENSION_PATTERN = Pattern.compile("[.][^.]+$");
+
 	private final LoadParameter loadParameter;
 
 	public FeatureStoreConfigWriter(LoadParameter loadParameter) {
@@ -88,7 +91,7 @@ public class FeatureStoreConfigWriter implements ItemWriter<AppSchema> {
 				loadParameter.getPropertiesWithPrimitiveHref());
 		String uriPathToSchema = new URI(loadParameter.getSchemaUrl()).getPath();
 		String schemaFileName = uriPathToSchema.substring(uriPathToSchema.lastIndexOf('/') + 1);
-		String fileName = schemaFileName.replaceFirst("[.][^.]+$", "");
+		String fileName = FILEXTENSION_PATTERN.matcher(schemaFileName).replaceFirst("");
 
 		String format = loadParameter.getFormat();
 		if (format.equals("all")) {


### PR DESCRIPTION
This PR is a rebased version of #1639 which resolved the conflicts.
Original Text:
> Proposal for replacing pattern compiles in degree for methods: String.replaceFirst and String.replaceAll

Closes #1639
Fixes #1633

References:
  * #1633 
  * #1639