### PR TITLE
Fixed value of nilReason (3.6)

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/gml/feature/GMLFeatureWriter.java
@@ -491,7 +491,7 @@ public class GMLFeatureWriter extends AbstractGMLObjectWriter {
 		writeAttributeWithNS(XSI_NIL.getNamespaceURI(), XSI_NIL.getLocalPart(), "true");
 		PrimitiveValue value = attributes.get(NIL_REASON);
 		if (value != null)
-			writeAttributeWithNS(NIL_REASON.getNamespaceURI(), NIL_REASON.getLocalPart(), "true");
+			writeAttributeWithNS(NIL_REASON.getNamespaceURI(), NIL_REASON.getLocalPart(), value.getAsText());
 	}
 
 	private boolean excludeByTimeSliceFilter(Property property) {


### PR DESCRIPTION
nilReason was previously true:
```
<ef:operationalActivityPeriod xsi:nil="true" nilReason="true"/>
```
With the fix the value from the database is used:
```
<ef:operationalActivityPeriod xsi:nil="true" nilReason="other:unpopulated"/>
```

PR with backport for 3.5 #1744