### PR TITLE
Write schemaLocation with https in WMS 1.1.3 capabilities (3.5)

### DIFF
--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Capabilities130XMLAdapter.java
@@ -144,8 +144,8 @@ public class Capabilities130XMLAdapter {
 		writer.writeNamespace("sld", SLDNS);
 
 		writer.writeAttribute(XSINS, "schemaLocation",
-				"http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd "
-						+ "http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd");
+				"http://www.opengis.net/wms https://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd "
+						+ "http://www.opengis.net/sld https://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd");
 
 		metadataWriter.writeService(writer);
 


### PR DESCRIPTION
Write schemaLocation with https in WMS 1.1.3 capabilities.