### PR TITLE
Enhance bbox requests without geometry property to consider all geometry properties (3.5)

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/AbstractWhereBuilder.java
@@ -668,8 +668,24 @@ public abstract class AbstractWhereBuilder {
 	 * @throws FilterEvaluationException if the filter contains invalid
 	 * {@link ValueReference}s
 	 */
-	protected abstract SQLOperation toProtoSQL(SpatialOperator op)
-			throws UnmappableException, FilterEvaluationException;
+	protected SQLOperation toProtoSQL(SpatialOperator op) throws UnmappableException, FilterEvaluationException {
+		List<SQLExpression> propNameExprs = toProtoSQLSpatial(op.getPropName());
+		checkIfExpressionsAreSpatial(propNameExprs, op.getPropName());
+
+		SQLOperationBuilder builder = new SQLOperationBuilder(BOOLEAN);
+		boolean isFirst = true;
+		for (SQLExpression propNameExpr : propNameExprs) {
+			if (!isFirst) {
+				builder.add(" OR ");
+			}
+			toProtoSql(op, propNameExpr, builder);
+			isFirst = false;
+		}
+		return builder.toOperation();
+	}
+
+	protected abstract void toProtoSql(SpatialOperator op, SQLExpression propNameExpr, SQLOperationBuilder builder)
+			throws FilterEvaluationException, UnmappableException;
 
 	/**
 	 * Translates the given {@link TemporalOperator} into an {@link SQLOperation}.
@@ -906,22 +922,25 @@ public abstract class AbstractWhereBuilder {
 	 * @throws FilterEvaluationException if the filter contains invalid
 	 * {@link ValueReference}s
 	 */
-	protected SQLExpression toProtoSQLSpatial(ValueReference propName)
+	protected List<SQLExpression> toProtoSQLSpatial(ValueReference propName)
 			throws FilterEvaluationException, UnmappableException {
-		SQLExpression sql = null;
-		PropertyNameMapping propMapping = mapper.getSpatialMapping(propName, aliasManager);
-		if (propMapping != null) {
-			propNameMappingList.add(propMapping);
-			if (propMapping instanceof ConstantPropertyNameMapping) {
-				// TODO get rid of ConstantPropertyNameMapping
-				PrimitiveType pt = new PrimitiveType(STRING);
-				PrimitiveValue value = new PrimitiveValue("" + ((ConstantPropertyNameMapping) propMapping).getValue(),
-						pt);
-				PrimitiveParticleConverter converter = new DefaultPrimitiveConverter(pt, null, false);
-				sql = new SQLArgument(value, converter);
-			}
-			else {
-				sql = new SQLColumn(propMapping.getTableAlias(), propMapping.getColumn(), propMapping.getConverter());
+		List<SQLExpression> sql = new ArrayList<>();
+		List<PropertyNameMapping> propMappings = mapper.getSpatialMappings(propName, aliasManager);
+		if (!propMappings.isEmpty()) {
+			for (PropertyNameMapping propMapping : propMappings) {
+				propNameMappingList.add(propMapping);
+				if (propMapping instanceof ConstantPropertyNameMapping) {
+					// TODO get rid of ConstantPropertyNameMapping
+					PrimitiveType pt = new PrimitiveType(STRING);
+					PrimitiveValue value = new PrimitiveValue(
+							"" + ((ConstantPropertyNameMapping) propMapping).getValue(), pt);
+					PrimitiveParticleConverter converter = new DefaultPrimitiveConverter(pt, null, false);
+					sql.add(new SQLArgument(value, converter));
+				}
+				else {
+					sql.add(new SQLColumn(propMapping.getTableAlias(), propMapping.getColumn(),
+							propMapping.getConverter()));
+				}
 			}
 		}
 		else {
@@ -1003,6 +1022,21 @@ public abstract class AbstractWhereBuilder {
 			throw new UnsupportedOperationException(msg);
 		}
 		return ((PrimitiveValue) value).getAsText();
+	}
+
+	private void checkIfExpressionsAreSpatial(List<SQLExpression> sqlExpressions, ValueReference propName)
+			throws FilterEvaluationException {
+		for (SQLExpression sqlExpression : sqlExpressions)
+			checkIfExpressionIsSpatial(sqlExpression, propName);
+	}
+
+	protected void checkIfExpressionIsSpatial(SQLExpression sqlExpression, ValueReference propName)
+			throws FilterEvaluationException {
+		if (!sqlExpression.isSpatial()) {
+			String msg = "Cannot evaluate spatial operator on database. Targeted property name '" + propName
+					+ "' does not denote a spatial column.";
+			throw new FilterEvaluationException(msg);
+		}
 	}
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/PropertyNameMapper.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/filter/PropertyNameMapper.java
@@ -37,6 +37,8 @@ package org.deegree.sqldialect.filter;
 import org.deegree.filter.FilterEvaluationException;
 import org.deegree.filter.expression.ValueReference;
 
+import java.util.List;
+
 /**
  * Implementations provide {@link ValueReference} to table/column mappings for
  * {@link AbstractWhereBuilder} implementations.
@@ -56,10 +58,10 @@ public interface PropertyNameMapper {
 	 * invalid
 	 * @throws UnmappableException
 	 */
-	public PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager)
+	PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager)
 			throws FilterEvaluationException, UnmappableException;
 
-	public PropertyNameMapping getSpatialMapping(ValueReference propName, TableAliasManager aliasManager)
+	List<PropertyNameMapping> getSpatialMappings(ValueReference propName, TableAliasManager aliasManager)
 			throws FilterEvaluationException, UnmappableException;
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilder.java
@@ -34,9 +34,6 @@
  ----------------------------------------------------------------------------*/
 package org.deegree.sqldialect.mssql;
 
-import static java.sql.Types.BOOLEAN;
-import static org.deegree.commons.tom.primitive.BaseType.DECIMAL;
-
 import org.deegree.commons.tom.primitive.PrimitiveType;
 import org.deegree.commons.tom.primitive.PrimitiveValue;
 import org.deegree.commons.tom.sql.DefaultPrimitiveConverter;
@@ -73,6 +70,9 @@ import org.deegree.sqldialect.filter.expression.SQLOperationBuilder;
 import org.deegree.sqldialect.filter.islike.IsLikeString;
 
 import java.util.List;
+
+import static java.sql.Types.BOOLEAN;
+import static org.deegree.commons.tom.primitive.BaseType.DECIMAL;
 
 /**
  * {@link AbstractWhereBuilder} implementation for Microsoft SQL Server databases.
@@ -162,17 +162,7 @@ public class MSSQLWhereBuilder extends AbstractWhereBuilder {
 	}
 
 	@Override
-	protected SQLOperation toProtoSQL(SpatialOperator op) throws UnmappableException, FilterEvaluationException {
-
-		SQLOperationBuilder builder = new SQLOperationBuilder(BOOLEAN);
-
-		SQLExpression propNameExpr = toProtoSQLSpatial(op.getPropName());
-		if (!propNameExpr.isSpatial()) {
-			String msg = "Cannot evaluate spatial operator on database. Targeted property name '" + op.getPropName()
-					+ "' does not denote a spatial column.";
-			throw new FilterEvaluationException(msg);
-		}
-
+	protected void toProtoSql(SpatialOperator op, SQLExpression propNameExpr, SQLOperationBuilder builder) {
 		ICRS storageCRS = propNameExpr.getCRS();
 		int srid = propNameExpr.getSRID() != null ? Integer.parseInt(propNameExpr.getSRID()) : 0;
 
@@ -269,7 +259,6 @@ public class MSSQLWhereBuilder extends AbstractWhereBuilder {
 				break;
 			}
 		}
-		return builder.toOperation();
 	}
 
 	private SQLExpression toProtoSQL(Geometry geom, ICRS targetCRS, int srid) {

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/test/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilderTest.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/test/java/org/deegree/sqldialect/mssql/MSSQLWhereBuilderTest.java
@@ -54,6 +54,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Tests for {@link MSSQLWhereBuilder}.
  *
@@ -70,14 +73,13 @@ public class MSSQLWhereBuilderTest {
 		PropertyNameMapper mapper = new PropertyNameMapper() {
 
 			@Override
-			public PropertyNameMapping getSpatialMapping(ValueReference propName, TableAliasManager aliasManager)
-					throws FilterEvaluationException, UnmappableException {
-				return new PropertyNameMapping(null, null, propName.getAsText(), "table");
+			public List<PropertyNameMapping> getSpatialMappings(ValueReference propName,
+					TableAliasManager aliasManager) {
+				return Collections.singletonList(new PropertyNameMapping(null, null, propName.getAsText(), "table"));
 			}
 
 			@Override
-			public PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager)
-					throws FilterEvaluationException, UnmappableException {
+			public PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager) {
 				return new PropertyNameMapping(null, null, propName.getAsText(), "table");
 			}
 		};

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleWhereBuilder.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleWhereBuilder.java
@@ -129,11 +129,7 @@ class OracleWhereBuilder extends AbstractWhereBuilder {
 	}
 
 	@Override
-	protected SQLOperation toProtoSQL(SpatialOperator op) throws UnmappableException, FilterEvaluationException {
-
-		SQLOperationBuilder builder = new SQLOperationBuilder(BOOLEAN);
-		SQLExpression propNameExpr = toProtoSQLSpatial(op.getPropName());
-
+	protected void toProtoSql(SpatialOperator op, SQLExpression propNameExpr, SQLOperationBuilder builder) {
 		switch (op.getSubType()) {
 			case BBOX:
 				BBOX bbox = (BBOX) op;
@@ -178,8 +174,6 @@ class OracleWhereBuilder extends AbstractWhereBuilder {
 				appendDWithinOperation(builder, propNameExpr, ((Beyond) op).getGeometry(), ((Beyond) op).getDistance());
 				break;
 		}
-
-		return builder.toOperation();
 	}
 
 	/**

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/H2WhereBuilder.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/H2WhereBuilder.java
@@ -55,6 +55,7 @@ import org.deegree.sqldialect.filter.expression.SQLArgument;
 import org.deegree.sqldialect.filter.expression.SQLColumn;
 import org.deegree.sqldialect.filter.expression.SQLExpression;
 import org.deegree.sqldialect.filter.expression.SQLOperation;
+import org.deegree.sqldialect.filter.expression.SQLOperationBuilder;
 
 /**
  * @author <a href="mailto:schmitz@lat-lon.de">Andreas Schmitz</a>
@@ -80,7 +81,8 @@ public class H2WhereBuilder extends AbstractWhereBuilder {
 	}
 
 	@Override
-	protected SQLOperation toProtoSQL(SpatialOperator op) throws UnmappableException, FilterEvaluationException {
+	protected void toProtoSql(SpatialOperator op, SQLExpression propNameExpr, SQLOperationBuilder builder)
+			throws UnmappableException {
 		throw new UnmappableException("Spatial operators are currently not mappable in h2.");
 	}
 

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -48,6 +48,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1669,8 +1670,7 @@ public class SQLFeatureStore implements FeatureStore {
 		final String srid = detectConfiguredSrid();
 		PropertyNameMapper mapper = new PropertyNameMapper() {
 			@Override
-			public PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager)
-					throws FilterEvaluationException, UnmappableException {
+			public PropertyNameMapping getMapping(ValueReference propName, TableAliasManager aliasManager) {
 				GeometryStorageParams geometryParams = new GeometryStorageParams(blobMapping.getCRS(), srid,
 						CoordinateDimension.DIM_2);
 				GeometryMapping bboxMapping = new GeometryMapping(null, false, new DBField(blobMapping.getBBoxColumn()),
@@ -1680,9 +1680,9 @@ public class SQLFeatureStore implements FeatureStore {
 			}
 
 			@Override
-			public PropertyNameMapping getSpatialMapping(ValueReference propName, TableAliasManager aliasManager)
-					throws FilterEvaluationException, UnmappableException {
-				return getMapping(propName, aliasManager);
+			public List<PropertyNameMapping> getSpatialMappings(ValueReference propName,
+					TableAliasManager aliasManager) {
+				return Collections.singletonList(getMapping(propName, aliasManager));
 			}
 		};
 		return dialect.getWhereBuilder(mapper, filter, null, null, allowInMemoryFiltering);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/SQLPropertyNameMapperTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/java/org/deegree/feature/persistence/sql/SQLPropertyNameMapperTest.java
@@ -34,7 +34,7 @@
 ----------------------------------------------------------------------------*/
 package org.deegree.feature.persistence.sql;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -85,9 +85,9 @@ public class SQLPropertyNameMapperTest {
 		ValueReference propName = new ValueReference("app:ftType2/app:geometry", nsContext());
 		List<FeatureTypeMapping> ftMapping = createFeatureTypeMappings(propName);
 		SQLPropertyNameMapper mapper = new SQLPropertyNameMapper(mockFeatureStore(), ftMapping, false);
-		PropertyNameMapping spatialMapping = mapper.getSpatialMapping(propName, mockAliasManager());
+		List<PropertyNameMapping> spatialMappings = mapper.getSpatialMappings(propName, mockAliasManager());
 
-		assertThat(spatialMapping, notNullValue());
+		assertThat(spatialMappings.size(), is(1));
 	}
 
 	@Test
@@ -96,9 +96,9 @@ public class SQLPropertyNameMapperTest {
 				CommonNamespaces.getNamespaceContext());
 		List<FeatureTypeMapping> ftMapping = createFeatureTypeMappings(propName);
 		SQLPropertyNameMapper mapper = new SQLPropertyNameMapper(mockFeatureStore(), ftMapping, false);
-		PropertyNameMapping spatialMapping = mapper.getSpatialMapping(propName, mockAliasManager());
+		List<PropertyNameMapping> spatialMappings = mapper.getSpatialMappings(propName, mockAliasManager());
 
-		assertThat(spatialMapping, notNullValue());
+		assertThat(spatialMappings.size(), is(1));
 	}
 
 	@Test
@@ -106,9 +106,19 @@ public class SQLPropertyNameMapperTest {
 		ValueReference propName = new ValueReference("ftType2/geometry", CommonNamespaces.getNamespaceContext());
 		List<FeatureTypeMapping> ftMapping = createFeatureTypeMappings(propName);
 		SQLPropertyNameMapper mapper = new SQLPropertyNameMapper(mockFeatureStore(), ftMapping, false);
-		PropertyNameMapping spatialMapping = mapper.getSpatialMapping(propName, mockAliasManager());
+		List<PropertyNameMapping> spatialMappings = mapper.getSpatialMappings(propName, mockAliasManager());
 
-		assertThat(spatialMapping, notNullValue());
+		assertThat(spatialMappings.size(), is(1));
+	}
+
+	@Test
+	public void testGetSpatialMapping_withNullPropName() throws Exception {
+		ValueReference propName = new ValueReference("app:ftType2/app:geometry", nsContext());
+		FeatureTypeMapping ftMapping = mockFeatureTypeMapping("ftType1", "http://www.deegree.org/app", propName);
+		SQLPropertyNameMapper mapper = new SQLPropertyNameMapper(mockFeatureStore(), ftMapping, false);
+		List<PropertyNameMapping> spatialMappings = mapper.getSpatialMappings(null, mockAliasManager());
+
+		assertThat(spatialMappings.size(), is(1));
 	}
 
 	private List<FeatureTypeMapping> createFeatureTypeMappings(ValueReference valueReference) {

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/mapping/EOPropertyNameMapper.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-ebrim-eo/src/main/java/org/deegree/metadata/persistence/ebrim/eo/mapping/EOPropertyNameMapper.java
@@ -593,9 +593,9 @@ public class EOPropertyNameMapper implements PropertyNameMapper {
 	}
 
 	@Override
-	public PropertyNameMapping getSpatialMapping(ValueReference propName, TableAliasManager aliasManager)
+	public List<PropertyNameMapping> getSpatialMappings(ValueReference propName, TableAliasManager aliasManager)
 			throws FilterEvaluationException, UnmappableException {
-		return getMapping(propName, aliasManager);
+		return Collections.singletonList(getMapping(propName, aliasManager));
 	}
 
 }

--- a/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOPropertyNameMapper.java
+++ b/deegree-datastores/deegree-mdstores/deegree-mdstore-iso/src/main/java/org/deegree/metadata/iso/persistence/ISOPropertyNameMapper.java
@@ -48,6 +48,7 @@ import static org.deegree.protocol.csw.CSWConstants.DC_NS;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -396,9 +397,9 @@ public class ISOPropertyNameMapper implements PropertyNameMapper {
 	}
 
 	@Override
-	public PropertyNameMapping getSpatialMapping(ValueReference propName, TableAliasManager aliasManager)
-			throws FilterEvaluationException, UnmappableException {
-		return getMapping(propName, aliasManager);
+	public List<PropertyNameMapping> getSpatialMappings(ValueReference propName, TableAliasManager aliasManager)
+			throws FilterEvaluationException {
+		return Collections.singletonList(getMapping(propName, aliasManager));
 	}
 
 }


### PR DESCRIPTION
This PR applies includes all available GeometryProperties of a FeatureType in a GetFeature request with bbox Parameter (without proeprty name), e.g. http://localhost:8081/deegree-webservices/services/inspirewfs_Gebaeude_3D_LoD2?service=WFS&request=GetFeature&version=2.0.0&srsName=urn:ogc:def:crs:EPSG::7423&typeNames=bu-core3d%3ABuilding&bbox=49.1,6.1,0,49.8,7.1,1000,urn:ogc:def:crs:EPSG::7423&namespaces=xmlns(bu-core3d,http%3A%2F%2Finspire.ec.europa.eu%2Fschemas%2Fbu-core3d%2F4.0)&count=1000

Prior to the change the first geometry column was considered. 