### PR TITLE
Added property with add-opens, add-exports JVM arguments

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -99,7 +99,7 @@
             <port>8080</port>
             <idleTimeout>60000</idleTimeout>
           </httpConnector>
-          <jvmArgs>--illegal-access=warn --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED</jvmArgs>
+          <jvmArgs>${jvm.args}</jvmArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/deegree-tests/pom.xml
+++ b/deegree-tests/pom.xml
@@ -46,7 +46,6 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <configuration>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopPort>${jetty.stop.port}</stopPort>
           <stopKey>STOP</stopKey>
           <stopWait>10</stopWait>
@@ -58,6 +57,7 @@
             <jetty.home>${project.basedir}/src/main/resources</jetty.home>
             <javax.xml.transform.TransformerFactory>net.sf.saxon.TransformerFactoryImpl</javax.xml.transform.TransformerFactory>
           </systemProperties>
+          <jvmArgs>${jvm.args}</jvmArgs>
           <loginServices>
             <loginService implementation="org.eclipse.jetty.security.HashLoginService">
               <name>deegree web configuration API</name>
@@ -78,7 +78,6 @@
               <goal>start</goal>
             </goals>
             <configuration>
-              <scanIntervalSeconds>0</scanIntervalSeconds>
             </configuration>
           </execution>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.3.0</version>
           <configuration>
-            <!-- Travis build workaround -->
-            <argLine>-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xms1024m -Xmx2048m --illegal-access=permit
+            <argLine>-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xms1024m -Xmx2048m
               --add-opens java.base/java.lang=ALL-UNNAMED
               --add-opens java.base/java.net=ALL-UNNAMED
               --add-opens java.base/java.util=ALL-UNNAMED
@@ -163,9 +162,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.3.0</version>
           <configuration>
-            <argLine>
-              --illegal-access=permit
-            </argLine>
+            <argLine>${jvm.args}</argLine>
           </configuration>
         </plugin>
         <!-- reporting and site -->
@@ -1215,6 +1212,7 @@
     <axiom.version>1.4.0</axiom.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.1</jsonsmart.version>
+    <jvm.args>--add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED</jvm.args>
   </properties>
 
   <modules>


### PR DESCRIPTION
This PR added property to reuse add-opens, add-export values, removed illegal-access=permit arg which was dropped with JDK 17, removed unsupported jetty plugin property