### PR TITLE
Upgraded dependencies to fit with Spring Boot 3.3.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.15.1</version>
+        <version>2.16.1</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -758,7 +758,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.1.6</version>
+        <version>1.2.0</version>
         <exclusions>
           <exclusion>
             <groupId>dom4j</groupId>
@@ -1171,12 +1171,12 @@
       <dependency>
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
       </dependency>
       <dependency>
         <groupId>jakarta.xml.soap</groupId>
         <artifactId>jakarta.xml.soap-api</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
       </dependency>
       <dependency>
         <groupId>jfree</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -437,12 +437,12 @@
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -758,25 +758,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.2.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>jdom</groupId>
-            <artifactId>jdom</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>
@@ -1101,7 +1083,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.2.220</version>
+        <version>2.2.224</version>
       </dependency>
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-impl</artifactId>
-        <version>${axoim.version}</version>
+        <version>${axiom.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.codehaus.woodstox</groupId>
@@ -730,7 +730,7 @@
       <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-api</artifactId>
-        <version>${axoim.version}</version>
+        <version>${axiom.version}</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1214,7 +1214,7 @@
     <spring-batch.version>5.1.2</spring-batch.version>
     <spring-framework.version>6.1.8</spring-framework.version>
     <batik.version>1.17</batik.version>
-    <axoim.version>1.4.0</axoim.version>
+    <axiom.version>1.4.0</axiom.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.1</jsonsmart.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1209,7 +1209,7 @@
     <antlr.version>3.5.3</antlr.version>
     <oracle.version>23.4.0.24.05</oracle.version>
     <log4j.version>2.23.1</log4j.version>
-    <slf4j.version>2.0.12</slf4j.version>
+    <slf4j.version>2.0.13</slf4j.version>
     <spring-boot.version>3.3.0</spring-boot.version>
     <spring-batch.version>5.1.2</spring-batch.version>
     <spring-framework.version>6.1.8</spring-framework.version>


### PR DESCRIPTION
PR upgrades dependencies to fit with Spring Boot Version 3.3.0, see issue #1718 for more information.