### PR TITLE
Moving Spring Boot BOM into submodule deegree-tools-gml

### DIFF
--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -135,6 +135,10 @@
       <artifactId>xmlunit-matchers</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-geometry/pom.xml
+++ b/deegree-core/deegree-core-geometry/pom.xml
@@ -33,6 +33,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-style/pom.xml
+++ b/deegree-core/deegree-core-style/pom.xml
@@ -102,6 +102,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -93,6 +93,10 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>   

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -329,5 +329,9 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/PasswordFileTest.java
+++ b/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/PasswordFileTest.java
@@ -2,9 +2,11 @@ package org.deegree.console.security;
 
 import static org.deegree.console.security.LogBean.PASSWORD_FILE;
 import static org.deegree.console.security.SaltedPassword.SHA256_PREFIX;
-import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertTrue;
 

--- a/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/SaltedPasswordTest.java
+++ b/deegree-services/deegree-webservices/src/test/java/org/deegree/console/security/SaltedPasswordTest.java
@@ -7,7 +7,10 @@ import java.nio.charset.StandardCharsets;
 
 import static org.deegree.console.security.SaltedPassword.SHA256_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -82,6 +82,19 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Import dependency management from Spring Boot -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.deegree</groupId>
@@ -135,8 +148,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- spring -->

--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>2.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>3.12.4</version>
@@ -1184,14 +1190,6 @@
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
         <version>1.0.2</version>
-      </dependency>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>


### PR DESCRIPTION
 This PR moves the import of the Spring Boot BOM in the dependencyManagement section of the root POM into the submodule deegree-tools-gml. As a result several dependencies were required to be added to some sub modules.
See #1718 for more information.