### PR TITLE
Fix URL creation when header X-Forwarded-Port and X-Forwarded-Host with port are used (3.5)

### DIFF
--- a/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
+++ b/deegree-services/deegree-services-commons/src/api/java/org/deegree/services/controller/OGCFrontController.java
@@ -1594,11 +1594,12 @@ public class OGCFrontController extends HttpServlet {
         String xForwardedProto = context.getXForwardedProto();
 
         String protocol = parseProtocol( xForwardedProto, serviceUrl );
-        String port = parsePort( xForwardedPort, serviceUrl );
+        String port = parsePort( xForwardedPort, xForwardedHost, serviceUrl );
         String path = serviceUrl.getPath();
+        String host = parseHost( xForwardedHost );
 
         StringBuffer urlBuilder = new StringBuffer();
-        urlBuilder.append( protocol ).append( "://" ).append( xForwardedHost );
+        urlBuilder.append( protocol ).append( "://" ).append( host );
         if ( port != null )
             urlBuilder.append( ":" ).append( port );
         if ( path != null && !"".equals( path ) )
@@ -1613,12 +1614,19 @@ public class OGCFrontController extends HttpServlet {
             return serviceUrl.getProtocol();
     }
 
-    private static String parsePort( String xForwardedPort, URL serviceUrl ) {
+    private static String parsePort( String xForwardedPort, String xForwardedHost, URL serviceUrl ) {
         if ( xForwardedPort != null && !"".equals( xForwardedPort ) )
             return xForwardedPort;
+        else if ( xForwardedHost != null && xForwardedHost.contains( ":" ) && ( xForwardedHost.lastIndexOf( ":" ) + 1 ) < xForwardedHost.length() )
+            return xForwardedHost.substring( xForwardedHost.lastIndexOf( ":" ) + 1 );
         else if ( serviceUrl.getPort() > -1 )
             return Integer.toString( serviceUrl.getPort() );
         return null;
     }
 
+	private static String parseHost(String xForwardedHost) {
+		if ( xForwardedHost != null && xForwardedHost.contains(":") )
+			return xForwardedHost.substring( 0, xForwardedHost.indexOf(":") );
+		return xForwardedHost;
+	}
 }

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/OGCFrontControllerTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/OGCFrontControllerTest.java
@@ -136,8 +136,10 @@ public class OGCFrontControllerTest {
 		PowerMockito.when(OGCFrontController.class, "getHttpURL").thenCallRealMethod();
 		PowerMockito.when(OGCFrontController.class, "buildUrlFromForwardedHeader", eq(mockedContext), any(URL.class))
 			.thenCallRealMethod();
+		PowerMockito.when(OGCFrontController.class, "parseHost", anyString()).thenCallRealMethod();
 		PowerMockito.when(OGCFrontController.class, "parseProtocol", anyString(), any(URL.class)).thenCallRealMethod();
-		PowerMockito.when(OGCFrontController.class, "parsePort", anyString(), any(URL.class)).thenCallRealMethod();
+		PowerMockito.when(OGCFrontController.class, "parsePort", anyString(), anyString(), any(URL.class))
+			.thenCallRealMethod();
 		PowerMockito.when(OGCFrontController.getContext()).thenReturn(mockedContext);
 	}
 
@@ -161,6 +163,36 @@ public class OGCFrontControllerTest {
 		when(context.getXForwardedPort()).thenReturn(xForwardedPort);
 		when(context.getXForwardedProto()).thenReturn(xForwardedProto);
 		return context;
+	}
+
+	@Test
+	public void testGetHttpPostURLWithXForwardedHostWithPortAndXForwardedPort() throws Exception {
+		String serviceUrl = "http://myservice.de:9090/deegree-webservices/test";
+		String xForwardedHost = "xForwardedHost.de:8088";
+		String xForwardedPort = "8089";
+		String xForwardedProto = "https";
+		RequestContext mockedContext = mockContext(serviceUrl, xForwardedHost, xForwardedPort, xForwardedProto);
+
+		prepareOGCFrontController(mockedContext);
+
+		String httpPostURL = OGCFrontController.getHttpPostURL();
+
+		assertThat(httpPostURL, is("https://xForwardedHost.de:8089/deegree-webservices/test"));
+	}
+
+	@Test
+	public void testGetHttpPostURLWithXForwardedHostWithPortWithoutXForwardedPort() throws Exception {
+		String serviceUrl = "http://myservice.de:9090/deegree-webservices/test";
+		String xForwardedHost = "xForwardedHost.de:8089";
+		String xForwardedPort = null;
+		String xForwardedProto = "https";
+		RequestContext mockedContext = mockContext(serviceUrl, xForwardedHost, xForwardedPort, xForwardedProto);
+
+		prepareOGCFrontController(mockedContext);
+
+		String httpPostURL = OGCFrontController.getHttpPostURL();
+
+		assertThat(httpPostURL, is("https://xForwardedHost.de:8089/deegree-webservices/test"));
 	}
 
 }

--- a/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/OGCFrontControllerTest.java
+++ b/deegree-services/deegree-services-commons/src/test/java/org/deegree/services/controller/OGCFrontControllerTest.java
@@ -138,7 +138,7 @@ public class OGCFrontControllerTest {
 			.thenCallRealMethod();
 		PowerMockito.when(OGCFrontController.class, "parseHost", anyString()).thenCallRealMethod();
 		PowerMockito.when(OGCFrontController.class, "parseProtocol", anyString(), any(URL.class)).thenCallRealMethod();
-		PowerMockito.when(OGCFrontController.class, "parsePort", anyString(), anyString(), any(URL.class))
+		PowerMockito.when(OGCFrontController.class, "parsePort", any(), anyString(), any(URL.class))
 			.thenCallRealMethod();
 		PowerMockito.when(OGCFrontController.getContext()).thenReturn(mockedContext);
 	}


### PR DESCRIPTION
Backport of #1755
Description of #1755:

When deegree is used behind a proxy or load balancer, the initial `Host` header gets passed as `X-Forwarded-Host`.
Along the `X-Forwarded-Host` most proxies also pass the `X-Forwarded-Port` header.

As `X-Forwarded-Host`  is not strictly defined by a standard (see [1]/[2] ) it is possible that the proxy also includes the port.
This results in an exception if the WFS capabilities are requested.

Example Request to trigger this:
```bash
curl --request GET \
  --url 'https://demo.deegree.org/inspire-workspace/services?SERVICE=WFS&REQUEST=GetCapabilities' \
  --header 'Host: demo.deegree.org:443'
```

Response (shortened):
```xml
<?xml version='1.0' encoding='UTF-8'?>
<WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:ogc="http://www.opengis.net/ogc" xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
  <ows:ServiceIdentification>
    <ows:Title>INSPIRE Addresses</ows:Title>
    <ows:Abstract>Direct Access Download Service for INSPIRE Addresses</ows:Abstract>
    <ows:ServiceType codeSpace="http://www.opengeospatial.org/">WFS</ows:ServiceType>
    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
    <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
  </ows:ServiceIdentification>
  <ows:ServiceProvider>
    <!-- snip -->
  </ows:ServiceProvider>
  <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="2.0.0">
    <ows:Exception exceptionCode="NoApplicableCode"/>
  </ows:ExceptionReport>
```
 
References:
  - [1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
  - [2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
References
- #1755