### PR TITLE
Removed the unmaintained and unused deegree.module.status property

### DIFF
--- a/deegree-client/deegree-jsf-core/pom.xml
+++ b/deegree-client/deegree-jsf-core/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-jsf-core</name>
   <description>Common JSF functionality for creating JSF-based web clients</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-client</artifactId>

--- a/deegree-core/deegree-connectionprovider-datasource/pom.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Database connection provider based on javax.sql.Datasource</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-3d/pom.xml
+++ b/deegree-core/deegree-core-3d/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model and rendering for terrain data and buildings</description>
 
-  <properties>
-    <deegree.module.status>unmaintained</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-annotations/pom.xml
+++ b/deegree-core/deegree-core-annotations/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Custom Java annotations</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-base/pom.xml
+++ b/deegree-core/deegree-core-base/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model for feature data, data model and evaluation for filter expressions, GML readers and writers (needs splitting)</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Common base functionality (needs splitting)</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-coverage/pom.xml
+++ b/deegree-core/deegree-core-coverage/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model for coverage (e.g. raster) data</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-cs/pom.xml
+++ b/deegree-core/deegree-core-cs/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Coordinate reference system model, coordinate transformations, CRS readers/writers and CRS persistence</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-db/pom.xml
+++ b/deegree-core/deegree-core-db/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Database connections module</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-featureinfo/pom.xml
+++ b/deegree-core/deegree-core-featureinfo/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Featureinfo export utilities (Templating, HTML, format handling)</description>
 
-  <properties> 
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-filterfunctions/pom.xml
+++ b/deegree-core/deegree-core-filterfunctions/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Common filter functions</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-gdal/pom.xml
+++ b/deegree-core/deegree-core-gdal/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Provides access to GDAL (via JNI)</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model and utilities for vector geometries</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-metadata/pom.xml
+++ b/deegree-core/deegree-core-metadata/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model and base functionality for metadata records</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-commons/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>OGC protocol common types</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wfs/pom.xml
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wfs/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Protocol and Client for accessing remote Web Feature Services</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-protocol</artifactId>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-commons/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-commons/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Common interfaces and base functionality for integrating remote OGC Web Services as deegree workspace resources</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wms/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Remote OGC Web Map Services as deegree workspace resources</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>

--- a/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
+++ b/deegree-core/deegree-core-remoteows/deegree-remoteows-wmts/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Remote OGC Web Map Tile Services as deegree workspace resources</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-remoteows</artifactId>

--- a/deegree-core/deegree-core-rendering-2d/pom.xml
+++ b/deegree-core/deegree-core-rendering-2d/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Rendering of maps from geospatial data</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Common interfaces and functionality for implementing SQL dialect adapters</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>  
   <description>SQL dialect for Microsoft SQL Server</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core-sqldialect</artifactId>

--- a/deegree-core/deegree-core-theme/pom.xml
+++ b/deegree-core/deegree-core-theme/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model for map layer themes</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-tile/pom.xml
+++ b/deegree-core/deegree-core-tile/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Data model for map tiles</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-core/deegree-core-workspace/pom.xml
+++ b/deegree-core/deegree-core-workspace/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Workspace module</description>
 
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-core</artifactId>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-commons/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-featurestore-commons</name>
   <description>Base interfaces and common functionality for feature store implementations</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-featurestore-shape</name>
   <description>Feature store implementation that accesses shapefiles</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-simplesql/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-featurestore-simplesql</name>
   <description>Feature store implementation for retrieving features from SQL databases, configuration based on SELECT statements</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-featurestore-sql</name>
   <description>Feature store implementation for accessing features stored in SQL databases that supports mapping of complex data models</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-featurestores</artifactId>

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/pom.xml
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-commons/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-mdstore-commons</name>
   <description>Common interfaces and functionality for metadata store implementations</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-mdstores</artifactId>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-filesystem/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Tile store implementation for accessing tile files stored in directory hierarchies in the filesystem</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
@@ -5,10 +5,6 @@
   <packaging>jar</packaging>
   <description>Tile store implementation that accesses tiles stored in GeoTIFF/BigTIFF files</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-tilestores</artifactId>

