### PR TITLE
Remove links to HTTP and replace them with HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>3.6.0-SNAPSHOT</version>
   <name>deegree</name>
   <description>Framework for OGC Web Service implementations and geospatial applications</description>
-  <url>http://www.deegree.org/</url>
+  <url>https://www.deegree.org</url>
 
   <scm>
     <connection>scm:git:git@github.com:deegree/deegree3.git</connection>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -8,8 +8,8 @@
   <body>
 
     <links>
-      <item name="Home" href="http://www.deegree.org/"/>
-      <item name="User Documentation" href="http://www.deegree.org/Documentation"/>
+      <item name="Home" href="https://www.deegree.org"/>
+      <item name="User Documentation" href="https://www.deegree.org/documentation/"/>
       <item name="Source Code Repository" href="https://github.com/deegree/deegree3"/>
     </links>
 


### PR DESCRIPTION
This PR covers only two instances, a lot of license headers of .java files still refer to the HTTP address.
 