### PR TITLE
Upgraded jetty and soapUI maven plugins to latest bugfix version

### DIFF
--- a/deegree-tests/deegree-integration-tests/pom.xml
+++ b/deegree-tests/deegree-integration-tests/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>com.smartbear.soapui</groupId>
         <artifactId>soapui-maven-plugin</artifactId>
-        <version>5.7.0</version>
+        <version>5.7.2</version>
         <dependencies>
           <dependency>
             <groupId>com.jgoodies</groupId>

--- a/deegree-tests/pom.xml
+++ b/deegree-tests/pom.xml
@@ -46,7 +46,6 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <configuration>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopPort>${jetty.stop.port}</stopPort>
           <stopKey>STOP</stopKey>
           <stopWait>10</stopWait>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>11.0.21</version>
+          <version>11.0.24</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This PR upgrades the maven plugins used for running the integration tests to their latest bugfix version:
- bumbed jetty to 11.0.24
- bumbed soapui to 5.7.2

Also removed outdated config option for jetty plugin.