--- a/deegree-layers/deegree-layers-coverage/pom.xml
+++ b/deegree-layers/deegree-layers-coverage/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-layers-coverage</name>
   <description>Layers implementation for layers created from coverage stores</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>

--- a/deegree-layers/deegree-layers-feature/pom.xml
+++ b/deegree-layers/deegree-layers-feature/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-layers-feature</name>
   <description>Layers implementation for layers created from feature stores</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>

--- a/deegree-layers/deegree-layers-gdal/pom.xml
+++ b/deegree-layers/deegree-layers-gdal/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-layers-gdal</name>
   <description>Layers implementation for layers created from coverage stores</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-layers</artifactId>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-commons</name>
   <description>Base interfaces and common functionality for OGC Web Service implementations</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-config/pom.xml
+++ b/deegree-services/deegree-services-config/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-config</name>
   <description>REST interface for accessing and modifying deegree workspaces</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-csw/pom.xml
+++ b/deegree-services/deegree-services-csw/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-csw</name>
   <description>Catalogue Service for the Web (CSW) implementation - Querying and modifying of metadata records for geospatial services and datasets</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-wcs/pom.xml
+++ b/deegree-services/deegree-services-wcs/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-wcs</name>
   <description>OGC Web Coverage Service (WCS) implementation - Rendering of geospatial coverage (e.g. raster) data</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-wfs</name>
   <description>OGC Web Feature Service (WFS) implementation - Querying and modifying of geospatial data objects</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-wms/pom.xml
+++ b/deegree-services/deegree-services-wms/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-wms</name>
   <description>Web Map Service (WMS) implementation - Rendering of maps from geospatial data</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-wmts/pom.xml
+++ b/deegree-services/deegree-services-wmts/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-wmts</name>
   <description>OGC Web Map Tiling Service (WMTS) implementation - Accessing of map tiles</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-wps/pom.xml
+++ b/deegree-services/deegree-services-wps/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-wps</name>
   <description>OGC Web Processing Service (WPS) implementation - Executing of geospatial processes</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-services-wpvs/pom.xml
+++ b/deegree-services/deegree-services-wpvs/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-services-wpvs</name>
   <description>Web Perspective View Service (WPVS) implementation - Rendering of 3D terrains and objects</description>
 
-  <properties>
-    <deegree.module.status>unmaintained</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -4,9 +4,6 @@
   <packaging>war</packaging>
   <name>deegree-webservices</name>
   <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules and service administration console</description>
-  <properties>
-    <deegree.module.status>rework</deegree.module.status>
-  </properties>
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>

--- a/deegree-themes/deegree-themes-remotewms/pom.xml
+++ b/deegree-themes/deegree-themes-remotewms/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-themes-remotewms</name>
   <description>Map layer theme implementation for remote Web Map Services</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-themes</artifactId>

--- a/deegree-workspaces/deegree-workspace-geosciml/pom.xml
+++ b/deegree-workspaces/deegree-workspace-geosciml/pom.xml
@@ -5,10 +5,6 @@
   <packaging>pom</packaging>
   <description>Example configuration for deploying GeoSciML via deegree WFS and WMS</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>

--- a/deegree-workspaces/deegree-workspace-utah/pom.xml
+++ b/deegree-workspaces/deegree-workspace-utah/pom.xml
@@ -5,10 +5,6 @@
   <packaging>pom</packaging>
   <description>Example configuration for a web mapping setup using deegree WMS, WMTS and WFS</description>
 
-  <properties>
-    <deegree.module.status>ok</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>

--- a/deegree-workspaces/deegree-workspace-wcts/pom.xml
+++ b/deegree-workspaces/deegree-workspace-wcts/pom.xml
@@ -5,10 +5,6 @@
   <name>deegree-workspace-wcts</name>
   <description>Example configuration for deploying a coordinate transformation service via deegree WPS</description>
 
-  <properties>
-    <deegree.module.status>check</deegree.module.status>
-  </properties>
-
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-workspaces</artifactId>


### PR DESCRIPTION
This PR removes the unmaintained and unused `deegree.module.status` property from all Maven pom.xml files.

The property was evaluated by the outdated [deegree-maven plugin](https://github.com/deegree/deegree-maven-plugin), which was already removed with PR #1169 for deegree 3.4.