### PR TITLE
Change SLF4J implementation of log4j2 to be compatible to SLF4J 2.x

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -301,7 +301,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/deegree-tests/deegree-compliance-tests/pom.xml
+++ b/deegree-tests/deegree-compliance-tests/pom.xml
@@ -184,7 +184,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 

--- a/deegree-tests/deegree-integration-tests/pom.xml
+++ b/deegree-tests/deegree-integration-tests/pom.xml
@@ -106,7 +106,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/deegree-tests/deegree-wms-remoteows-tests/pom.xml
+++ b/deegree-tests/deegree-wms-remoteows-tests/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-tests/deegree-wms-similarity-tests/pom.xml
+++ b/deegree-tests/deegree-wms-similarity-tests/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 

--- a/deegree-tests/deegree-wmts-tests/pom.xml
+++ b/deegree-tests/deegree-wmts-tests/pom.xml
@@ -114,7 +114,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-tests/deegree-workspace-tests/pom.xml
+++ b/deegree-tests/deegree-workspace-tests/pom.xml
@@ -122,7 +122,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 

--- a/deegree-tools/deegree-tools-3d/pom.xml
+++ b/deegree-tools/deegree-tools-3d/pom.xml
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 

--- a/deegree-tools/deegree-tools-base/pom.xml
+++ b/deegree-tools/deegree-tools-base/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
PR changes the SLF4J implementation of log4j2, to the one for SLF4J v2.x, as there are two different implementations available.

SLF4J was updated in #1669

References:
 - #1669