### PR TITLE
Adjust the information displayed in the service metadata example of deegree

### DIFF
--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/metadata/example.xml
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/metadata/example.xml
@@ -13,9 +13,9 @@
     <ServiceContact>
       <IndividualName>Gerhard Mercator</IndividualName>
       <PositionName>Geographer</PositionName>
-      <Phone>0123/123456</Phone>
-      <Facsimile>0123/123456</Facsimile>
-      <ElectronicMailAddress>info@deegree.org</ElectronicMailAddress>
+      <Phone>0000/000000</Phone>
+      <Facsimile>0000/000000</Facsimile>
+      <ElectronicMailAddress>info@example.com</ElectronicMailAddress>
       <Address>
         <DeliveryPoint>9450 SW Gemini Dr #42523</DeliveryPoint>
         <City>Beaverton</City>

--- a/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/metadata/example.xml
+++ b/deegree-services/deegree-services-commons/src/main/resources/META-INF/schemas/services/metadata/example.xml
@@ -8,24 +8,24 @@
   </ServiceIdentification>
 
   <ServiceProvider>
-    <ProviderName>Technical Management Committe</ProviderName>
-    <ProviderSite>http://www.deegree.org</ProviderSite>
+    <ProviderName>deegree</ProviderName>
+    <ProviderSite>https://www.deegree.org</ProviderSite>
     <ServiceContact>
-      <IndividualName>Technical Management Committe</IndividualName>
-      <PositionName>Technical Management Committe</PositionName>
-      <Phone>-</Phone>
-      <Facsimile>-</Facsimile>
-      <ElectronicMailAddress>tmc@deegree.org</ElectronicMailAddress>
+      <IndividualName>Gerhard Mercator</IndividualName>
+      <PositionName>Geographer</PositionName>
+      <Phone>0123/123456</Phone>
+      <Facsimile>0123/123456</Facsimile>
+      <ElectronicMailAddress>info@deegree.org</ElectronicMailAddress>
       <Address>
-        <DeliveryPoint>-</DeliveryPoint>
-        <City>-</City>
-        <AdministrativeArea>-</AdministrativeArea>
-        <PostalCode>-</PostalCode>
-        <Country>-</Country>
+        <DeliveryPoint>9450 SW Gemini Dr #42523</DeliveryPoint>
+        <City>Beaverton</City>
+        <AdministrativeArea>OR</AdministrativeArea>
+        <PostalCode>97008</PostalCode>
+        <Country>USA</Country>
       </Address>
-      <OnlineResource>http://www.deegree.org</OnlineResource>
-      <HoursOfService>-</HoursOfService>
-      <ContactInstructions>-</ContactInstructions>
+      <OnlineResource>https://www.deegree.org</OnlineResource>
+      <HoursOfService>24x7</HoursOfService>
+      <ContactInstructions>Don't hesitate to email</ContactInstructions>
       <Role>PointOfContact</Role>
     </ServiceContact>
   </ServiceProvider>


### PR DESCRIPTION
The information was changed so it matches the information of already adjusted example templates.

This PR closes issue #1551.