### PR TITLE
[DRAFT] Added calculation of the bounding box across multiple geometry columns for PostgreSQL

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/AbstractSQLDialect.java
@@ -34,6 +34,13 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.sqldialect;
 
+import org.deegree.commons.jdbc.TableName;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
 /**
  * Implementations provide the vendor-specific behavior for a spatial DBMS so it can be
  * accessed by deegree.
@@ -42,6 +49,8 @@ package org.deegree.sqldialect;
  *
  */
 public abstract class AbstractSQLDialect implements SQLDialect {
+
+	private static final Logger LOG = getLogger(AbstractSQLDialect.class);
 
 	private char defaultEscapeChar = Character.UNASSIGNED;
 
@@ -58,6 +67,17 @@ public abstract class AbstractSQLDialect implements SQLDialect {
 	@Override
 	public boolean isRowLimitingCapable() {
 		return true;
+	}
+
+	@Override
+	public String getSelectBBox(List<String> columns, List<TableName> tables) {
+		if (columns.size() > 1 || tables.size() > 1)
+			LOG.warn("Multiple geometry columns are currently not supported. Using first.");
+		StringBuilder sql = new StringBuilder("SELECT ");
+		sql.append(getBBoxAggregateSnippet(columns.get(0)));
+		sql.append(" FROM ");
+		sql.append(tables.get(0));
+		return sql.toString();
 	}
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
@@ -139,11 +139,22 @@ public interface SQLDialect {
 	/**
 	 * Returns an SQL snippet for SELECTing the aggregate bounding box of the given
 	 * column.
-	 * @param colummn name of the column that stores the bounding box, never
+	 * @param column name of the column that stores the bounding box, never
 	 * <code>null</code>
 	 * @return SQL snippet, never <code>null</code>
 	 */
-	String getBBoxAggregateSnippet(String colummn);
+	String getBBoxAggregateSnippet(String column);
+
+	/**
+	 * Returns an SQL snippet for SELECTing the aggregate bounding box of the given
+	 * columns.
+	 * @param columns list of column names that stores the bounding box, never
+	 * <code>null</code>
+	 * @param tables list of table names that stores the bounding box, never
+	 * <code>null</code>
+	 * @return SQL snippet, never <code>null</code>
+	 */
+	String getSelectBBox(List<String> columns, List<TableName> tables);
 
 	/**
 	 * Converts the value that has been SELECTed via

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
@@ -121,7 +121,7 @@ public class MSSQLDialect extends AbstractSQLDialect implements SQLDialect {
 	}
 
 	@Override
-	public String getBBoxAggregateSnippet(String colummn) {
+	public String getBBoxAggregateSnippet(String column) {
 		return "1";
 	}
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/FeatureTypeMapping.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/FeatureTypeMapping.java
@@ -157,6 +157,24 @@ public class FeatureTypeMapping {
 	 * defined)
 	 */
 	public Pair<TableName, GeometryMapping> getDefaultGeometryMapping() {
+		List<Pair<TableName, GeometryMapping>> defaultGeometryMappings = getAllGeometryMappings();
+		if (defaultGeometryMappings.isEmpty())
+			return null;
+		return defaultGeometryMappings.get(0);
+	}
+
+	/**
+	 * Returns all {@link GeometryMapping}.
+	 * @return all geometry mappings, may be <code>empty</code> (no geometry mapping
+	 * defined) but never <code>null</code>
+	 */
+	public List<Pair<TableName, GeometryMapping>> getAllGeometryMappings() {
+		List<Pair<TableName, GeometryMapping>> defaultGeometryMappings = new ArrayList<>();
+		addGeometryMappings(defaultGeometryMappings);
+		return defaultGeometryMappings;
+	}
+
+	private void addGeometryMappings(List<Pair<TableName, GeometryMapping>> defaultGeometryMappings) {
 		TableName table = getFtTable();
 		for (Mapping particle : particles) {
 			if (particle instanceof GeometryMapping) {
@@ -164,33 +182,28 @@ public class FeatureTypeMapping {
 				if (joins != null && !joins.isEmpty()) {
 					table = joins.get(joins.size() - 1).getToTable();
 				}
-				return new Pair<TableName, GeometryMapping>(table, (GeometryMapping) particle);
+				defaultGeometryMappings.add(new Pair<>(table, (GeometryMapping) particle));
 			}
-		}
-		for (Mapping particle : particles) {
-			TableName propTable = table;
 			if (particle instanceof CompoundMapping) {
+				TableName propTable = table;
 				List<TableJoin> joins = particle.getJoinedTable();
 				if (joins != null && !joins.isEmpty()) {
 					propTable = joins.get(joins.size() - 1).getToTable();
 				}
-				Pair<TableName, GeometryMapping> gm = getDefaultGeometryMapping(propTable, (CompoundMapping) particle);
-				if (gm != null) {
-					return gm;
-				}
+				addGeometryMappings(defaultGeometryMappings, propTable, (CompoundMapping) particle);
 			}
 		}
-		return null;
 	}
 
-	private Pair<TableName, GeometryMapping> getDefaultGeometryMapping(TableName table, CompoundMapping complex) {
+	private void addGeometryMappings(List<Pair<TableName, GeometryMapping>> defaultGeometryMappings, TableName table,
+			CompoundMapping complex) {
 		for (Mapping particle : complex.getParticles()) {
 			if (particle instanceof GeometryMapping) {
 				List<TableJoin> joins = particle.getJoinedTable();
 				if (joins != null && !joins.isEmpty()) {
 					table = joins.get(joins.size() - 1).getToTable();
 				}
-				return new Pair<TableName, GeometryMapping>(table, (GeometryMapping) particle);
+				defaultGeometryMappings.add(new Pair<>(table, (GeometryMapping) particle));
 			}
 		}
 		for (Mapping particle : complex.getParticles()) {
@@ -200,13 +213,9 @@ public class FeatureTypeMapping {
 				if (joins != null && !joins.isEmpty()) {
 					propTable = joins.get(joins.size() - 1).getToTable();
 				}
-				Pair<TableName, GeometryMapping> gm = getDefaultGeometryMapping(propTable, (CompoundMapping) particle);
-				if (gm != null) {
-					return gm;
-				}
+				addGeometryMappings(defaultGeometryMappings, propTable, (CompoundMapping) particle);
 			}
 		}
-		return null;
 	}
 
 }


### PR DESCRIPTION
With this PR, the functionality of deegree was enhanced so the bounding box (BBOX) can be calculated across multiple geometry columns (PostgreSQL) when the REST API request `/deegree-webservices/config/update/bboxcache` is used. 

Prior to the change the functionality behind the mentioned REST API request would only consider the first fitting geometry column for its calculation, even if it was supposedly empty.