### PR TITLE
Changing format of password stored in console.pw to UNIX crypt extended format

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -280,6 +280,10 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
       <version>13.0.6</version>

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/security/LogBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/security/LogBean.java
@@ -113,7 +113,7 @@ public class LogBean implements Serializable {
 		return newPassword2;
 	}
 
-	public String logIn() throws NoSuchAlgorithmException, IOException {
+	public String logIn() throws IOException {
 
 		SaltedPassword storedPassword = passwordFile.getCurrentContent();
 		if (storedPassword == null) {
@@ -125,7 +125,7 @@ public class LogBean implements Serializable {
 
 		SaltedPassword givenPassword = new SaltedPassword(currentPassword, storedPassword.getSalt());
 		loggedIn = storedPassword.equals(givenPassword);
-		LOG.debug("Provided password matches stored password. Successfully logged in.");
+		LOG.debug("Provided password matches stored password: {}", loggedIn);
 		return FacesContext.getCurrentInstance().getViewRoot().getViewId();
 	}
 

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/security/LogBean.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/security/LogBean.java
@@ -29,6 +29,7 @@ package org.deegree.console.security;
 
 import static jakarta.faces.application.FacesMessage.SEVERITY_ERROR;
 import static jakarta.faces.application.FacesMessage.SEVERITY_WARN;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import jakarta.faces.context.FacesContext;
 
 import jakarta.inject.Named;
 import org.deegree.commons.config.DeegreeWorkspace;
+import org.slf4j.Logger;
 
 /**
  * JSF backing bean for logging in, logging out, checking login status and password
@@ -56,7 +58,9 @@ public class LogBean implements Serializable {
 
 	private static final long serialVersionUID = -4865071415988778817L;
 
-	private static final String PASSWORD_FILE = "console.pw";
+	private static final Logger LOG = getLogger(LogBean.class);
+
+	protected static final String PASSWORD_FILE = "console.pw";
 
 	public static final String CONSOLE = "/index";
 
@@ -121,6 +125,7 @@ public class LogBean implements Serializable {
 
 		SaltedPassword givenPassword = new SaltedPassword(currentPassword, storedPassword.getSalt());
 		loggedIn = storedPassword.equals(givenPassword);
+		LOG.debug("Provided password matches stored password. Successfully logged in.");
 		return FacesContext.getCurrentInstance().getViewRoot().getViewId();
 	}
 
@@ -145,9 +150,10 @@ public class LogBean implements Serializable {
 
 			SaltedPassword newSaltedPassword = new SaltedPassword(newPassword);
 			passwordFile.update(newSaltedPassword);
+			LOG.info("Password file updated successfully");
 		}
 		catch (Throwable e) {
-			e.printStackTrace();
+			LOG.error("Failed to update password file due to {}", e.getMessage(), e);
 			FacesMessage fm = new FacesMessage(SEVERITY_ERROR, "Error updating password: " + e.getMessage(), null);
 			FacesContext.getCurrentInstance().addMessage(null, fm);
 			return CHANGE_PASSWORD;

--- a/deegree-services/deegree-webservices/src/main/java/org/deegree/console/security/PasswordFile.java
+++ b/deegree-services/deegree-webservices/src/main/java/org/deegree/console/security/PasswordFile.java
@@ -28,6 +28,7 @@
 package org.deegree.console.security;
 
 import static java.lang.Character.digit;
+import static org.deegree.console.security.SaltedPassword.SHA256_PREFIX;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -96,7 +97,7 @@ public class PasswordFile implements Serializable {
 		}
 		String[] parts = encoded.split("\\$");
 
-		return new SaltedPassword(parts[3].getBytes(StandardCharsets.UTF_8), parts[2]);
+		return new SaltedPassword(parts[3].getBytes(StandardCharsets.UTF_8), SHA256_PREFIX + parts[2]);
 	}
 
 	/**

--- a/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/PasswordFileTest.java
+++ b/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/PasswordFileTest.java
@@ -1,9 +1,11 @@
 package org.deegree.console.security;
 
 import static org.deegree.console.security.LogBean.PASSWORD_FILE;
+import static org.deegree.console.security.SaltedPassword.SHA256_PREFIX;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -22,6 +24,11 @@ import org.junit.Test;
  */
 public class PasswordFileTest {
 
+	/**
+	 * This unit tests can validate if the existing console.pw file contains a password in
+	 * the new extended password format introduced with deegree version 3.6.
+	 * @throws IOException in case of errors
+	 */
 	@Test
 	@Ignore
 	public void getCurrentContentFromWorkspaceRoot() throws IOException {
@@ -31,14 +38,16 @@ public class PasswordFileTest {
 		assertTrue(passwordFileFQN.isFile());
 		PasswordFile passwordFile = new PasswordFile(passwordFileFQN);
 		assertTrue(passwordFile.exists());
-		assertThat(passwordFile.getCurrentContent().toString(), not(isEmptyOrNullString()));
+		SaltedPassword saltedPassword = passwordFile.getCurrentContent();
+		assertThat(saltedPassword.toString(), not(isEmptyOrNullString()));
+		assertThat(saltedPassword.getSalt(), startsWith(SHA256_PREFIX));
 	}
 
 	/**
 	 * Attention: Enabling this unit test will overwrite the content of the console.pw
 	 * file! This test is intended as an example how to create a valid console.pw file
 	 * with the new extended passwort format introduced with deegree version 3.6.
-	 * @throws IOException
+	 * @throws IOException in case of errors
 	 * @since 3.6
 	 * @see SaltedPassword
 	 */

--- a/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/PasswordFileTest.java
+++ b/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/PasswordFileTest.java
@@ -1,0 +1,70 @@
+package org.deegree.console.security;
+
+import static org.deegree.console.security.LogBean.PASSWORD_FILE;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.NoSuchAlgorithmException;
+
+import org.deegree.commons.config.DeegreeWorkspace;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:friebe@lat-lon.de">Torsten Friebe</a>
+ * @since 3.6
+ */
+public class PasswordFileTest {
+
+	@Test
+	@Ignore
+	public void getCurrentContentFromWorkspaceRoot() throws IOException {
+		File workspaceDir = new File(DeegreeWorkspace.getWorkspaceRoot());
+		File passwordFileFQN = new File(workspaceDir, PASSWORD_FILE);
+		assertTrue(passwordFileFQN.exists());
+		assertTrue(passwordFileFQN.isFile());
+		PasswordFile passwordFile = new PasswordFile(passwordFileFQN);
+		assertTrue(passwordFile.exists());
+		assertThat(passwordFile.getCurrentContent().toString(), not(isEmptyOrNullString()));
+	}
+
+	/**
+	 * Attention: Enabling this unit test will overwrite the content of the console.pw
+	 * file! This test is intended as an example how to create a valid console.pw file
+	 * with the new extended passwort format introduced with deegree version 3.6.
+	 * @throws IOException
+	 * @since 3.6
+	 * @see SaltedPassword
+	 */
+	@Test
+	@Ignore
+	public void update() throws IOException {
+		File workspaceDir = new File(DeegreeWorkspace.getWorkspaceRoot());
+		File passwordFileFQN = new File(workspaceDir, PASSWORD_FILE);
+		PasswordFile passwordFile = new PasswordFile(passwordFileFQN);
+		passwordFile.update(new SaltedPassword("deegree3"));
+	}
+
+	@Test
+	public void writePasswordToWriter() throws IOException, NoSuchAlgorithmException {
+		SaltedPassword mypassword = new SaltedPassword("deegree3");
+		PasswordFile passwordFile = new PasswordFile(File.createTempFile("pwd", ".tmp"));
+		StringWriter writer = new StringWriter();
+		passwordFile.writePasswordToWriter(new PrintWriter(writer), mypassword);
+		assertThat(writer.toString(), not(isEmptyOrNullString()));
+		assertThat(writer.toString(), is(equalTo(mypassword.toString())));
+	}
+
+	@Test
+	public void exists() throws IOException {
+		PasswordFile passwordFile = new PasswordFile(File.createTempFile("pwd", ".tmp"));
+		assertTrue(passwordFile.exists());
+	}
+
+}

--- a/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/SaltedPasswordTest.java
+++ b/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/SaltedPasswordTest.java
@@ -5,8 +5,10 @@ import org.junit.Test;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
+import static org.deegree.console.security.SaltedPassword.SHA256_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:friebe@lat-lon.de">Torsten Friebe</a>
@@ -18,7 +20,7 @@ public class SaltedPasswordTest {
 	public void testCreatingFromPlainPassword() throws UnsupportedEncodingException {
 		SaltedPassword plainpassword = new SaltedPassword("foo");
 		String saltedPassword = new String(plainpassword.getSaltedAndHashedPassword(), StandardCharsets.UTF_8);
-		assertThat(plainpassword.getSalt(), startsWith("$5$"));
+		assertThat(plainpassword.getSalt(), startsWith(SHA256_PREFIX));
 		assertThat(saltedPassword, is(notNullValue()));
 	}
 
@@ -29,6 +31,15 @@ public class SaltedPasswordTest {
 		SaltedPassword saltedpassword = new SaltedPassword(password.getBytes(StandardCharsets.UTF_8), salt);
 		assertThat(new String(saltedpassword.getSaltedAndHashedPassword(), StandardCharsets.UTF_8), is(password));
 		assertThat(saltedpassword.getSalt(), is(salt));
+	}
+
+	@Test
+	public void testCreateNewPasswordWithSaltFromOtherPassword() throws UnsupportedEncodingException {
+		String plainpassword = "foo";
+		SaltedPassword storedPassword = new SaltedPassword(plainpassword);
+		String saltFromStoredPassword = storedPassword.getSalt();
+		SaltedPassword givenPassword = new SaltedPassword(plainpassword, saltFromStoredPassword);
+		assertTrue(storedPassword.equals(givenPassword));
 	}
 
 	@Test
@@ -45,7 +56,5 @@ public class SaltedPasswordTest {
 		// the hashed password
 		assertThat(parts[3], hasLength(43));
 	}
-
-
 
 }

--- a/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/SaltedPasswordTest.java
+++ b/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/SaltedPasswordTest.java
@@ -1,0 +1,51 @@
+package org.deegree.console.security;
+
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * @author <a href="mailto:friebe@lat-lon.de">Torsten Friebe</a>
+ * @since 3.6
+ */
+public class SaltedPasswordTest {
+
+	@Test
+	public void testCreatingFromPlainPassword() throws UnsupportedEncodingException {
+		SaltedPassword plainpassword = new SaltedPassword("foo");
+		String saltedPassword = new String(plainpassword.getSaltedAndHashedPassword(), StandardCharsets.UTF_8);
+		assertThat(plainpassword.getSalt(), startsWith("$5$"));
+		assertThat(saltedPassword, is(notNullValue()));
+	}
+
+	@Test
+	public void testCreatingFromSaltedPassword() {
+		String password = "nxIKX54gpaik7RiymYmMEhDou8.9DjFTzFkJxHKQ3D/";
+		String salt = "$5$12345678";
+		SaltedPassword saltedpassword = new SaltedPassword(password.getBytes(StandardCharsets.UTF_8), salt);
+		assertThat(new String(saltedpassword.getSaltedAndHashedPassword(), StandardCharsets.UTF_8), is(password));
+		assertThat(saltedpassword.getSalt(), is(salt));
+	}
+
+	@Test
+	public void testSaltedPasswordAsParts() throws UnsupportedEncodingException {
+		SaltedPassword password = new SaltedPassword("foo");
+		assertThat(password.toString(), startsWith("$"));
+		String[] parts = password.toString().split("\\$");
+		// first is empty as the string starts with $
+		assertThat(parts[0], is(""));
+		// the ID for SHA-256
+		assertThat(parts[1], is("5"));
+		// the salt
+		assertThat(parts[2], hasLength(8));
+		// the hashed password
+		assertThat(parts[3], hasLength(43));
+	}
+
+
+
+}


### PR DESCRIPTION
Fixes #1616. This PR introduces the UNIX crypt extended password format for the file console.pw. It will introduce a breaking change to the file format of the console.pw file. Users need to re-create their password when upgrading to deegree 3.6.
