### PR TITLE
Fix recognization of deprecated FeatureCollections in deegree

### DIFF
--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/schema/GMLAppSchemaReaderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/schema/GMLAppSchemaReaderTest.java
@@ -44,16 +44,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import javax.xml.namespace.QName;
 import java.util.List;
 
-import javax.xml.namespace.QName;
-
 import org.apache.xerces.impl.xs.XSAttributeDecl;
-import org.apache.xerces.xs.XSAttributeDeclaration;
 import org.apache.xerces.xs.XSAttributeUse;
 import org.apache.xerces.xs.XSComplexTypeDefinition;
 import org.apache.xerces.xs.XSElementDeclaration;
-import org.apache.xerces.xs.XSTypeDefinition;
 import org.deegree.commons.tom.gml.GMLObjectType;
 import org.deegree.commons.tom.gml.property.PropertyType;
 import org.deegree.commons.utils.test.TestProperties;
@@ -472,6 +469,46 @@ public class GMLAppSchemaReaderTest {
 			}
 		}
 		assertFalse(attrUse.getRequired());
+	}
+
+	@Test
+	public void testGml32DeprecatedFeatureCollections()
+			throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+		GMLSchemaInfoSet.setRecognizeDeprecatedTypes(true);
+		String schemaURL = this.getClass()
+			.getResource("../inspire/schema/geophysicsCore/GeophysicsCore.xsd")
+			.toString();
+		GMLAppSchemaReader adapter = new GMLAppSchemaReader(null, null, schemaURL);
+		AppSchema schema = adapter.extractAppSchema();
+		FeatureType geophProfile = schema
+			.getFeatureType(new QName("http://inspire.ec.europa.eu/schemas/ge_gp/4.0", "GeophProfile"));
+		assertTrue(geophProfile instanceof FeatureCollectionType);
+		FeatureType campaign = schema
+			.getFeatureType(new QName("http://inspire.ec.europa.eu/schemas/ge_gp/4.0", "Campaign"));
+		assertTrue(campaign instanceof FeatureCollectionType);
+
+		FeatureType gml32FeatureCollection = schema.getFeatureType(new QName(GML3_2_NS, "FeatureCollection"));
+		assertTrue(gml32FeatureCollection instanceof FeatureCollectionType);
+	}
+
+	@Test
+	public void testGml32DeprecatedFeatureCollections_recognitionDisabled()
+			throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+		GMLSchemaInfoSet.setRecognizeDeprecatedTypes(false);
+		String schemaURL = this.getClass()
+			.getResource("../inspire/schema/geophysicsCore/GeophysicsCore.xsd")
+			.toString();
+		GMLAppSchemaReader adapter = new GMLAppSchemaReader(null, null, schemaURL);
+		AppSchema schema = adapter.extractAppSchema();
+		FeatureType geophProfile = schema
+			.getFeatureType(new QName("http://inspire.ec.europa.eu/schemas/ge_gp/4.0", "GeophProfile"));
+		assertFalse(geophProfile instanceof FeatureCollectionType);
+		FeatureType campaign = schema
+			.getFeatureType(new QName("http://inspire.ec.europa.eu/schemas/ge_gp/4.0", "Campaign"));
+		assertFalse(campaign instanceof FeatureCollectionType);
+
+		FeatureType gml32FeatureCollection = schema.getFeatureType(new QName(GML3_2_NS, "FeatureCollection"));
+		assertTrue(gml32FeatureCollection instanceof FeatureCollectionType);
 	}
 
 	private void assertPropertyType(GMLObjectType geometryDecl, int propDeclIdx, QName propName, int minOccurs,

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/2.0_observation.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/2.0_observation.xsd
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+	xmlns:gml="http://www.opengis.net/gml/3.2"
+	xmlns:gmd="http://www.isotc211.org/2005/gmd"
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:om="http://www.opengis.net/om/2.0"
+	targetNamespace="http://www.opengis.net/om/2.0"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	version="2.0.0">
+	<annotation>
+		<documentation> observation.xsd 
+			
+			Observations and Measurements - XML Implementation is an OGC Standard.
+			
+			Copyright (c) [2010] Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
+		</documentation>
+	</annotation>
+	<!-- ====================================================================== -->
+	<!-- bring in other schemas -->
+	<import
+		namespace="http://www.opengis.net/gml/3.2"
+		schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<import
+		namespace="http://www.isotc211.org/2005/gmd"
+		schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- ===== Common properties of observations ====== -->
+	<!-- ====================================================================== -->
+	<group
+		name="OM_CommonProperties">
+		<annotation>
+			<documentation>Base type for Observations. Observation is an act ("event"), whose result
+				is an estimate of the value of a property of the feature of interest. The observed
+				property may be any property associated with the type of the feature of interest.
+				Concrete observation types must add a *result* property of a suitable type.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element
+				name="type"
+				type="gml:ReferenceType"
+				minOccurs="0">
+				<annotation>
+					<documentation>If present, the sub-element 'type' shall indicate the class of
+						observation. A register of type identifiers corresponding with the
+						observation types in ISO 19156, which distinguishes types on the basis of
+						the type of the result, is provided by OGC at
+						http://www.opengis.net/def/observationType/OGC-OM/2.0/ </documentation>
+				</annotation>
+			</element>
+			<element
+				name="metadata"
+				type="gmd:MD_Metadata_PropertyType"
+				minOccurs="0">
+				<annotation>
+					<documentation> If present, the association Metadata shall link the
+						OM_Observation to descriptive metadata. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="relatedObservation"
+				type="om:ObservationContextPropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> Some observations depend on other observations to provide
+						context which is important, sometimes essential, in understanding the
+						result. These dependencies are stronger than mere spatiotemporal
+						coincidences, requiring explicit representation. If present, the association
+						class ObservationContext (Figure 2) shall link a OM_Observation to another
+						OM_Observation, with the role name relatedObservation for the target.
+					</documentation>
+				</annotation>
+			</element>
+			<element
+				name="phenomenonTime"
+				type="om:TimeObjectPropertyType">
+				<annotation>
+					<documentation> The attribute phenomenonTime:TM_Object shall describe the time
+						that the result (6.2.2.9) applies to the property of the feature-of-interest
+						(6.2.2.7). This is often the time of interaction by a sampling procedure
+						(8.1.3) or observation procedure (6.2.2.10) with a real-world feature.
+					</documentation>
+				</annotation>
+			</element>
+			<element
+				name="resultTime"
+				type="gml:TimeInstantPropertyType"
+				block="#all">
+				<!-- om:resultTime is used in schematron-based validaty tests, so must not be changed -->
+				<annotation>
+					<documentation> The attribute resultTime:TM_Instant shall describe the time when
+						the result became available, typically when the procedure (6.2.2.10)
+						associated with the observation was completed For some observations this is
+						identical to the samplingTime. However, there are important cases where they
+						differ. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="validTime"
+				type="gml:TimePeriodPropertyType"
+				minOccurs="0">
+				<annotation>
+					<documentation> If present, the attribute validTime:TM_Period shall describe the
+						time period during which the result is intended to be used. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="procedure"
+				type="om:OM_ProcessPropertyType"
+				nillable="true">
+				<annotation>
+					<documentation> The association ProcessUsed shall link the OM_Observation to the
+						OM_Process (6.2.3) used to generate the result. The process has the role
+						procedure with respect to the observation. A process might be responsible
+						for more than one generatedObservation. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="parameter"
+				type="om:NamedValuePropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> If present, the attributes parameter:NamedValue shall describe
+						an arbitrary event-specific parameter. This might be an environmental
+						parameter, an instrument setting or input, or an event-specific sampling
+						parameter that is not tightly bound to either the feature-of-interest
+						(6.2.2.7) or to the observation procedure (6.2.2.10). To avoid ambiguity,
+						there shall be no more than one parameter with the same name. NOTE
+						Parameters that are tightly bound to the procedure may be recorded as part
+						of the procedure description. In some contexts the Observation::procedure
+						(6.2.2.10) is a generic or standard procedure, rather than an event-specific
+						process. In this context, parameters bound to the observation act, such as
+						instrument settings, calibrations or inputs, local position, detection
+						limits, asset identifier, operator, may augment the description of a
+						standard procedure. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="observedProperty"
+				type="gml:ReferenceType"
+				nillable="true">
+				<annotation>
+					<appinfo>
+						<gml:targetElement>xs:anyType</gml:targetElement>
+					</appinfo>
+					<documentation> The association Phenomenon shall link the OM_Observation to the
+						GFI_PropertyType (C.2.2) for which the OM_Observation:result (6.2.2.9)
+						provides an estimate of its value. The property type has the role
+						observedProperty with respect to the observation. The observed property
+						shall be a phenomenon associated with the type of the featureOfInterest.
+						NOTE An observed property may, but need not be modelled as a property (in
+						the sense of the General Feature Model) in a formal application schema that
+						defines the type of the feature of interest The observed property supports
+						semantic or thematic classification of observations, which is useful for
+						discovery and data fusion. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="featureOfInterest"
+				type="gml:FeaturePropertyType"
+				nillable="true">
+				<annotation>
+					<documentation> The association Domain shall link the OM_Observation to the
+						GFI_Feature (C.2.1) that is the subject of the observation and carries the
+						observed property. This feature has the role featureOfInterest with respect
+						to the observation. This feature is the real-world object whose properties
+						are under observation, or is a feature intended to sample the real-world
+						object, as described in Clause 8 of this International Standard. An
+						observation instance serves as a propertyValueProvider for its feature of
+						interest. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="resultQuality"
+				type="gmd:DQ_Element_PropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> If present, the attributes resultQuality:DQ_Element shall
+						describe the quality of the result (6.2.2.9). This instance-specific
+						description complements the description of the observation procedure
+						(6.2.2.10), which provides information concerning the quality of all
+						observations using this procedure. Quality of a result may be assessed
+						following the procedures in ISO 19114:2003. Multiple measures may be
+						provided (ISO/TS 19138:2006). </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</group>
+	<!-- ====================================================================== -->
+	<!-- ===== Generic Observation result ======= -->
+	<!-- ===== global element in order to support restriction across namespace boundaries ======= -->
+	<!-- ====================================================================== -->
+	<element
+		name="result">
+		<annotation>
+			<documentation> The association Range shall link the OM_Observation to the value
+				generated by the procedure. The value has the role result with respect to the
+				observation. The type of the result is shown as Any, since it may represent the
+				value of any feature property. NOTE 1 OGC SWE Common provides a model suitable for
+				describing many kinds of observation results. The type of the observation result
+				shall be consistent with the observed property, and the scale or scope for the value
+				shall be consistent with the quantity or category type. If the observed property
+				(6.2.2.8) is a spatial operation or function, the type of the result may be a
+				coverage, NOTE 2 In some contexts, particularly in earth and environmental sciences,
+				the term “observation” is used to refer to the result itself. </documentation>
+		</annotation>
+	</element>
+	<!-- ====================================================================== -->
+	<!-- ===== Generic Observation ======= -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="OM_ObservationType">
+		<annotation>
+			<documentation> Generic observation, whose result is anyType The following properties
+				are inherited from AbstractFeatureType: <!--	from AbstractGMLType
+					<element ref="gml:metaDataProperty" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="gml:description" minOccurs="0"/>
+					<element ref="gml:name" minOccurs="0" maxOccurs="unbounded"/> -->
+				<!--    from AbstractFeatureType
+				<element ref="gml:boundedBy" minOccurs="0"/> -->
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension
+				base="gml:AbstractFeatureType">
+				<sequence>
+					<group
+						ref="om:OM_CommonProperties"/>
+					<element
+						ref="om:result"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- ......................... -->
+	<element
+		name="OM_Observation"
+		type="om:OM_ObservationType"
+		substitutionGroup="gml:AbstractFeature">
+		<annotation>
+			<documentation>Observation is an act ("event"), whose result is an estimate of the value
+				of a property of the feature of interest. The observed property may be any property
+				associated with the type of the feature of interest.</documentation>
+		</annotation>
+	</element>
+	<!-- ...................... -->
+	<complexType
+		name="OM_ObservationPropertyType">
+		<sequence
+			minOccurs="0">
+			<element
+				ref="om:OM_Observation"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ===== Observation Context  ======= -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="ObservationContextType">
+		<annotation>
+			<documentation> Some observations depend on other observations to provide context which
+				is important, sometimes essential, in understanding the result. These dependencies
+				are stronger than mere spatiotemporal coincidences, requiring explicit
+				representation. If present, the association class ObservationContext (Figure 2)
+				shall link a OM_Observation to another OM_Observation, with the role name
+				relatedObservation for the target. </documentation>
+		</annotation>
+		<sequence>
+			<element
+				name="role"
+				type="gml:ReferenceType">
+				<annotation>
+					<documentation>The attribute 'role' shall describe the relationship of the
+						target OM_Observation to the source OM_Observation. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="relatedObservation"
+				type="gml:ReferenceType">
+				<annotation>
+					<appinfo>
+						<gml:targetElement>om:OM_Observation</gml:targetElement>
+					</appinfo>
+					<documentation> Some observations depend on other observations to provide
+						context which is important, sometimes essential, in understanding the
+						result. These dependencies are stronger than mere spatiotemporal
+						coincidences, requiring explicit representation. If present, the association
+						class ObservationContext (Figure 2) shall link a OM_Observation to another
+						OM_Observation, with the role name relatedObservation for the target.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- ......................... -->
+	<element
+		name="ObservationContext"
+		type="om:ObservationContextType">
+		<annotation>
+			<documentation> Some observations depend on other observations to provide context which
+				is important, sometimes essential, in understanding the result. These dependencies
+				are stronger than mere spatiotemporal coincidences, requiring explicit
+				representation. If present, the association class ObservationContext (Figure 2)
+				shall link a OM_Observation to another OM_Observation, with the role name
+				relatedObservation for the target. </documentation>
+		</annotation>
+	</element>
+	<!-- ...................... -->
+	<complexType
+		name="ObservationContextPropertyType">
+		<annotation>
+			<documentation>ObservationContext is a dataType, without identity, so may only be used
+				inline</documentation>
+		</annotation>
+		<sequence>
+			<element
+				ref="om:ObservationContext"/>
+		</sequence>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ===== Observation process  ======= -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="OM_ProcessPropertyType">
+		<annotation>
+			<documentation> The purpose of an observation process is to generate an observation
+				result. An instance is often an instrument or sensor, but may be a human observer, a
+				simulator, or a process or algorithm applied to more primitive results used as
+				inputs. The model for OM_Process is abstract, and has no attributes, operations, or
+				associations. NOTE ISO 19115-2:2008 provides MI_Instrument, LE_Processing and
+				LE_Algorithm, which could all be modelled as specializations of OM_Process. Any
+				suitable XML may be used to describe the observation process in line, provided that
+				it is contained in a single XML element. If reference to a schema is provided it
+				must also be valid. OGC SensorML provides a model which is suitable for many
+				observation procedures. </documentation>
+		</annotation>
+		<sequence
+			minOccurs="0">
+			<any
+				namespace="##any"
+				processContents="lax">
+				<annotation>
+					<documentation> Any suitable XML may be used to describe the observation process
+						in line, provided that it is contained in a single XML element. If refernece
+						to a schema is provided it must also be valid. </documentation>
+				</annotation>
+			</any>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ===== Named Value  ======= -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="NamedValueType">
+		<annotation>
+			<documentation> The class 'NamedValue' provides for a generic soft-typed parameter
+				value. NamedValue shall support two attributes. </documentation>
+		</annotation>
+		<sequence>
+			<element
+				name="name"
+				type="gml:ReferenceType">
+				<annotation>
+					<documentation> The attribute 'name' shall indicate the meaning of the named
+						value. Its value should be taken from a well-governed source if possible.
+					</documentation>
+				</annotation>
+			</element>
+			<element
+				name="value">
+				<annotation>
+					<documentation> The attribute 'value' shall provide the value. The type Any
+						should be substituted by a suitable concrete type, such as
+						CI_ResponsibleParty or Measure. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- ......................... -->
+	<element
+		name="NamedValue"
+		type="om:NamedValueType">
+		<annotation>
+			<documentation> The class 'NamedValue' provides for a generic soft-typed parameter
+				value. NamedValue shall support two attributes. </documentation>
+		</annotation>
+	</element>
+	<!-- ...................... -->
+	<complexType
+		name="NamedValuePropertyType">
+		<annotation>
+			<documentation> The class 'NamedValue' provides for a generic soft-typed parameter
+				value. NamedValue shall support two attributes. </documentation>
+		</annotation>
+		<sequence
+			minOccurs="0">
+			<element
+				ref="om:NamedValue"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ===== TimeObjectProperty  ======= -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="TimeObjectPropertyType">
+		<annotation>
+			<documentation>This property type is not provided directly by GML</documentation>
+		</annotation>
+		<sequence
+			minOccurs="0">
+			<element
+				ref="gml:AbstractTimeObject"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/Addresses.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/Addresses.xsd
@@ -1,0 +1,1014 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ad="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:au="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:bu-base="http://inspire.ec.europa.eu/schemas/bu-base/4.0" xmlns:cp="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" targetNamespace="http://inspire.ec.europa.eu/schemas/ad/4.0" elementFormDefault="qualified" version="4.1">
+	<annotation>
+		<documentation>Application schema for Addresses</documentation>
+	</annotation>
+	<import namespace="http://inspire.ec.europa.eu/schemas/au/4.0" schemaLocation="AdministrativeUnits.xsd"/>
+	<import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+	<import namespace="http://inspire.ec.europa.eu/schemas/bu-base/4.0" schemaLocation="BuildingsBase.xsd"/>
+	<import namespace="http://inspire.ec.europa.eu/schemas/cp/4.0" schemaLocation="CadastralParcels.xsd"/>
+	<import namespace="http://inspire.ec.europa.eu/schemas/gn/4.0" schemaLocation="GeographicalNames.xsd"/>
+	<import namespace="http://inspire.ec.europa.eu/schemas/tn/4.0" schemaLocation="CommonTransportElements.xsd"/>
+	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<!-- v4.1 of this schema released in INSPIRE schema release v.2024.1.
+       Change performed: Changed the datatype for the "building" association of the Address feature type. - non-breaking change - Amendment 1089/2010
+       See https://github.com/INSPIRE-MIF/application-schemas/releases/tag/2024.1 -->
+	<element name="Address" type="ad:AddressType" substitutionGroup="gml:AbstractFeature">
+		<annotation>
+			<documentation>-- Definition --
+An identification of the fixed location of property by means of a structured composition of geographic names and identifiers.
+
+-- Description --
+NOTE 1 The spatial object, referenced by the address, is defined as the "addressable object". The addressable object is not within the application schema, but it is possible to represent the address' reference to a cadastral parcel or a building through associations. It should, however, be noted that in different countries and regions, different traditions and/or regulations determine which object types should be regarded as addressable objects. 
+
+NOTE 2 In most situations the addressable objects are current, real world objects. However, addresses may also reference objects which are planned, under construction or even historical.
+
+NOTE 3 Apart from the identification of the addressable objects (like e.g. buildings), addresses are very often used by a large number of other applications to identify object types e.g. statistics of the citizens living in the building, for taxation of the business entities that occupy the building, and the utility installations. 
+
+NOTE 4 For different purposes, the identification of an address can be represented in different ways (see example 3). 
+
+EXAMPLE 1 A property can e.g., be a plot of land, building, part of building, way of access or other construction,
+
+EXAMPLE 2 In the Netherlands the primary addressable objects are buildings and dwellings which may include parts of buildings, mooring places or places for the permanent placement of trailers (mobile homes), in the UK it is the lowest level of unit for the delivery of services, in the Czech Republic it is buildings and entrance doors. 
+
+EXAMPLE 3 Addresses can be represented differently. In a human readable form an address in Spain and an address in Denmark could be represented like this: "Calle Mayor, 13, Cortijo del Marqués, 41037 Écija, Sevilla, España" or "Wildersgade 60A, st. th, 1408 Copenhagen K., Denmark".</documentation>
+		</annotation>
+	</element>
+	<complexType name="AddressType">
+		<complexContent>
+			<extension base="gml:AbstractFeatureType">
+				<sequence>
+					<element name="inspireId" type="base:IdentifierPropertyType">
+						<annotation>
+							<documentation>-- Definition --
+External object identifier of the address.
+
+-- Description --
+NOTE 1 An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the addressable object. 
+
+NOTE 2 The primary purpose of this identifier is to enable links between various sources and the address components.
+
+EXAMPLE An address spatial object from Denmark could carry this identifier: 
+Namespace: DK_ADR
+Local identifier: 0A3F507B2AB032B8E0440003BA298018
+Version identifier: 12-02-2008T10:05:01+01:00</documentation>
+						</annotation>
+					</element>
+					<element name="alternativeIdentifier" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+External, thematic identifier of the address spatial object, which enables interoperability with existing legacy systems or applications. 
+
+-- Description --
+NOTE 1 Compared with the proper identifier of the address, the alternative identifier is not necessarily persistent in the lifetime of the address spatial object. Likewise it is usually not globally unique and in general does not include information on the version of the address spatial object. 
+
+NOTE 2 Often alternative address identifiers are composed by a set of codes that, e.g., identify the region and the municipality, the thoroughfare name and the address number. These alternative identifiers will not remain persistent e.g. in the case of the merging of two municipalities. 
+
+EXAMPLE In Denmark many legacy systems (e.g. in the Statistics Denmark or the Central Business Register) uses as address identification the three digit municipality code plus the four character street name code plus the address number.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="string">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="position" type="ad:GeographicPositionPropertyType" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Position of a characteristic point which represents the location of the address according to a certain specification, including information on the origin of the position.</documentation>
+						</annotation>
+					</element>
+					<element name="status" type="gml:ReferenceType" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+Validity of the address within the life-cycle (version) of the address spatial object. 
+
+-- Description --
+NOTE This status relates to the address and is not a property of the object to which the address is assigned (the addressable object).</documentation>
+						</annotation>
+					</element>
+					<element name="locator" type="ad:AddressLocatorPropertyType" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Human readable designator or name.</documentation>
+						</annotation>
+					</element>
+					<element name="validFrom" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Date and time of which this version of the address was or will be valid in the real world. 
+
+-- Description --
+NOTE This date and time can be set in the future for situations where an address or a version of an address has been decided by the appropriate authority to take effect for a future date.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="validTo" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+Date and time at which this version of the address ceased or will cease to exist in the real world.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="beginLifespanVersion" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.
+
+-- Description --
+NOTE This date is recorded to enable the generation of change only update files.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="endLifespanVersion" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.
+
+-- Description --
+NOTE This date is recorded primarily for those systems which "close" an entry in the spatial data set in the event of an attribute change.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="parcel" type="gml:ReferenceType" nillable="true" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Cadastral parcel that this address is assigned to or associated with.  
+
+-- Description --
+NOTE An address could potentially have an association to zero, one or several cadastral parcels. Also it is possible (but this is not expressed in this application schema) that several addresses are associated to a single cadastral parcel.
+
+EXAMPLE In the street "Wildersgade" in Copenhagen, Denmark, the address designated as "Wildersgade 66, 1408 København K" is associated to the cadastral parcel identifier "81" in the district of "Christianshavn".</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">cp:CadastralParcel</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+					<element name="parentAddress" type="gml:ReferenceType" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+The main (parent) address with which this (sub) address is tightly connected.
+
+-- Description --
+NOTE 1 The relationship between a set of subaddresses and the main address most often means that the sub addresses use the same locator and address components (for example , thoroughfare name, address area, post code) as the parent address. For each sub address additional address locators are then included for identification, like e.g. flat number, floor identifier, door number. 
+
+NOTE 2 In some countries several levels of parent-, sub- and sub-sub-addresses exist. In other countries the concept of parent addresses does not exist; all addresses are thus of the same level. 
+
+EXAMPLE 1 In a Spanish city the address "Calle Gran Vía 8" is a parent address where the locator "8" represents the building. In the building, the sub address "Calle Gran Via 8, door 3" represents a sub-address, while the more detailed sub-sub address "Calle Gran Via 8, door 3, staircase A, floor 5, dwelling 1" represents the address of a specific dwelling. 
+
+EXAMPLE 2 In Denmark the legislation on addresses define two types of addresses: the parent "access level" and the sub "unit level". In the city of Copenhagen "Wildersgade 60A" is a parent access address that represents a specific entrance to a building. Inside the entrance, subaddresses using floor and door designators identifies the individual dwellings like e.g. "Wildersgade 60A, 1st floor, left door". 
+
+EXAMPLE 3 In The Netherlands only one level of addresses exists.</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">ad:Address</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+					<element name="building" type="bu-base:BuildingPropertyType" nillable="true" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Name --
+building
+
+-- Definition --
+Building that the address is assigned to or associated with. 
+
+-- Description --
+NOTE An address could potentially have an association to zero, one or several buildings. Also it is possible (but this is not expressed in this application schema) that several addresses are associated to a single building.
+
+EXAMPLE In Praha, The Czech Republic, the address designated "NaPankráci 1690/125" is associated to a specific building in the street, in this case the building with number 1690 in the district   (cz: cast obce) "Nusle".</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">bu-base:BuildingPropertyType</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+					<element name="component" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Represents that the address component is engaged as a part of the address.
+
+-- Description --
+EXAMPLE For the address designated "Calle Mayor 13, Cortijo del Marqués, 41037, Écija, Sevilla, España" the six address components "Calle Mayor", "Cortijo del Marqués", "41037", "Écija", "Sevilla" and "España" are engaged as address components.</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">ad:AddressComponent</targetElement>
+							</appinfo>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence/>
+									<attributeGroup ref="gml:AssociationAttributeGroup"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AddressPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ad:Address"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="AddressAreaName" type="ad:AddressAreaNameType" substitutionGroup="ad:AddressComponent">
+		<annotation>
+			<documentation>-- Definition --
+An address component which represents the name of a geographic area or locality that groups a number of addressable objects for addressing purposes, without being an administrative unit.
+
+-- Description --
+NOTE 1 In some countries and regions an address area is a true subdivision of an administrative unit (most often a municipality), so that every address area is fully inside the municipality and so that every part of the municipality is within an address area. In other countries, the concept of address area names is less strict and based on local tradition or specific needs. 
+
+NOTE 2 In some situations an address area name is not required to obtain unambiguousness; instead the purpose is to make the complete address more informative and descriptive, adding a well known place name (e.g. of a village or community) to the address. This is particularly useful if the municipality or post code covers a large area. 
+
+EXAMPLE 1 In Sweden a "Kommundel" (en: Municipal sub division) is a type of address area names that ensures that street names are unique within the sub division. 
+
+EXAMPLE 2 In Spain an "Entidad de población" (en: population entity) has the same function. It is the general address area which depending on its characteristics can be classified as "Entidad Singular" (en: singular entity) or "Entidad Colectiva" (en: collective entity). Moreover, according to the population distribution, these areas can contain one or several "Núcleo de población" (en: population core) and/or "Población diseminada" (en: scattered population).
+
+EXAMPLE 3 In Denmark "Supplerende bynavn" (en: Supplementary town name) is sometimes compulsory to ensure uniqueness of street names within the post code, sometimes it is just useful extra information, that makes the address more informative.</documentation>
+		</annotation>
+	</element>
+	<complexType name="AddressAreaNameType">
+		<complexContent>
+			<extension base="ad:AddressComponentType">
+				<sequence>
+					<element name="name" type="gn:GeographicalNamePropertyType" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Proper noun applied to the address area. 
+
+-- Description --
+NOTE The data type allows names in different languages and scripts as well as inclusion of alternative name, alternative spellings, historical name and exonyms.</documentation>
+						</annotation>
+					</element>
+					<element name="namedPlace" type="gml:ReferenceType" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+The named place that this address area name represents.  
+
+-- Description --
+NOTE In order to populate this association, it is important that the area covered by the identified Named Place is exactly the same as the area covered by the address area name in question; if this is not the case the association would result in an inconsistency.
+
+EXAMPLE The geographical name "Huskvarna", which represents a part of the municipality of Jönköping in Sweden, is the source of the address area name, "Huskvarna".</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">gn:NamedPlace</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AddressAreaNamePropertyType">
+		<sequence minOccurs="0">
+			<element ref="ad:AddressAreaName"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="AddressComponent" type="ad:AddressComponentType" abstract="true" substitutionGroup="gml:AbstractFeature">
+		<annotation>
+			<documentation>-- Definition --
+Identifier or geographic name of a specific geographic area, location, or other spatial object which defines the scope of an address.
+
+-- Description --
+NOTE 1 Four different subclasses of address components are defined: 
+o    Administrative unit name, which may include name of country, name of municipality, name of district
+o    Address area name like e.g. name of village or settlement 
+o    Thoroughfare name, most often road name  
+o    Postal descriptor 
+In order to construct an address, these subclasses are often structured hierarchically.
+
+NOTE 2 It is the combination of the address locator and the address components, which makes a specific address spatial object readable and unambiguous for the human user. 
+
+EXAMPLE The combination of the locator "13" and the address components "Calle Mayor" (thoroughfare name), "Cortijo del Marqués" (address area name), "41037" (postal descriptor), "Écija", "Sevilla" and "España" (administrative unit names) makes this specific address spatial object readable and unambiguous.</documentation>
+		</annotation>
+	</element>
+	<complexType name="AddressComponentType" abstract="true">
+		<complexContent>
+			<extension base="gml:AbstractFeatureType">
+				<sequence>
+					<element name="inspireId" type="base:IdentifierPropertyType" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+External object identifier of the address component.
+
+-- Description --
+NOTE 1 An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon. 
+
+NOTE 2 The primary purpose of this identifier is to enable links between various sources and the address components.
+
+EXAMPLE An address component spatial object from Denmark could carry this identifier: 
+Namespace: DK_ADR
+Local identifier: 0A3F507B2AB032B8E0440003BA298018
+Version identifier: 12-02-2008T10:05:01+01:00</documentation>
+						</annotation>
+					</element>
+					<element name="alternativeIdentifier" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+External, thematic identifier of the address component spatial object, which enables interoperability with existing legacy systems or applications. 
+
+-- Description --
+NOTE Compared with a proper identifier of the address component, the alternative identifier is not necessarily persistent in the lifetime of the component spatial object. Likewise it is usually not globally unique and in general does include information on the version of the spatial object. 
+
+EXAMPLE 1 National or regional sector-specific identifiers (like e.g. a number- or letter code) for administrative units, address areas (localities, villages, sub-divisions) or thoroughfare names, which are used by a number of existing legacy systems. 
+
+EXAMPLE 2 In Denmark the four character municipal "road name code" (0001-9899) is only unique within the present municipality, thus if two municipalities merge, it is necessary to assign new road name codes.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="string">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="beginLifespanVersion" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set. 
+
+-- Description --
+NOTE This date is recorded to enable the generation of change only update files.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="endLifespanVersion" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.
+
+-- Description --
+NOTE This date is recorded primarily for those systems which "close" an entry in the spatial data set in the event of an attribute change.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="status" type="gml:ReferenceType" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+Validity of the address component within the life-cycle (version) of the address component spatial object. 
+
+-- Description --
+NOTE This status relates to the address component and is not a property of the object to which the address is assigned (the addressable object).</documentation>
+						</annotation>
+					</element>
+					<element name="validFrom" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Date and time of which this version of the address component was or will be valid in the real world. 
+
+-- Description --
+NOTE This date and time can be set in the future for situations where an address component or a version of an address component has been decided by the appropriate authority to take effect for a future date.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="validTo" nillable="true" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+Date and time at which the address component ceased or will cease to exist in the real world.</documentation>
+						</annotation>
+						<complexType>
+							<simpleContent>
+								<extension base="dateTime">
+									<attribute name="nilReason" type="gml:NilReasonType"/>
+								</extension>
+							</simpleContent>
+						</complexType>
+					</element>
+					<element name="situatedWithin" type="gml:ReferenceType" nillable="true" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Another address component within which the geographic feature represented by this address component is situated.
+
+-- Description --
+NOTE 1 The association enables the application schema to express that the subtypes of address components in the dataset form a hierarchy e.g. like: thoroughfare name within municipality within region within country 
+
+NOTE 2 The representation of the hierarchy facilitates queries e.g. for a specific thoroughfare name within a given municipality or postcode. It is also necessary where the application schema is used to create or update, for example , a gazetteer which is based on the hierarchical structure of the address components. 
+
+NOTE 3 The multiplicity of the association allows it to express that a thoroughfare name is situated in a certain municipality and in a certain postcode. It is also possible to express, for example, that some thoroughfare names cross borders between municipalities and thus is situated within more than one municipality.
+
+EXAMPLE 1 In Spain many spatial objects of the thoroughfare name "Calle Santiago" exist. The association can express that one of the spatial objects is situated within in the municipality of Albacete. From the same example the municipality name "Albacete" is situated within the administrative name (region) of "Castilla La Mancha".
+
+EXAMPLE 2 In Denmark, several address area names entitled "Strandby" exists. In order to identify a specific spatial object it is necessary to know that the relevant spatial object is situated e.g. in the municipality of "Frederikshavn".</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">ad:AddressComponent</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AddressComponentPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ad:AddressComponent"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="AddressLocator" type="ad:AddressLocatorType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+Human readable designator or name that allows a user or application to reference and distinguish the address from neighbour addresses, within the scope of a thoroughfare name, address area name, administrative unit name or postal designator, in which the address is situated.
+
+-- Description --
+NOTE 1 The most common locators are designators like an address number, building number or flat identifier as well as the name of the property, complex or building.
+
+NOTE 2 The locator identifier(s) are most often only unambiguous and meaningful within the scope of the adjacent thoroughfare name, address area name or post code. 
+
+NOTE 3 The locator could be composed of one or more designators e.g., address number, address number suffix, building number or name, floor number, flat or room identifier. In addition to these common locator types, also narrative or descriptive locators are possible.
+
+NOTE 4 The locators of an address could be composed as a hierarchy, where one level of locators identifies the real property or building while another level of locators identifies the flats or dwellings inside the property. 
+
+EXAMPLE 1 In a Spanish city a "site-level" locator could identify a building on the thoroughfare name "Calle Gran Vía using the address number "8". If the building has four entrance doors, the door number "3" could be the "access-level" locator. The 3rd door could, via two staircases "A" and "B", give access to a number of floors, identified by a number "1" to "5" on which a number of dwellings are situated, also identified by numbers "1" to "3"; The "unit level" locator will thus composed of staircase-, floor- and dwelling identification e.g. "staircase A, floor 5, dwelling 1". In total, the three parent-child levels of locators uniquely identify the dwelling. 
+
+EXAMPLE 2 In Copenhagen an "access level" locator could identify a specific entrance door in a building on the thoroughfare name "Wildersgade" using the address number "60A" (In Denmark the optional suffix is a part of the address number). The entrance door gives access to a number of floors, e.g, "st", "1", "2", "3", on which two dwellings are situated "tv" and "th". The "unit level" locator will thus be composed by a floor- and a door identifier: "2. th." (2nd floor, door to the right). In total, the two parent-child levels of locators uniquely identify the dwelling. 
+
+EXAMPLE 3 In The Netherlands only one level of locators exists. The individual apartment within a large complex, a dwelling, a part of other kinds of buildings (for example an office), a mooring place or a place for the permanent placing of trailers are addressable objects which must have an address. This address is the only level of the locator. This locator could be composed by three attributes the house number, plus optionally an additional house letter, plus optionally an additional housenumber suffix.
+
+EXAMPLE 4 Sometimes the building name is an alternative identifier to the address number e.g. the house located in "Calle Santiago, 15, Elizondo-Baztán, Navarra, Spain" is also identified by the building name "Urtekoetxea"</documentation>
+		</annotation>
+	</element>
+	<complexType name="AddressLocatorType">
+		<sequence>
+			<element name="designator" type="ad:LocatorDesignatorPropertyType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+A number or a sequence of characters that uniquely identifies the locator within the relevant scope(s).</documentation>
+				</annotation>
+			</element>
+			<element name="name" type="ad:LocatorNamePropertyType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+A geographic name or descriptive text associated to a property identified by the locator.
+
+-- Description --
+NOTE 1 The locator name could be the name of the property or complex (e.g. an estate, hospital or a shopping mall), of the building or part of the building (e.g. a wing), or it could be the name of a room inside the building.
+
+NOTE 2 As locator name it is also possible to use a description that allows a user to identify the property in question. 
+
+NOTE 3 The locator name could be an alternative addition to the locator designator (e.g. the address number) or it could be an independent identifier. 
+
+EXAMPLE In the address "Calle Santiago, 15, Elizondo-Baztán, Navarra, Spain" the building name "Urtekoetxea" is an alternative to the building identifier "3".</documentation>
+				</annotation>
+			</element>
+			<element name="level" type="gml:ReferenceType">
+				<annotation>
+					<documentation>-- Definition --
+The level to which the locator refers.</documentation>
+				</annotation>
+			</element>
+			<element name="withinScopeOf" type="gml:ReferenceType" nillable="true" minOccurs="0">
+				<annotation>
+					<documentation>-- Definition --
+The address component that defines the scope within which the address locator is assigned according to rules ensuring unambiguousness. 
+
+-- Description --
+NOTE 1 For the assignment of unambiguous locators (e.g. address numbers) different rules exists in different countries and regions. According to the most common rule, an address number should be unique within the scope of the thoroughfare name. In other areas the address number is unique inside an address area name (e.g. the name of the village) or postal designator (e.g. the post code). In some areas even a combination of rules are applied: e.g. addresses with two locators, each of them referencing to a separate address component. 
+
+NOTE 2 Locators that has the level of unit (like e.g. floor identifier and door or unit identifiers) are most often assigned so that they are unambiguous within the more narrow scope of the property or building; for these locators the association should therefore not be populated. 
+
+EXAMPLE 1 In a typical European address dataset, parts of the addresses have locators which are unambiguous within the scope of the road name (thoroughfare name) while others are unambiguous within the name ogf the village or district (address area name). 
+
+EXAMPLE 2 In Lithuania and Estonia a concept of "corner addresses" exists. Corner addresses have two address numbers (designators) each of them referring to a thoroughfare name (primary and secondary street name). E.g. in Vilnius the address designated "A. Stulginskio gatve 4 / A. Smetonos gatve 7" is situated on the corner of the two streets. 
+
+EXAMPLE 3 In the Czech Republic in some cities an address has two locator designators: A building number which referres to the address area (district, cz: "cast obce") and a address number that referres to the thoroughfare name. As an example in Praha for address designated "Na Pankráci 1690/125, Nusle" the designator "1690" is a building number unique within the address area (cz cast obce) "Nusle", while the "125" is an address number that has the thoroughfare name as its scope.</documentation>
+					<appinfo>
+						<targetElement xmlns="http://www.opengis.net/gml/3.2">ad:AddressComponent</targetElement>
+					</appinfo>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="AddressLocatorPropertyType">
+		<sequence>
+			<element ref="ad:AddressLocator"/>
+		</sequence>
+	</complexType>
+	<element name="AddressRepresentation" type="ad:AddressRepresentationType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+Representation of an address spatial object for use in external application schemas that need to include the basic, address information in a readable way.
+
+-- Description --
+NOTE 1 The data type includes the all necessary readable address components as well as the address locator(s), which allows the identification of the address spatial objects, e.g., country, region, municipality, address area, post code, street name and address number. It also includes an optional reference to the full address spatial object. 
+
+NOTE 2 The datatype could be used in application schemas that wish to include address information e.g. in a dataset that registers buildings or properties.</documentation>
+		</annotation>
+	</element>
+	<complexType name="AddressRepresentationType">
+		<sequence>
+			<element name="adminUnit" type="gn:GeographicalNamePropertyType" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+The name or names of a unit of administration where a Member State has and/or exercises jurisdictional rights, for local, regional and national governance.</documentation>
+				</annotation>
+			</element>
+			<element name="locatorDesignator" type="string" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+A number or a sequence of characters which allows a user or an application to interpret, parse and format the locator within the relevant scope. A locator may include more locator designators.</documentation>
+				</annotation>
+			</element>
+			<element name="locatorName" type="gn:GeographicalNamePropertyType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+Proper noun(s) applied to the real world entity identified by the locator.</documentation>
+				</annotation>
+			</element>
+			<element name="addressArea" nillable="true" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+The name or names of a geographic area or locality that groups a number of addressable objects for addressing purposes, without being an administrative unit.</documentation>
+				</annotation>
+				<complexType>
+					<sequence>
+						<element ref="gn:GeographicalName"/>
+					</sequence>
+					<attribute name="nilReason" type="gml:NilReasonType"/>
+				</complexType>
+			</element>
+			<element name="postName" nillable="true" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+One or more names created and maintained for postal purposes to identify a subdivision of addresses and postal delivery points.</documentation>
+				</annotation>
+				<complexType>
+					<sequence>
+						<element ref="gn:GeographicalName"/>
+					</sequence>
+					<attribute name="nilReason" type="gml:NilReasonType"/>
+				</complexType>
+			</element>
+			<element name="postCode" nillable="true" minOccurs="0">
+				<annotation>
+					<documentation>-- Definition --
+A code created and maintained for postal purposes to identify a subdivision of addresses and postal delivery points.</documentation>
+				</annotation>
+				<complexType>
+					<simpleContent>
+						<extension base="string">
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</extension>
+					</simpleContent>
+				</complexType>
+			</element>
+			<element name="thoroughfare" nillable="true" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+The name or names of a passage or way through from one location to another like a road or a waterway.</documentation>
+				</annotation>
+				<complexType>
+					<sequence>
+						<element ref="gn:GeographicalName"/>
+					</sequence>
+					<attribute name="nilReason" type="gml:NilReasonType"/>
+				</complexType>
+			</element>
+			<element name="addressFeature" type="gml:ReferenceType" nillable="true" minOccurs="0">
+				<annotation>
+					<documentation>-- Definition --
+Reference to the address spatial object.</documentation>
+					<appinfo>
+						<targetElement xmlns="http://www.opengis.net/gml/3.2">ad:Address</targetElement>
+					</appinfo>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="AddressRepresentationPropertyType">
+		<sequence>
+			<element ref="ad:AddressRepresentation"/>
+		</sequence>
+	</complexType>
+	<element name="AdminUnitName" type="ad:AdminUnitNameType" substitutionGroup="ad:AddressComponent">
+		<annotation>
+			<documentation>-- Definition --
+An address component which represents the name of a unit of administration where a Member State has and/or exercises jurisdictional rights, for local, regional and national governance.</documentation>
+		</annotation>
+	</element>
+	<complexType name="AdminUnitNameType">
+		<complexContent>
+			<extension base="ad:AddressComponentType">
+				<sequence>
+					<element name="name" type="gn:GeographicalNamePropertyType" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Official, geographical name of the administrative unit, given in different languages where required.
+
+-- Description --
+NOTE The data type allows names in different languages and scripts as well as inclusion of alternative name, alternative spellings, historical name and exonyms.</documentation>
+						</annotation>
+					</element>
+					<element name="level" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+The level of administration in the national administrative hierarchy.</documentation>
+						</annotation>
+					</element>
+					<element name="adminUnit" type="gml:ReferenceType" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+The administrative unit that is the source of the content of the administrative unit name.
+
+-- Description --
+EXAMPLE The administrative unit (municipality) "Gävle" in Sweden is the source of the address component administrative unit name, "Gävle".</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AdminUnitNamePropertyType">
+		<sequence minOccurs="0">
+			<element ref="ad:AdminUnitName"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="GeographicPosition" type="ad:GeographicPositionType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+The position of a characteristic point which represents the location of the address according to a certain specification, including information on the origin of the position.</documentation>
+		</annotation>
+	</element>
+	<complexType name="GeographicPositionType">
+		<sequence>
+			<element name="geometry" type="gml:PointPropertyType">
+				<annotation>
+					<documentation>-- Definition --
+The position of the point expressed in coordinates in the chosen spatial reference system.</documentation>
+				</annotation>
+			</element>
+			<element name="specification" type="gml:ReferenceType" nillable="true">
+				<annotation>
+					<documentation>-- Definition --
+Information defining the specification used to create or derive this geographic position of the address.</documentation>
+				</annotation>
+			</element>
+			<element name="method" type="gml:ReferenceType" nillable="true">
+				<annotation>
+					<documentation>-- Definition --
+Description of how and by whom the geographic position of the address was created or derived.
+
+-- Description --
+NOTE The geographic position could be created manually by the address authority itself, by an independent party (e.g. by field surveying or digitizing of paper maps) or it could be derived automatically from the addressable object or from other Inspire features.</documentation>
+				</annotation>
+			</element>
+			<element name="default" type="boolean">
+				<annotation>
+					<documentation>-- Definition --
+Specifies whether or not this position should be considered as the default.
+
+-- Description --
+NOTE As a member state may provide several positions of an address, there is a need to identify the commonly used (main) position. Preferrably, the default position should be the one with best accuracy.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="GeographicPositionPropertyType">
+		<sequence>
+			<element ref="ad:GeographicPosition"/>
+		</sequence>
+	</complexType>
+	<element name="LocatorDesignator" type="ad:LocatorDesignatorType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+A number or a sequence of characters that uniquely identifies the locator within the relevant scope(s). The full identification of the locator could include one or more locator designators.
+
+-- Description --
+NOTE 1 Locator designators are often assigned according to a set of commonly known rules which enables a user or application to "parse" the information: Address numbers are most often assigned in ascending order with odd and even numbers on each side of the thoroughfare. In a building, the floor identifier represents the level according to the traditions within the area, e.g., 1, 2, 3. 
+
+NOTE 2 Several types of locator designators exist, such as: Address number, address number suffix, building identifier, building name. A locator could be composed by an ordered set of these. 
+
+EXAMPLE In Paris, France a locator could be composed by two locator designators: address number "18" and address number suffix: "BIS".</documentation>
+		</annotation>
+	</element>
+	<complexType name="LocatorDesignatorType">
+		<sequence>
+			<element name="designator" type="string">
+				<annotation>
+					<documentation>-- Definition --
+The identifying part of the locator designator composed by one or more digits or other characters. 
+
+-- Description --
+NOTE The value is often a descriptive code assigned according to certain well known rules e.g. like ascending odd and even address numbers along the thoroughfare, or like floor identifiers: 0, 1, 2, 3.  
+
+EXAMPLE Address number "2065", Address number suffix "B", Floor identifier "7" door identifier "B707" are all locator attribute values.</documentation>
+				</annotation>
+			</element>
+			<element name="type" type="gml:ReferenceType">
+				<annotation>
+					<documentation>-- Definition --
+The type of locator value, which enables an application to interpret, parse or format it according to certain rules.
+
+-- Description --
+NOTE The type enables a user or an application to understand if the value "A" is e.g. an identifier of a specific building, door, staircase or dwelling.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="LocatorDesignatorPropertyType">
+		<sequence>
+			<element ref="ad:LocatorDesignator"/>
+		</sequence>
+	</complexType>
+	<element name="LocatorName" type="ad:LocatorNameType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+Proper noun applied to the real world entity identified by the locator.
+
+-- Description --
+NOTE The locator name could be the name of the property or complex, of the building or part of the building, or it could be the name of a room inside a building.</documentation>
+		</annotation>
+	</element>
+	<complexType name="LocatorNameType">
+		<sequence>
+			<element name="name" type="gn:GeographicalNamePropertyType" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+The identifying part of the locator name. 
+
+-- Description --
+NOTE 1 The data type allows names in different languages and scripts as well as inclusion of alternative name, alternative spellings, historical name and exonyms.
+
+NOTE 2 The locator name could be the name of the property or complex, of the building or part of the building (e.g. a wing), or it could be the name of a room or similar inside the building.  
+
+NOTE 3 The locator name sometimes refer to the name of the family or business entity which at present or in the past has owned or occupied the property or building; although this is the case the locator name must not be confused with the name of the addressee(s).
+
+NOTE 4 As locator name it is also possible to use a descriptive text that allows a user to identify the property in question.
+
+EXAMPLE 1 The "Radford Mill Farm" in Timsbury, Bath, UK; The allotment house area "Brumleby" in Copenhagen, Denmark, the university campus "Cité Universitaire", in Paris, France. 
+
+EXAMPLE 2 "Millers House" in Stromness, Orkney Isles, UK; "Ulla's Pension" in Niederfell, Rheinland-Pfalz, Germany.
+
+EXAMPLE 3 "Multi-storey car park at Southampton Magistrates Courts" in Southampton, UK.</documentation>
+				</annotation>
+			</element>
+			<element name="type" type="gml:ReferenceType">
+				<annotation>
+					<documentation>-- Definition --
+The type of locator value, which enables an application to interpret, parse or format it according to certain rules.
+
+-- Description --
+NOTE The type enables a user or an application to understand if the name "Radford Mill Farm" is for example a name of a specific site or of a building.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="LocatorNamePropertyType">
+		<sequence>
+			<element ref="ad:LocatorName"/>
+		</sequence>
+	</complexType>
+	<element name="PartOfName" type="ad:PartOfNameType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+A part of the full name resulting from the subdivision of the thoroughfare name into separate, semantic parts, using the same language and script as the full thoroughfare name.
+
+-- Description --
+NOTE Each part of the name must be qualified by using the type attribute.</documentation>
+		</annotation>
+	</element>
+	<complexType name="PartOfNameType">
+		<sequence>
+			<element name="part" type="string">
+				<annotation>
+					<documentation>-- Definition --
+The character string that expresses the separate part of the name using the same language and script as the full thoroughfare name.</documentation>
+				</annotation>
+			</element>
+			<element name="type" type="gml:ReferenceType">
+				<annotation>
+					<documentation>-- Definition --
+A classification of the part of name according to its semantics (meaning) in the complete thoroughfare name.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="PartOfNamePropertyType">
+		<sequence>
+			<element ref="ad:PartOfName"/>
+		</sequence>
+	</complexType>
+	<element name="PostalDescriptor" type="ad:PostalDescriptorType" substitutionGroup="ad:AddressComponent">
+		<annotation>
+			<documentation>-- Definition --
+An address component which represents the identification of a subdivision of addresses and postal delivery points in a country, region or city for postal purposes. 
+
+-- Description --
+NOTE 1 The postal descriptor is specified by means of a post code and/or names of the associated post office, town or area.
+
+NOTE 2 In some countries post codes are seen as a proper geographic subdivision of the country, in other countries the post code is regarded only as an attribute that characterizes a (usually small) number of adjacent postal delivery points and addresses. 
+
+NOTE 3 The postal descriptors are created and developed on the basis of postal requirements (e.g. efficient sorting, logistics, transport and distribution). Consequently, there is not often a tight relationship between the postal areas and administrative units in the same area.
+
+NOTE 4 The structure schema and formats of national postal descriptor systems are different. Sometimes (for example in the UK) the post code itself is the only information required for a valid address; in other situations both the post code and the associated name of post office or town is required. Sometimes there is a simple relationship between the code and the name; in other situations a set of postcodes are associated with a single post office or town.
+
+NOTE 5 In some countries like e.g. The Republic of Ireland, no post code system currently exists, therefore the postal descriptor is only represented by the name of the post town. 
+
+EXAMPLE 1 In the UK the post code "EC4M 7DR" is sufficient, as a postal descriptor, while the related town name "London" is informative, but not necessary in the postal address. 
+
+EXAMPLE 2 In Sweden all postcodes starting with "80" is related to the postal name "Gävle". Therefore in the postal descriptor "802 74 Gävle", the postcode "802 74" bears all postal necessary information, while the town name "Gävle" is extra information. 
+
+EXAMPLE 3 In Denmark, outside the centre of Copenhagen, each postcode has a 1:1 relationship to one post name only: Postcode "6372" relates to the village "Bylderup-Bov". 
+
+EXAMPLE 4 In Germany the lowest level of the Postal descriptor (the 5 digit Postleitzahl) often does not fall within an administrative unit (e.g. municipality). The Postleitzahl is handled completely independent from the hierarchal systematic of the addresses. In addition, some "Postleitzahlen" represent not a delivery area, but institutions with a big amount of post.</documentation>
+		</annotation>
+	</element>
+	<complexType name="PostalDescriptorType">
+		<complexContent>
+			<extension base="ad:AddressComponentType">
+				<sequence>
+					<element name="postName" type="gn:GeographicalNamePropertyType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+One or more names created and maintained for postal purposes to identify a subdivision of addresses and postal delivery points. 
+
+-- Description --
+NOTE 1 Often the post name (or names) is a supplementary identification of the post office to which the associated post code belongs. For example it may be the name of the town in which the office is situated. In other situations the post name could be an independent descriptor without any post code or it could be a postal subdivision connected to a parent postal descriptor (post code and post name). 
+
+NOTE 2 In some countries like e.g. Spain and The Netherlands, no post names exit therefore the postal descriptor is only represented by the post code. 
+
+NOTE 3 Even though the post name is the same as the name of an administrative unit or an address area, the area covered are not necessarilythe same.</documentation>
+						</annotation>
+					</element>
+					<element name="postCode" type="string" minOccurs="0">
+						<annotation>
+							<documentation>-- Definition --
+A code created and maintained for postal purposes to identify a subdivision of addresses and postal delivery points. 
+
+-- Description --
+NOTE 1 The structure, schema and formats of post codes are different in different countries. Often the components of the post code are hierarchical, e.g. when the first character(s) identifies the region covered by the post code and the next characters define the subdivision. 
+
+NOTE 2 In some countries, e.g., The Republic of Ireland, no post codes exists therefore the postal descriptor is only represented by the post name (e.g. town name).
+
+EXAMPLE In the UK postcodes starting with W covers the Western (W1) and Paddington (W2-14) districts of the London postal district. In Sweden all postcodes starting with "80" is related to the postal name "Gävle".</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="PostalDescriptorPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ad:PostalDescriptor"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="ThoroughfareName" type="ad:ThoroughfareNameType" substitutionGroup="ad:AddressComponent">
+		<annotation>
+			<documentation>-- Definition --
+An address component which represents the name of a passage or way through from one location to another. 
+
+-- Description --
+NOTE 1 A thoroughfare can, e.g., be a road or a waterway
+
+NOTE 2 Thoroughfare names includes names of squares and of cul de sacs, and they can also represent the network of smaller roads or paths e.g. in a small village or settlement.</documentation>
+		</annotation>
+	</element>
+	<complexType name="ThoroughfareNameType">
+		<complexContent>
+			<extension base="ad:AddressComponentType">
+				<sequence>
+					<element name="name" type="ad:ThoroughfareNameValuePropertyType" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+Name of the thoroughfare.
+
+-- Description --
+NOTE 1 The name can optionally include an often used alternative name, alternative spelling of the name, a historic name or spelling, which is still in use. It may also optionally include a subdivision of the name into parts.
+
+NOTE 2 Most often thoroughfares are roads, in this situation the thoroughfare name is the road name.  
+
+NOTE 3 The data type also allows a representation of the thoroughfare name in separate parts e.g. "rue" + "de la" + "Paix"</documentation>
+						</annotation>
+					</element>
+					<element name="transportLink" type="gml:ReferenceType" nillable="true" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>-- Definition --
+One or several transport network links to which the spatial object of the thoroughfare name has been designated.
+
+-- Description --
+EXAMPLE The thoroughfare name "Na Pankráci" in Praha, The Czech Republic, has been designated as a road name for a number of road links (street segments) in the city.</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">tn:TransportLink</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ThoroughfareNamePropertyType">
+		<sequence minOccurs="0">
+			<element ref="ad:ThoroughfareName"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="ThoroughfareNameValue" type="ad:ThoroughfareNameValueType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+Proper noun applied to thoroughfare optionally including a subdivision of the name into parts.
+
+-- Description --
+NOTE 1 The data type allows names in different languages and scripts as well as inclusion of alternative name, alternative spellings, historical name and exonyms. 
+
+NOTE 2 The data type allows optionally a representation of the thoroughfare name subdivided into separate, semantic parts e.g. "Avenue" + "de la" + "Poste".</documentation>
+		</annotation>
+	</element>
+	<complexType name="ThoroughfareNameValueType">
+		<sequence>
+			<element name="name" type="gn:GeographicalNamePropertyType">
+				<annotation>
+					<documentation>-- Definition --
+Proper noun applied to the thoroughfare.
+
+-- Description --
+NOTE 1 The complete name of the thoroughfare must be applied in this attribute, including type, prefix or qualifier, like for example "Avenue de la Poste", "Calle del Christo Canneregio" or "Untere Quai". The name part attribute enables a representation of the name subdivided into separate semantic parts.
+
+NOTE 2 The data type allows names in different languages as well as inclusion of exonyms.</documentation>
+				</annotation>
+			</element>
+			<element name="nameParts" nillable="true" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>-- Definition --
+One or several parts into which the thoroughfare name can be subdivided.
+
+-- Description --
+NOTE 1 This is a definition which is consistent with that adopted by the UPU
+
+NOTE 2 A subdivision of a thoroughfare name into semantic parts could improve parsing (e.g. of abbreviated or misspelled names) and for sorting of address data for example for postal delivery purposes. It could also improve the creation of alphabetically sorted street gazetteers. 
+
+NOTE 3 The data type requires that each part of the subdivided thoroughfare name is qualified with information on the semantics e.g. if it is a thoroughfare type (e.g., Rua, Place, Calle, Street), a prefix (e.g., da, de la, del), a qualifier (e.g., Unterer, Little) or if it is the core of the name, which would normally be used for sorting or indexing. 
+
+NOTE 4 In some countries or regions and for some thoroughfare names it is not feasible or it does not add value to subdivide the thoroughfare name into parts.
+
+EXAMPLE In France the thoroughfare name "Avenue de la Poste" could be subdivided into these parts: "Avenue" + "de la" + "Poste".</documentation>
+				</annotation>
+				<complexType>
+					<sequence>
+						<element ref="ad:PartOfName"/>
+					</sequence>
+					<attribute name="nilReason" type="gml:NilReasonType"/>
+				</complexType>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="ThoroughfareNameValuePropertyType">
+		<sequence>
+			<element ref="ad:ThoroughfareNameValue"/>
+		</sequence>
+	</complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/AdministrativeUnits.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/AdministrativeUnits.xsd
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:au="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/au/4.0" version="4.0">
+  <import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/gn/4.0" schemaLocation="GeographicalNames.xsd"/>
+  <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element name="AdministrativeBoundary" substitutionGroup="gml:AbstractFeature" type="au:AdministrativeBoundaryType">
+    <annotation>
+      <documentation>-- Name --
+administrative boundary
+
+-- Definition --
+A line of demarcation between administrative units.</documentation>
+    </annotation>
+  </element>
+  <complexType name="AdministrativeBoundaryType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="geometry" type="gml:CurvePropertyType">
+            <annotation>
+              <documentation>-- Name --
+geometry
+
+-- Definition --
+Geometric representation of border line.</documentation>
+            </annotation>
+          </element>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Name --
+inspire id
+
+-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element name="country" type="gmd:Country_PropertyType">
+            <annotation>
+              <documentation>-- Name --
+country
+
+-- Definition --
+Two-character country code according to the Interinstitutional style guide published by the Publications Office of the European Union.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="6" name="nationalLevel" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+national level
+
+-- Definition --
+The hierarchy levels of all adjacent administrative units this boundary is part of.</documentation>
+            </annotation>
+          </element>
+          <element name="legalStatus" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+legal status
+
+-- Definition --
+Legal status of this administrative boundary. 
+
+-- Description --
+NOTE The legal status is considered in terms of political agreement or disagreement of the administrative units separated by this boundary.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="au:LegalStatusValueType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="technicalStatus" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+technical status
+
+-- Definition --
+The technical status of the administrative boundary.
+
+-- Description --
+NOTE The technical status of the boundary is considered in terms of its topological matching or not-matching with the borders of all separated administrative units. Edge-matched means that the same set of coordinates is used.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="au:TechnicalStatusValueType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+begin lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+end lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="admUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+adm unit
+
+-- Definition --
+The administrative units separated by this administrative boundary. 
+
+-- Description --
+NOTE In case of a national boundary (i.e. nationalLevel='1st order')  only one national administrative unit (i.e. country) is provided.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:boundary</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="AdministrativeBoundaryPropertyType">
+    <sequence minOccurs="0">
+      <element ref="au:AdministrativeBoundary"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="AdministrativeUnit" substitutionGroup="gml:AbstractFeature" type="au:AdministrativeUnitType">
+    <annotation>
+      <documentation>-- Name --
+administrative unit
+
+-- Definition --
+Unit of administration where a Member State has and/or exercises jurisdictional rights, for local, regional and national governance.</documentation>
+    </annotation>
+  </element>
+  <complexType name="AdministrativeUnitType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="geometry" type="gml:MultiSurfacePropertyType">
+            <annotation>
+              <documentation>-- Name --
+geometry
+
+-- Definition --
+Geometric representation of spatial area covered by this administrative unit.</documentation>
+            </annotation>
+          </element>
+          <element name="nationalCode" type="string">
+            <annotation>
+              <documentation>-- Name --
+national code
+
+-- Definition --
+Thematic identifier corresponding to the national administrative codes defined in each country.</documentation>
+            </annotation>
+          </element>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Name --
+inspire id
+
+-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element name="nationalLevel" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+national level
+
+-- Definition --
+Level in the national administrative hierarchy, at which the administrative unit is established.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" name="nationalLevelName" nillable="true" type="gmd:LocalisedCharacterString_PropertyType">
+            <annotation>
+              <documentation>-- Name --
+national level name
+
+-- Definition --
+Name of the level in the national administrative hierarchy, at which  the administrative unit is established.</documentation>
+            </annotation>
+          </element>
+          <element name="country" type="gmd:Country_PropertyType">
+            <annotation>
+              <documentation>-- Name --
+country
+
+-- Definition --
+Two-character country code according to the Interinstitutional style guide published by the Publications Office of the European Union.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" name="name" type="gn:GeographicalNamePropertyType">
+            <annotation>
+              <documentation>-- Name --
+name
+
+-- Definition --
+Official national geographical name of the administrative unit, given in several languages where required.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" name="residenceOfAuthority" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+residence of authority
+
+-- Definition --
+Center for national or local administration.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="au:ResidenceOfAuthority"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+begin lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+end lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="condominium" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+condominium
+
+-- Definition --
+Condominium administered by this administrative unit.
+
+-- Description --
+NOTE Condominiums may only exist at state level and can be administered only by administrative units at the highest level of the national administrative hierarchy (i.e. countries).</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:Condominium</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:admUnit</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="lowerLevelUnit" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+lower level unit
+
+-- Definition --
+Units established at a lower level of the national administrative hierarchy which are administered by the administrative unit. 
+
+-- Description --
+NOTE For administrative units at the lowest level of the national hierarchy no lower level unit exists. 
+
+CONSTRAINT Each administrative unit except for the lowest level units shall refer to its lower level units</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:upperLevelUnit</reversePropertyName>
+              </appinfo>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMemberType">
+                  <sequence/>
+                  <attributeGroup ref="gml:AssociationAttributeGroup"/>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="upperLevelUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+upper level unit
+
+-- Definition --
+A unit established at a higher level of national administrative hierarchy that this administrative unit administers. 
+
+-- Description --
+NOTE Administrative units at the highest level of national hierarchy (i.e. the country) do not have upper level units. 
+
+CONSTRAINT Each administrative unit at the level other than '1st order' (i.e. nationalLevel &lt;&gt; '1st order') shall refer their upper level unit.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:lowerLevelUnit</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="administeredBy" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+administered by
+
+-- Definition --
+Administrative unit established at same level of national administrative hierarchy that administers this administrative unit.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:coAdminister</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="coAdminister" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+co administer
+
+-- Definition --
+Administrative unit established at same level of national administrative hierarchy which is co-administered by this administrative unit.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:administeredBy</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" name="boundary" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+boundary
+
+-- Definition --
+The administrative boundaries between this administrative unit and all the units adjacent to it.
+
+-- Description --
+NOTE Administrative boundary corresponds to the curve established between the  nodes  at lowest level of territory division in Member State. Thus, it does not necessarily represents boundary in political terms, but just part of it.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeBoundary</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:admUnit</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="AdministrativeUnitPropertyType">
+    <sequence minOccurs="0">
+      <element ref="au:AdministrativeUnit"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="Condominium" substitutionGroup="gml:AbstractFeature" type="au:CondominiumType">
+    <annotation>
+      <documentation>-- Name --
+condominium
+
+-- Definition --
+An administrative area established independently to any national administrative division of territory  and administered by two or more countries. 
+
+-- Description --
+NOTE Condominium is not a part of any national administrative hierarchy of territory division in Member State.</documentation>
+    </annotation>
+  </element>
+  <complexType name="CondominiumType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Name --
+inspire id
+
+-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="name" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+name
+
+-- Definition --
+Official geographical name of this condominium, given in several languages where required.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="geometry" type="gml:MultiSurfacePropertyType">
+            <annotation>
+              <documentation>-- Name --
+geometry
+
+-- Definition --
+Geometric representation of spatial area covered by this condominium.</documentation>
+            </annotation>
+          </element>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+begin lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+end lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="admUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+adm unit
+
+-- Definition --
+The administrative unit administering the condominium.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">au:condominium</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="CondominiumPropertyType">
+    <sequence minOccurs="0">
+      <element ref="au:Condominium"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <simpleType name="LegalStatusValueType">
+    <annotation>
+      <documentation>-- Name --
+legal status value
+
+-- Definition --
+Description of the legal status of administrative boundaries.</documentation>
+    </annotation>
+    <restriction base="string">
+      <enumeration value="agreed">
+        <annotation>
+          <documentation>-- Name --
+agreed
+
+-- Definition --
+The edge-matched boundary has been agreed between neighbouring administrative units and is stable now.</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="notAgreed">
+        <annotation>
+          <documentation>-- Name --
+not agreed
+
+-- Definition --
+The edge-matched boundary has not yet been agreed between neighbouring administrative units and could be changed.</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+  <element name="ResidenceOfAuthority" substitutionGroup="gml:AbstractObject" type="au:ResidenceOfAuthorityType">
+    <annotation>
+      <documentation>-- Definition --
+Data type representing the name and position of a residence of authority.</documentation>
+    </annotation>
+  </element>
+  <complexType name="ResidenceOfAuthorityType">
+    <sequence>
+      <element name="name" type="gn:GeographicalNamePropertyType">
+        <annotation>
+          <documentation>-- Definition --
+Name of the residence of authority.</documentation>
+        </annotation>
+      </element>
+      <element name="geometry" nillable="true" type="gml:PointPropertyType">
+        <annotation>
+          <documentation>-- Definition --
+Position of the residence of authority.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="ResidenceOfAuthorityPropertyType">
+    <sequence>
+      <element ref="au:ResidenceOfAuthority"/>
+    </sequence>
+  </complexType>
+  <simpleType name="TechnicalStatusValueType">
+    <annotation>
+      <documentation>-- Name --
+technical status value
+
+-- Definition --
+Description of the technical status of administrative boundaries.</documentation>
+    </annotation>
+    <restriction base="string">
+      <enumeration value="edgeMatched">
+        <annotation>
+          <documentation>-- Name --
+edge matched
+
+-- Definition --
+The boundaries of neighbouring administrative units have the same set of coordinates.</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="notEdgeMatched">
+        <annotation>
+          <documentation>-- Name --
+not edge matched
+
+-- Definition --
+The boundaries of neighbouring administrative units do not have the same set of coordinates.</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/BaseTypes.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/BaseTypes.xsd
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" targetNamespace="http://inspire.ec.europa.eu/schemas/base/3.3" elementFormDefault="qualified" version="3.3.1">
+	<!-- Bugfix version 3.3.1
+		 - The <SpatialDataSet>, <SpatialDataSetType> and <SpatialDataSetPropertyType> elements are deprecated (in accordance with D2.7 v3.3 Recommendation 11 stating that wfs:FeatureCollection should be used instead)
+		 - The (optional) <member> element, which was accidentally removed in v3.3(.0), is re-included inside the (deprecated) <SpatialDataSet> element. -->
+	<annotation>
+		<documentation>-- Definition --
+schema for basic types used by multiple themes</documentation>
+	</annotation>
+	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<!--XML Schema document created by ShapeChange-->
+	<simpleType name="VerticalPositionValueType">
+		<annotation>
+			<documentation>-- Definition --
+The relative vertical position of a spatial object.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="onGroundSurface">
+				<annotation>
+					<documentation>-- Definition --
+The spatial object is on ground level.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="suspendedOrElevated">
+				<annotation>
+					<documentation>-- Definition --
+The spatial object is suspended or elevated.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="underground">
+				<annotation>
+					<documentation>-- Definition --
+The spatial object is underground.</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- WARNING This element has been deprecated in v3.3.1 of this schema (in accordance with D2.7 v3.3 Recommendation 11 stating that wfs:FeatureCollection should be used instead of base:SpatialDataSet). -->
+	<element name="SpatialDataSet" type="base:SpatialDataSetType" substitutionGroup="gml:AbstractFeature">
+		<annotation>
+			<documentation>-- Definition --
+Identifiable collection of spatial data.
+
+-- Description --
+WARNING This element has been deprecated in v3.3.1 of this schema (in accordance with D2.7 v3.3 Recommendation 11 stating that wfs:FeatureCollection should be used instead of base:SpatialDataSet).
+
+NOTE The type SpatialDataSet is offered as a pre-defined type for spatial data sets. The scope of this type is packaging pre-defined data sets for the non-direct access download service. It may be reused in thematic application schemas, but if it does not fit an application-schema-specific data set object should be modelled. This type may have the same name and definition like this type, but may have a different set of properties.
+
+This type specifies three properties: an external object identifier, a container for metadata (may be void), and an association to zero or more spatial objects.</documentation>
+		</annotation>
+	</element>
+	<!-- WARNING This type has been deprecated in v3.3.1 of this schema (in accordance with D2.7 v3.3 Recommendation 11 stating that wfs:FeatureCollection should be used instead of base:SpatialDataSet). -->
+	<complexType name="SpatialDataSetType">
+		<complexContent>
+			<extension base="gml:AbstractFeatureType">
+				<sequence>
+					<element name="identifier" type="base:IdentifierPropertyType">
+						<annotation>
+							<documentation>-- Definition --
+Identifier of the spatial data set.</documentation>
+						</annotation>
+					</element>
+					<element name="metadata" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Metadata of the spatial data set.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMetadataPropertyType">
+									<sequence minOccurs="0">
+										<element ref="gmd:MD_Metadata"/>
+									</sequence>
+									<attributeGroup ref="gml:AssociationAttributeGroup"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element name="member" type="gml:FeaturePropertyType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>The spatial objects that are members of the spatial data set</documentation>
+							<appinfo>
+								<targetElement xmlns="http://www.opengis.net/gml/3.2">gml:AbstractFeature</targetElement>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- WARNING This type has been deprecated in v3.3.1 of this schema (in accordance with D2.7 v3.3 Recommendation 11 stating that wfs:FeatureCollection should be used instead of base:SpatialDataSet). -->
+	<complexType name="SpatialDataSetPropertyType">
+		<sequence minOccurs="0">
+			<element ref="base:SpatialDataSet"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="Identifier" type="base:IdentifierType" substitutionGroup="gml:AbstractObject">
+		<annotation>
+			<documentation>-- Definition --
+External unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object.
+
+-- Description --
+NOTE1 External object identifiers are distinct from thematic object identifiers.
+
+NOTE 2 The voidable version identifier attribute is not part of the unique identifier of a spatial object and may be used to distinguish two versions of the same spatial object.
+
+NOTE 3 The unique identifier will not change during the life-time of a spatial object.</documentation>
+		</annotation>
+	</element>
+	<complexType name="IdentifierType">
+		<sequence>
+			<element name="localId" type="string">
+				<annotation>
+					<documentation>-- Definition --
+A local identifier, assigned by the data provider. The local identifier is unique within the namespace, that is no other spatial object carries the same unique identifier.
+
+-- Description --
+NOTE It is the responsibility of the data provider to guarantee uniqueness of the local identifier within the namespace.</documentation>
+				</annotation>
+			</element>
+			<element name="namespace" type="string">
+				<annotation>
+					<documentation>-- Definition --
+Namespace uniquely identifying the data source of the spatial object.
+
+-- Description --
+NOTE The namespace value will be owned by the data provider of the spatial object and will be registered in the INSPIRE External Object Identifier Namespaces Register.</documentation>
+				</annotation>
+			</element>
+			<element name="versionId" nillable="true" minOccurs="0">
+				<annotation>
+					<documentation>-- Definition --
+The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique. 
+
+-- Description --
+NOTE The maximum length has been selected to allow for time stamps based on ISO 8601, for example, "2007-02-12T12:12:12+05:30" as the version identifier.
+
+NOTE 2 The property is void, if the spatial data set does not distinguish between different versions of the spatial object. It is missing, if the spatial object type does not support any life-cycle information.</documentation>
+				</annotation>
+				<complexType>
+					<simpleContent>
+						<extension base="string">
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</extension>
+					</simpleContent>
+				</complexType>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="IdentifierPropertyType">
+		<sequence>
+			<element ref="base:Identifier"/>
+		</sequence>
+	</complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/BaseTypes2.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/BaseTypes2.xsd
@@ -1,0 +1,515 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ad="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/base2/2.0" version="2.0">
+  <annotation>
+    <documentation>-- Definition --
+schema for additional basic types used by multiple themes
+
+-- Description --
+NOTE	The additional types specified with Annex II/III data specifications are placed in a separate schema to maintain backwards compatibility.</documentation>
+  </annotation>
+  <import namespace="http://inspire.ec.europa.eu/schemas/ad/4.0" schemaLocation="Addresses.xsd"/>
+  <import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="ShapeChangeAppinfo.xsd"/>
+  <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element name="Contact" substitutionGroup="gml:AbstractObject" type="base2:ContactType">
+    <annotation>
+      <documentation>-- Name --
+contact
+
+-- Definition --
+Communication channels by which it is possible to gain access to someone or something.
+
+-- Description --</documentation>
+    </annotation>
+  </element>
+  <complexType name="ContactType">
+    <sequence>
+      <element minOccurs="0" name="address" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+An address provided as free text.</documentation>
+        </annotation>
+        <complexType>
+          <sequence>
+            <element ref="ad:AddressRepresentation"/>
+          </sequence>
+          <attribute name="nilReason" type="gml:NilReasonType"/>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="contactInstructions" nillable="true" type="gmd:PT_FreeText_PropertyType">
+        <annotation>
+          <documentation>-- Definition --
+Supplementary instructions on how or when to contact an individual or organisation.
+
+
+-- Description --</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="electronicMailAddress" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+An address of the organisation's or individual's electronic mailbox.
+
+-- Description --</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="hoursOfService" nillable="true" type="gmd:PT_FreeText_PropertyType">
+        <annotation>
+          <documentation>-- Definition --
+Periods of time when the organisation or individual can be contacted.
+
+-- Description --</documentation>
+        </annotation>
+      </element>
+      <element maxOccurs="unbounded" minOccurs="0" name="telephoneFacsimile" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Number of a facsimile machine of the organisation or individual.
+
+-- Description --</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element maxOccurs="unbounded" minOccurs="0" name="telephoneVoice" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Telephone number of the organisation or individual.
+
+-- Description --</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="website" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Pages provided on the World Wide Web by the organisation or individual.
+
+-- Description --</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="anyURI">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="ContactPropertyType">
+    <sequence>
+      <element ref="base2:Contact"/>
+    </sequence>
+  </complexType>
+  <element name="DocumentCitation" substitutionGroup="gml:AbstractGML" type="base2:DocumentCitationType">
+    <annotation>
+      <documentation>-- Name --
+document citation
+
+-- Definition --
+Citation for the purposes of unambiguously referencing a document.</documentation>
+    </annotation>
+  </element>
+  <complexType name="DocumentCitationType">
+    <complexContent>
+      <extension base="gml:AbstractGMLType">
+        <sequence>
+          <element name="name" type="string">
+            <annotation>
+              <documentation>-- Name --
+name
+
+-- Definition --
+Name of the document.
+
+-- Description --
+NOTE	For legal documents, this should be the official name assigned to the legislative instrument.
+
+EXAMPLE The official legal name for the INSPIRE Directive is "Directive 2007/2/EC of the European Parliament and of the Council of 14 March 2007 establishing an Infrastructure for Spatial Information in the European Community (INSPIRE)"</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="shortName" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+short name
+
+-- Definition --
+Short name or alternative title of the document.
+
+-- Description --
+NOTE	For legal documents, this should be a short name or alternative title commonly used to identify the legislation.
+
+EXAMPLE 1: INSPIRE Directive is the short name for "Directive 2007/2/EC of the European Parliament and of the Council of 14 March 2007 establishing an Infrastructure for Spatial Information in the European Community (INSPIRE)"
+
+EXAMPLE 2: CAFE Directive is the short name for the Directive 2008/50/EC of the European Parliament and of the Council of 21 May 2008 on ambient air quality and cleaner air for Europe" 
+
+EXAMPLE  3: Water Framework Directive the short name for "Directive 2000/60/EC of the European Parliament and of the Council establishing a framework for the Community action in the field of water policy"</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="string">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="date" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+date
+
+-- Definition --
+Date of creation, publication or revision of the document.</documentation>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMetadataPropertyType">
+                  <sequence>
+                    <element ref="gmd:CI_Date"/>
+                  </sequence>
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="link" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+link to online version
+
+-- Definition --
+Link to an online version of the document</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="anyURI">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="specificReference" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+specific reference
+
+-- Definition --
+Reference to a specific part of the document.
+
+-- Description --
+EXAMPLE For legal documents, this attribute can contain a reference to article(s) that specify a specific requirement or obligation.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="string">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="DocumentCitationPropertyType">
+    <sequence minOccurs="0">
+      <element ref="base2:DocumentCitation"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="LegislationCitation" substitutionGroup="base2:DocumentCitation" type="base2:LegislationCitationType">
+    <annotation>
+      <documentation>-- Name --
+legislation citation
+
+-- Definition --
+Citation for the purposes of unambiguously referencing a legal act or a specific part of a legal act.</documentation>
+    </annotation>
+  </element>
+  <complexType name="LegislationCitationType">
+    <complexContent>
+      <extension base="base2:DocumentCitationType">
+        <sequence>
+          <element minOccurs="0" name="identificationNumber" type="string">
+            <annotation>
+              <documentation>-- Name --
+identification number
+
+-- Definition --
+Code used to identify the legislative instrument
+
+-- Description --
+
+EXAMPLE 1: 2007/2/EC is the identification number for the INSPIRE Directive
+
+EXAMPLE 2: 2008/50/EC is the identification number for the CAFE Directive
+
+EXAMPLE 3: 2000/60/EC is the identification number for the  Water Framework Directive</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="officialDocumentNumber" type="string">
+            <annotation>
+              <documentation>-- Name --
+official document number
+
+-- Definition --
+Official document number used to uniquely identify the legislative instrument.
+
+-- Description --
+NOTE: An official document number may be assigned to uniquely identify the legislative instrument.
+
+EXAMPLE: CELEX Number used to uniquely identify European Union Legislation</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="dateEnteredIntoForce" type="gml:TimePositionType">
+            <annotation>
+              <documentation>-- Name --
+date entered into force
+
+-- Definition --
+Date the legislative instrument entered into force.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="dateRepealed" type="gml:TimePositionType">
+            <annotation>
+              <documentation>-- Name --
+date repealed
+
+-- Definition --
+Date the legislative instrument was repealed.</documentation>
+            </annotation>
+          </element>
+          <element name="level" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+name
+
+-- Definition --
+The level at which the legislative instrument is adopted.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="journalCitation" type="base2:OfficialJournalInformationPropertyType">
+            <annotation>
+              <documentation>-- Name --
+journal citation
+
+-- Definition --
+Citation of the official journal in which the legislation is published.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="LegislationCitationPropertyType">
+    <sequence minOccurs="0">
+      <element ref="base2:LegislationCitation"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="OfficialJournalInformation" substitutionGroup="gml:AbstractObject" type="base2:OfficialJournalInformationType">
+    <annotation>
+      <documentation>-- Name --
+official journal information
+
+-- Definition --
+Full citation of the location of the legislative instrument within the official journal.</documentation>
+    </annotation>
+  </element>
+  <complexType name="OfficialJournalInformationType">
+    <sequence>
+      <element name="officialJournalIdentification" type="string">
+        <annotation>
+          <documentation>-- Name --
+official journal identification
+
+-- Definition --
+Reference to the location within the official journal within which the legislative instrument was published. This reference shall be comprised of three parts:
+&lt;ul&gt;
+	&lt;li&gt;the title of the official journal&lt;/li&gt;
+	&lt;li&gt;the volume and/or series number&lt;/li&gt;
+	&lt;li&gt;Page number(s)&lt;/li&gt;
+&lt;/ul&gt;
+
+-- Description --
+EXAMPLE: Official Journal of European Union (OJEU), L108, Volume 50, 1-14</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="ISSN" type="string">
+        <annotation>
+          <documentation>-- Name --
+ISSN
+
+-- Definition --
+The International Standard Serial Number (ISSN) is an eight-digit number that identifies the periodical publication in which the legislative instrument was published.
+
+-- Description --
+NOTE: Periodical publilcations are issued in successive parts, usually having numerical or chronological designations and required that each serial publication can be uniquely identified.
+
+EXAMPLE: OJ Series in which INSPIRE Directive is published has been assigned the ISSN: 1725-2555</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="ISBN" type="string">
+        <annotation>
+          <documentation>-- Name --
+ISBN
+
+-- Definition --
+International Standard Book Number (ISBN) is an nine-digit number that uniquely identifies the book in which the legislative instrument was published.</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="linkToJournal" type="anyURI">
+        <annotation>
+          <documentation>-- Name --
+link to online version
+
+-- Definition --
+Link to an online version of the official journal</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="OfficialJournalInformationPropertyType">
+    <sequence>
+      <element ref="base2:OfficialJournalInformation"/>
+    </sequence>
+  </complexType>
+  <element name="RelatedParty" substitutionGroup="gml:AbstractObject" type="base2:RelatedPartyType">
+    <annotation>
+      <documentation>-- Name --
+related party
+
+-- Definition --
+An organisation or a person with a role related to a resource.
+
+-- Description --
+NOTE 1 A party, typically an individual person, acting as a general point of contact for a resource can be specified without providing any particular role.</documentation>
+    </annotation>
+  </element>
+  <complexType name="RelatedPartyType">
+    <sequence>
+      <element minOccurs="0" name="individualName" nillable="true" type="gmd:PT_FreeText_PropertyType">
+        <annotation>
+          <documentation>-- Name --
+individual name
+
+-- Definition --
+Name of the related person.</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="organisationName" nillable="true" type="gmd:PT_FreeText_PropertyType">
+        <annotation>
+          <documentation>-- Name --
+organisation name
+
+-- Definition --
+Name of the related organisation.</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="positionName" nillable="true" type="gmd:PT_FreeText_PropertyType">
+        <annotation>
+          <documentation>-- Name --
+position name
+
+-- Definition --
+Position of the party in relation to a resource, such as head of department.</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="contact" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+contact
+
+-- Definition --
+Contact information for the related party.</documentation>
+        </annotation>
+        <complexType>
+          <sequence>
+            <element ref="base2:Contact"/>
+          </sequence>
+          <attribute name="nilReason" type="gml:NilReasonType"/>
+        </complexType>
+      </element>
+      <element maxOccurs="unbounded" minOccurs="0" name="role" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+Role(s) of the party in relation to a resource, such as owner.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">TG</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="RelatedPartyPropertyType">
+    <sequence>
+      <element ref="base2:RelatedParty"/>
+    </sequence>
+  </complexType>
+  <element name="ThematicIdentifier" substitutionGroup="gml:AbstractObject" type="base2:ThematicIdentifierType">
+    <annotation>
+      <documentation>-- Name --
+thematic identifier
+
+-- Definition --
+Thematic identifier to uniquely identify the spatial object. 
+
+-- Description --
+Some spatial objects may be assigned multiple unique identifiers. 
+These may have been established to meet data exchange requirements of different reporting obligations at International, European or national levels and/or internal data maintenance requirements.</documentation>
+    </annotation>
+  </element>
+  <complexType name="ThematicIdentifierType">
+    <sequence>
+      <element name="identifier" type="string">
+        <annotation>
+          <documentation>-- Name --
+identifier
+
+-- Definition --
+Unique identifier used to identify the spatial object within the specified identification scheme.</documentation>
+        </annotation>
+      </element>
+      <element name="identifierScheme" type="string">
+        <annotation>
+          <documentation>-- Name --
+identifier scheme
+
+-- Definition --
+Identifier defining the scheme used to assign the identifier.
+
+-- Description --
+NOTE 1: Reporting requirements for different environmental legislation mandate that each spatial object is assigned an identifier conforming to specific lexical rules. 
+
+NOTE 2: These rules are often inconsistent so a spatial object may be assigned multiple identifiers which are used for object referencing to link information to the spatial object.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="ThematicIdentifierPropertyType">
+    <sequence>
+      <element ref="base2:ThematicIdentifier"/>
+    </sequence>
+  </complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/BuildingsBase.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/BuildingsBase.xsd
@@ -1,0 +1,787 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:bu-base="http://inspire.ec.europa.eu/schemas/bu-base/4.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/bu-base/4.0" version="4.0">
+  <annotation>
+    <documentation>-- Name --
+Building base
+
+-- Definition --
+The base application schema for INSPIRE theme buildings.</documentation>
+  </annotation>
+  <import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/gn/4.0" schemaLocation="GeographicalNames.xsd"/>
+  <import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="ShapeChangeAppinfo.xsd"/>
+  <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element abstract="true" name="AbstractBuilding" substitutionGroup="bu-base:AbstractConstruction" type="bu-base:AbstractBuildingType">
+    <annotation>
+      <documentation>-- Name --
+Abstract building
+
+-- Definition --
+Abstract spatial object type grouping the common semantic properties of the spatial object types Building and BuildingPart.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="AbstractBuildingType">
+    <complexContent>
+      <extension base="bu-base:AbstractConstructionType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="buildingNature" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+Building nature
+
+-- Definition --
+Characteristic of the building that makes it generally of interest for mappings applications. The characteristic may be related to the physical aspect and/or to the function of the building.
+
+-- Description --
+This attribute focuses on the physical aspect of the building; however, this physical aspect is often expressed as a function (e.g. stadium, silo, windmill); this attribute aims to fulfil mainly mapping purposes and addresses only specific, noticeable buildings.</documentation>
+              <appinfo>
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+              </appinfo>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="currentUse" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Current use
+
+-- Definition --
+Activity hosted within the building. This attribute addresses mainly the buildings hosting human activities.
+-- Description --
+NOTE: . This attribute aims to fulfill management requirements, such as computation of population or spatial planning ; this classification aims to be exhaustive for the functional buildings hosting human activities.</documentation>
+              <appinfo>
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+              </appinfo>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:CurrentUse"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="numberOfDwellings" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Number of dwellings
+
+-- Definition --
+Number of dwellings.
+
+-- Description --
+A dwelling is a residential unit which may consist of one or several rooms designed for the occupation of households.
+NOTE: In the data sets including building units, a dwelling is a residential building unit or, only when that building has no building units, a residential building&lt;i&gt;.&lt;/i&gt;
+EXAMPLES: a single building dwelling could be a detached or semi-detached house.  A block of flats will contain multiple dwellings determined by the number of individual flats.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="integer">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="numberOfBuildingUnits" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Number of building units
+
+-- Definition --
+Number of building units in the building. A BuildingUnit is a subdivision of Building with its own lockable access from the outside or from a common area (i.e. not from another BuildingUnit), which is atomic, functionally independent, and may be separately sold, rented out, inherited, etc.
+-- Description --
+Building units are spatial objects aimed at subdividing buildings and/or building parts into smaller parts that are treated as seperate entities in daily life. A building unit is homogeneous, regarding management aspects.
+EXAMPLES: It may be e.g. an apartment in a condominium, a terraced house, or a shop inside a shopping arcade.
+NOTE 1: According to national regulations, a building unit may be a flat, a cellar, a garage or set of a flat, a cellar and a garage.
+NOTE 2: According to national regulation, a building that is one entity for daily life (typically, a single family house) may be considered as a Building composed of one BuildingUnit or as a Building composed of zero BuildingUnit.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="integer">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="numberOfFloorsAboveGround" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Number of floors above ground
+
+-- Definition --
+Number of floors above ground.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="integer">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="AbstractBuildingPropertyType">
+    <sequence minOccurs="0">
+      <element ref="bu-base:AbstractBuilding"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="AbstractConstruction" substitutionGroup="gml:AbstractFeature" type="bu-base:AbstractConstructionType">
+    <annotation>
+      <documentation>-- Name --
+Abstract construction
+
+-- Definition --
+Abstract spatial object type grouping the semantic properties of  buildings, building parts and of some optional spatial object types that may be added in order to provide more information about the theme Buildings.
+
+-- Description --
+The optional spatial object types that may be added to core profiles are described in the extended profiles. The ones inheriting from the attributes of AbstractConstruction are Installation and OtherConstruction.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="AbstractConstructionType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Begin lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="conditionOfConstruction" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Name --
+Condition of construction
+
+-- Definition --
+Status of the construction.
+
+-- Description --
+EXAMPLES: functional, projected, ruin</documentation>
+              <appinfo>
+                <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+              </appinfo>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="dateOfConstruction" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Date of construction
+
+-- Definition --
+Date of construction.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:DateOfEvent"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="dateOfDemolition" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Date of demolition
+
+-- Definition --
+Date of demolition.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:DateOfEvent"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="dateOfRenovation" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Date of last major renovation
+
+-- Definition --
+Date of last major renovation.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:DateOfEvent"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="elevation" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Elevation
+
+-- Definition --
+Vertically-constrained dimensional property consisting of an absolute measure referenced to a well-defined surface which is commonly taken as origin (geoïd, water level, etc.).
+-- Description --
+Source: adapted from the definition given in the data specification of the theme Elevation.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:Elevation"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+End lifespan version
+
+-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="externalReference" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+External reference
+
+-- Definition --
+Reference to an external information system containing any piece of information related to the spatial object.
+
+-- Description --
+
+EXAMPLE 1: Reference to another spatial data set containing another view on buildings; the externalReference may be used for instance to ensure consistency between 2D and 3D representations of the same buildings
+
+EXAMPLE 2: Reference to cadastral or dwelling register. The reference to this register may enable to find legal information related to the building, such as the owner(s) or valuation criteria (e.g. type of heating, toilet, kitchen)
+
+EXAMPLE 3: Reference to the system recording the building permits. The reference to the building permits may be used to find detailed information about the building physical and temporal aspects.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:ExternalReference"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="heightAboveGround" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Height above ground
+
+-- Definition --
+Height above ground.
+
+-- Description --
+NOTE: height above ground may be defined as the difference between elevation at a low reference (ground level) and elevation as a high reference (e.g. roof level, top of construction)</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="bu-base:HeightAboveGround"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Name --
+inspire id
+
+-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="name" nillable="true">
+            <annotation>
+              <documentation>-- Name --
+Name
+
+-- Definition --
+Name of the construction.
+
+-- Description --
+EXAMPLES:  Big Ben, Eiffel Tower, Sacrada Familia</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="AbstractConstructionPropertyType">
+    <sequence minOccurs="0">
+      <element ref="bu-base:AbstractConstruction"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="Building" substitutionGroup="bu-base:AbstractBuilding" type="bu-base:BuildingType">
+    <annotation>
+      <documentation>-- Name --
+Building
+
+-- Definition --
+A Building is an enclosed &lt;b&gt;construction &lt;/b&gt;above and/or underground, used or intended for the shelter of humans, animals or things or for the production of economic goods. A building refers to any structure permanently constructed or erected on its site.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="BuildingType">
+    <complexContent>
+      <extension base="bu-base:AbstractBuildingType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="parts" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The building parts composing the Building.
+-- Description --
+A building may be a simple building (with no BuildingPart) or a composed building (with several BuildingParts).</documentation>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMemberType">
+                  <sequence minOccurs="0">
+                    <element ref="bu-base:BuildingPart"/>
+                  </sequence>
+                  <attributeGroup ref="gml:AssociationAttributeGroup"/>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="BuildingPropertyType">
+    <sequence minOccurs="0">
+      <element ref="bu-base:Building"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="BuildingGeometry2D" substitutionGroup="gml:AbstractObject" type="bu-base:BuildingGeometry2DType">
+    <annotation>
+      <documentation>-- Name --
+Building geometry 2D
+
+-- Definition --
+This data types includes the geometry of the building and metadata information about which element of the building was captured and how.</documentation>
+    </annotation>
+  </element>
+  <complexType name="BuildingGeometry2DType">
+    <sequence>
+      <element name="geometry" type="gml:GeometryPropertyType">
+        <annotation>
+          <documentation>-- Name --
+Geometry
+
+-- Definition --
+2D or 2.5D geometric representation</documentation>
+        </annotation>
+      </element>
+      <element name="referenceGeometry" type="boolean">
+        <annotation>
+          <documentation>-- Name --
+Reference geometry
+
+-- Definition --
+The geometry to be taken into account by view services, for portrayal.
+
+-- Description --
+NOTE 1: In case of multiple representation by point and by surface, it is generally recommended to provide the surface as reference geometry.
+NOTE 2: The geometric representation whose referenceGeometry is true may also be used preferably for spatial queries by download services (WFS) or by Geographical Information System (GIS).</documentation>
+        </annotation>
+      </element>
+      <element name="horizontalGeometryReference" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Horizontal geometry reference
+
+-- Definition --
+Element of the building that was captured by (X,Y) coordinates.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="verticalGeometryReference" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Vertical geometry reference
+
+-- Definition --
+Element of the building that was captured by vertical coordinates.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element name="horizontalGeometryEstimatedAccuracy" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+Horizontal geometry estimated accuracy
+
+-- Definition --
+The estimated absolute positional accuracy of the (X,Y) coordinates of the building geometry, in the INSPIRE official Coordinate Reference System. Absolute positional accuracy is defined as the mean value of the positional uncertainties for a set of positions where the positional uncertainties are defined as the distance between a measured position and what is considered as the corresponding true position.
+-- Description --
+NOTE: This mean value may come from quality measures on a homogeneous population of buildings or from an estimation based on the knowledge of the production processes and of their accuracy.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="gml:LengthType">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="verticalGeometryEstimatedAccuracy" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+Vertical geometry estimated accuracy
+
+-- Definition --
+The estimated absolute positional accuracy of the Z coordinates of the  building geometry, in the INSPIRE official Coordinate Reference System. Absolute positional accuracy is defined as the mean value of the positional uncertainties for a set of positions where the positional uncertainties are defined as the distance between a measured position and what is considered as the corresponding true position.
+-- Description --
+NOTE: This mean value may come from quality measures on a homogeneous population of buildings or from an estimation based on the knowledge of the production processes and of their accuracy.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="gml:LengthType">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="BuildingGeometry2DPropertyType">
+    <sequence>
+      <element ref="bu-base:BuildingGeometry2D"/>
+    </sequence>
+  </complexType>
+  <element abstract="true" name="BuildingPart" substitutionGroup="bu-base:AbstractBuilding" type="bu-base:BuildingPartType">
+    <annotation>
+      <documentation>-- Name --
+Building part
+
+-- Definition --
+A BuildingPart is a sub-division of a Building that might be considered itself as a building.
+
+-- Description --
+NOTE 1: A BuildingPart is homogeneous related to its physical, functional or temporal aspects. 
+
+NOTE 2: Building and BuildingPart share the same set of properties.
+EXAMPLE: A building may be composed of two building parts having different heights above ground.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="BuildingPartType">
+    <complexContent>
+      <extension base="bu-base:AbstractBuildingType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="BuildingPartPropertyType">
+    <sequence minOccurs="0">
+      <element ref="bu-base:BuildingPart"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="CurrentUse" substitutionGroup="gml:AbstractObject" type="bu-base:CurrentUseType">
+    <annotation>
+      <documentation>-- Name --
+Current use
+
+-- Definition --
+This data type enables to detail the current use(s).</documentation>
+    </annotation>
+  </element>
+  <complexType name="CurrentUseType">
+    <sequence>
+      <element name="currentUse" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Current use
+
+-- Definition --
+The current use.
+
+-- Description --
+EXAMPLE: trade</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element name="percentage" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+Percentage
+
+-- Definition --
+The proportion of the real world object, given as a percentage, devoted to this current use.
+-- Description --
+NOTE: The percentage of use is generally the percentage of floor area dedicated to this given use. If it is not the case, it is recommended to explain what the percentage refers to in metadata (template for additional information)
+EXAMPLE: 30 (if 30% of the building is occupied by trade activity).</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="integer">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="CurrentUsePropertyType">
+    <sequence>
+      <element ref="bu-base:CurrentUse"/>
+    </sequence>
+  </complexType>
+  <element name="DateOfEvent" substitutionGroup="gml:AbstractObject" type="bu-base:DateOfEventType">
+    <annotation>
+      <documentation>-- Name --
+Date of event
+
+-- Definition --
+This data type includes the different possible ways to define the date of an event.</documentation>
+    </annotation>
+  </element>
+  <complexType name="DateOfEventType">
+    <sequence>
+      <element minOccurs="0" name="anyPoint" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+Any point
+
+-- Definition --
+A date and time of any point of the event, between its beginning and its end.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="dateTime">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="beginning" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+Beginning
+
+-- Definition --
+Date and time when the event begun.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="dateTime">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="end" nillable="true">
+        <annotation>
+          <documentation>-- Name --
+End
+
+-- Definition --
+Date and time when the event ended.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="dateTime">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="DateOfEventPropertyType">
+    <sequence>
+      <element ref="bu-base:DateOfEvent"/>
+    </sequence>
+  </complexType>
+  <element name="Elevation" substitutionGroup="gml:AbstractObject" type="bu-base:ElevationType">
+    <annotation>
+      <documentation>-- Name --
+Elevation
+
+-- Definition --
+This data types includes the elevation value itself  and information on how this elevation was measured.</documentation>
+    </annotation>
+  </element>
+  <complexType name="ElevationType">
+    <sequence>
+      <element name="elevationReference" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Elevation reference
+
+-- Definition --
+Element where the elevation was measured.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element name="elevationValue" type="gml:DirectPositionType">
+        <annotation>
+          <documentation>-- Name --
+elevation value
+
+-- Definition --
+Value of the elevation.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="ElevationPropertyType">
+    <sequence>
+      <element ref="bu-base:Elevation"/>
+    </sequence>
+  </complexType>
+  <element name="ExternalReference" substitutionGroup="gml:AbstractObject" type="bu-base:ExternalReferenceType">
+    <annotation>
+      <documentation>-- Name --
+External reference
+
+-- Definition --
+Reference to an external information system containing any piece of information related to the spatial object.</documentation>
+    </annotation>
+  </element>
+  <complexType name="ExternalReferenceType">
+    <sequence>
+      <element name="informationSystem" type="anyURI">
+        <annotation>
+          <documentation>-- Name --
+Information system
+
+-- Definition --
+Uniform Resource Identifier of the external information system.</documentation>
+        </annotation>
+      </element>
+      <element name="informationSystemName" type="gmd:PT_FreeText_PropertyType">
+        <annotation>
+          <documentation>-- Name --
+Information system name
+
+-- Definition --
+The name of the external information system.
+
+-- Description --
+EXAMPLES: Danish Register of Dwellings, Spanish Cadastre.</documentation>
+        </annotation>
+      </element>
+      <element name="reference" type="string">
+        <annotation>
+          <documentation>-- Name --
+Reference
+
+-- Definition --
+Thematic identifier of the spatial object or of any piece of information related to the spatial object.
+-- Description --
+NOTE: This reference will act as a foreign key to implement the association between the spatial object in the INSPIRE data set and in the external information system.
+EXAMPLE: The cadastral reference of a given building in the national cadastral register.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="ExternalReferencePropertyType">
+    <sequence>
+      <element ref="bu-base:ExternalReference"/>
+    </sequence>
+  </complexType>
+  <element name="HeightAboveGround" substitutionGroup="gml:AbstractObject" type="bu-base:HeightAboveGroundType">
+    <annotation>
+      <documentation>-- Name --
+Height above ground
+
+-- Definition --
+Vertical distance (measured or estimated) between a low reference and a high reference.</documentation>
+    </annotation>
+  </element>
+  <complexType name="HeightAboveGroundType">
+    <sequence>
+      <element name="heightReference" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Height reference
+
+-- Definition --
+Element used as the high reference.
+
+-- Description --
+EXAMPLE: The height of the building has been captured up to the top of building.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element name="lowReference" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Low reference
+
+-- Definition --
+Element  as the low reference.
+
+-- Description --
+EXAMPLE: the height of the building has been captured from its the lowest ground point.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element name="status" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Name --
+Status
+
+-- Definition --
+The way the height has been captured.</documentation>
+          <appinfo>
+            <taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+          </appinfo>
+        </annotation>
+      </element>
+      <element name="value" type="gml:LengthType">
+        <annotation>
+          <documentation>-- Name --
+Value
+
+-- Definition --
+Value of the height above ground.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="HeightAboveGroundPropertyType">
+    <sequence>
+      <element ref="bu-base:HeightAboveGround"/>
+    </sequence>
+  </complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/CadastralParcels.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/CadastralParcels.xsd
@@ -1,0 +1,629 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:au="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:cp="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/cp/4.0" version="4.0">
+  <annotation>
+    <documentation>-- Definition --
+The application schema CadastralParcels contains the feature types CadastralParcel, CadastralBoundary and CadastralIndexSet.</documentation>
+  </annotation>
+  <import namespace="http://inspire.ec.europa.eu/schemas/au/4.0" schemaLocation="AdministrativeUnits.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/gn/4.0" schemaLocation="GeographicalNames.xsd"/>
+  <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/ml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element name="BasicPropertyUnit" substitutionGroup="gml:AbstractFeature" type="cp:BasicPropertyUnitType">
+    <annotation>
+      <documentation>-- Definition --
+The basic unit of ownership that is recorded in the land books, land registers or equivalent. It is defined by unique ownership and homogeneous real property rights, and may consist of one or more adjacent or geographically separate parcels.
+
+-- Description --
+SOURCE Adapted from UN ECE 2004.
+
+NOTE 1 In the INSPIRE context, basic property units are to be made available by member states where unique cadastral references are given only for basic property units and not for parcels.
+
+NOTE 2 In many (but not all) countries, the area of the basic property unit corresponds to the cadastral parcel itself.
+
+NOTE 3 Some countries, such as Finland, may also register officially basic property units without any area. These basic property units are considered out of the INSPIRE scope.
+
+NOTE 4 Some countries, such as Norway, may have parcels which belong to several basic property units.</documentation>
+    </annotation>
+  </element>
+  <complexType name="BasicPropertyUnitType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element name="nationalCadastralReference" type="string">
+            <annotation>
+              <documentation>-- Definition --
+Thematic identifier at national level, generally the full national code of the basic property unit. Must ensure the link to the national cadastral register or equivalent.
+
+-- Description --
+The national cadastral reference can be used also in further queries in national services.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="areaValue" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Registered area value giving quantification of the area projected on the horizontal plane of the cadastral parcels composing the basic property unit.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="gml:AreaType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Official date and time the basic property unit was/will be legally established.
+
+-- Description --
+NOTE This is the date and time the national cadastral reference can be used in legal acts.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which the basic property unit legally ceased/will cease to be used.
+
+-- Description --
+NOTE This is the date and time the national cadastral reference can no longer be used in legal acts.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="administrativeUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The administrative unit of lowest administrative level containing this basic property unit.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="BasicPropertyUnitPropertyType">
+    <sequence minOccurs="0">
+      <element ref="cp:BasicPropertyUnit"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="CadastralBoundary" substitutionGroup="gml:AbstractFeature" type="cp:CadastralBoundaryType">
+    <annotation>
+      <documentation>-- Definition --
+Part of the outline of a cadastral parcel. One cadastral boundary may be shared by two neighbouring cadastral parcels.
+
+-- Description --
+NOTE In the INSPIRE context, cadastral boundaries are to be made available by member states where absolute positional accuracy information is recorded for the cadastral boundary (attribute estimated accuracy).</documentation>
+    </annotation>
+  </element>
+  <complexType name="CadastralBoundaryType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="estimatedAccuracy" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Estimated absolute positional accuracy of the cadastral boundary in the used INSPIRE coordinate reference system. Absolute positional accuracy is the mean value of the positional uncertainties for a set of positions, where the positional uncertainties are the distance between a measured position and what is considered as the corresponding true position. 
+
+-- Description --
+NOTE This mean value may come from quality measures on a homogeneous population of cadastral boundaries or from an estimation based on the knowledge of the production processes and of their accuracy.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="gml:LengthType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="geometry" type="gml:CurvePropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Geometry of the cadastral boundary.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Official date and time the cadastral boundary was/will be legally established.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which the cadastral boundary legally ceased/will cease to be used.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="2" name="parcel" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The cadastral parcel(s) outlined by this cadastral boundary. A cadastral boundary may outline one or two cadastral parcels.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">cp:CadastralParcel</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="CadastralBoundaryPropertyType">
+    <sequence minOccurs="0">
+      <element ref="cp:CadastralBoundary"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="CadastralParcel" substitutionGroup="gml:AbstractFeature" type="cp:CadastralParcelType">
+    <annotation>
+      <documentation>-- Definition --
+Areas defined by cadastral registers or equivalent.
+
+-- Description --
+SOURCE [INSPIRE Directive:2007].
+
+NOTE As much as possible, in the INSPIRE context, cadastral parcels should be forming a partition of national territory. Cadastral parcel should be considered as a single area of Earth surface (land and/or water), under homogeneous real property rights and unique ownership, real property rights and ownership being defined by national law (adapted from UN ECE 2004 and WG-CPI, 2006). By unique ownership is meant that the ownership is held by one or several joint owners for the whole parcel.</documentation>
+    </annotation>
+  </element>
+  <complexType name="CadastralParcelType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element minOccurs="0" name="areaValue" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Registered area value giving quantification of the area projected on the horizontal plane of the cadastral parcel.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="gml:AreaType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="geometry" type="gml:GeometryPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Geometry of the cadastral parcel.
+
+-- Description --
+As much as possible, the geometry should be a single area.</documentation>
+            </annotation>
+          </element>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element name="label" type="string">
+            <annotation>
+              <documentation>-- Definition --
+Text commonly used to display the cadastral parcel identification.
+
+-- Description --
+NOTE 1 The label is usually the last part of the national cadastral reference.
+
+NOTE 2 The label can be used for label in portrayal.</documentation>
+            </annotation>
+          </element>
+          <element name="nationalCadastralReference" type="string">
+            <annotation>
+              <documentation>-- Definition --
+Thematic identifier at national level, generally the full national code of the cadastral parcel. Must ensure the link to the national cadastral register or equivalent.
+
+-- Description --
+The national cadastral reference can be used also in further queries in national services.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="referencePoint" nillable="true" type="gml:PointPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+A point within the cadastral parcel.
+
+-- Description --
+EXAMPLE The centroid of the cadastral parcel geometry.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Official date and time the cadastral parcel was/will be legally established.
+
+-- Description --
+NOTE This is the date and time the national cadastral reference can be used in legal acts.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which the cadastral parcel legally ceased/will cease to be used.
+
+-- Description --
+NOTE This is the date and time the national cadastral reference can no longer be used in legal acts.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="basicPropertyUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The basic property unit(s) containing this cadastral parcel.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">cp:BasicPropertyUnit</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="administrativeUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The administrative unit of lowest administrative level containing this cadastral parcel.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">au:AdministrativeUnit</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="zoning" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The cadastral zoning of lowest level containing this cadastral parcel.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">cp:CadastralZoning</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="CadastralParcelPropertyType">
+    <sequence minOccurs="0">
+      <element ref="cp:CadastralParcel"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="CadastralZoning" substitutionGroup="gml:AbstractFeature" type="cp:CadastralZoningType">
+    <annotation>
+      <documentation>-- Definition --
+Intermediary areas used in order to divide national territory into cadastral parcels.
+
+-- Description --
+NOTE 1 In the INSPIRE context, cadastral zonings are to be used to carry metadata information and to facilitate portrayal and search of data.
+
+NOTE 2 Cadastral zonings have generally been defined when cadastral maps were created for the first time.
+
+EXAMPLE Municipality, section, parish, district, block.</documentation>
+    </annotation>
+  </element>
+  <complexType name="CadastralZoningType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="estimatedAccuracy" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The estimated absolute positional accuracy of cadastral parcels within the cadastral zoning in the used INSPIRE coordinate reference system. Absolute positional accuracy is the mean value of the positional uncertainties for a set of positions, where the positional uncertainties are the distance between a measured position and what is considered as the corresponding true position.
+
+-- Description --
+NOTE This mean value may come from quality measures on a homogeneous population of cadastral parcels or from an estimation based on the knowledge of the production processes and of their accuracy.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="gml:LengthType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="geometry" type="gml:MultiSurfacePropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Geometry of the cadastral zoning.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of spatial object.
+
+-- Description --
+NOTE 
+An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element name="label" type="string">
+            <annotation>
+              <documentation>-- Definition --
+Text commonly used to display the cadastral zoning identification.
+
+-- Description --
+NOTE 1 The label is usually the last part of the national cadastral zoning reference or that reference itself or the name.
+
+NOTE 2 The label can be used for label in portrayal.</documentation>
+            </annotation>
+          </element>
+          <element name="level" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Level of the cadastral zoning in the national cadastral hierarchy.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" name="levelName" nillable="true" type="gmd:LocalisedCharacterString_PropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Name of the level of the cadastral zoning in the national cadastral hierarchy, in at least one official language of the European Union. 
+
+-- Description --
+EXAMPLE  For Spain, level name might be supplied as "municipio" (in Spanish) and as "municipality" (in English).</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="name" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Name of the cadastral zoning.
+
+-- Description --
+NOTE 1 Cadastral zonings which are also administrative units have generally a name.
+
+EXAMPLE Bordeaux, Copenhagen.
+
+NOTE 2 The language of the name should be filled in most cases, except if the data producer does not know in which language the names are.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="nationalCadastalZoningReference" type="string">
+            <annotation>
+              <documentation>-- Definition --
+Thematic identifier at national level, generally the full national code of the cadastral zoning.
+
+-- Description --
+EXAMPLE 03260000AB (France), 30133 (Austria), APD00F (Netherlands).</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="originalMapScaleDenominator" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The denominator in the scale of the original paper map (if any) to whose extent the cadastral zoning corresponds.
+
+-- Description --
+EXAMPLE 2000 means that original cadastral map was designed at scale 1: 2000.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="integer">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="referencePoint" nillable="true" type="gml:PointPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+A point within the cadastral zoning.
+
+-- Description --
+EXAMPLE The centroid of the cadastral parcel geometry.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Official date and time the cadastral zoning was/will be legally established.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which the cadastral zoning legally ceased/will cease to be used.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="upperLevelUnit" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The next upper level cadastral zoning containing this cadastral zoning.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">cp:CadastralZoning</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="CadastralZoningPropertyType">
+    <sequence minOccurs="0">
+      <element ref="cp:CadastralZoning"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/CommonTransportElements.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/CommonTransportElements.xsd
@@ -1,0 +1,786 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/tn/4.0" version="4.0">
+  <annotation>
+    <documentation>-- Definition --
+This package defines the types that are common for all transport networks subthemes.</documentation>
+  </annotation>
+  <import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/gn/4.0" schemaLocation="GeographicalNames.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/net/4.0" schemaLocation="Network.xsd"/>
+  <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element name="AccessRestriction" substitutionGroup="tn:TransportProperty" type="tn:AccessRestrictionType">
+    <annotation>
+      <documentation>-- Definition --
+A restriction on the access to a transport element.</documentation>
+    </annotation>
+  </element>
+  <complexType name="AccessRestrictionType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="restriction" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Nature of the access restriction.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="AccessRestrictionPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:AccessRestriction"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="ConditionOfFacility" substitutionGroup="tn:TransportProperty" type="tn:ConditionOfFacilityType">
+    <annotation>
+      <documentation>-- Definition --
+State of a transport network element with regards to its completion and use.</documentation>
+    </annotation>
+  </element>
+  <complexType name="ConditionOfFacilityType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="currentStatus" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Current status value of a transport network element with regards to its completion and use.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="ConditionOfFacilityPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:ConditionOfFacility"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="MaintenanceAuthority" substitutionGroup="tn:TransportProperty" type="tn:MaintenanceAuthorityType">
+    <annotation>
+      <documentation>-- Definition --
+The authority responsible for maintenance of the transport element.</documentation>
+    </annotation>
+  </element>
+  <complexType name="MaintenanceAuthorityType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="authority">
+            <annotation>
+              <documentation>-- Definition --
+Identification of the maintenance authority.</documentation>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMetadataPropertyType">
+                  <sequence>
+                    <element ref="gmd:CI_Citation"/>
+                  </sequence>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="MaintenanceAuthorityPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:MaintenanceAuthority"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="MarkerPost" substitutionGroup="tn:TransportPoint" type="tn:MarkerPostType">
+    <annotation>
+      <documentation>-- Definition --
+Reference marker placed along a route in a transport network, mostly at regular intervals, indicating the distance from the beginning of the route, or some other reference point, to the point where the marker is located.
+
+-- Description --
+EXAMPLE Examples of routes along which marker posts can be found are roads, railway lines and navigable waterways.</documentation>
+    </annotation>
+  </element>
+  <complexType name="MarkerPostType">
+    <complexContent>
+      <extension base="tn:TransportPointType">
+        <sequence>
+          <element name="location" type="gml:LengthType">
+            <annotation>
+              <documentation>-- Definition --
+Distance from the beginning of the route, or some other reference point, to the point where a marker post is located.</documentation>
+            </annotation>
+          </element>
+          <element name="route" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Route in a transport network along which the marker post is placed.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">tn:TransportLinkSet</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">tn:post</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="MarkerPostPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:MarkerPost"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="OwnerAuthority" substitutionGroup="tn:TransportProperty" type="tn:OwnerAuthorityType">
+    <annotation>
+      <documentation>-- Definition --
+The authority owning the transport element.</documentation>
+    </annotation>
+  </element>
+  <complexType name="OwnerAuthorityType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="authority">
+            <annotation>
+              <documentation>-- Definition --
+Identification of the owning authority.</documentation>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMetadataPropertyType">
+                  <sequence>
+                    <element ref="gmd:CI_Citation"/>
+                  </sequence>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="OwnerAuthorityPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:OwnerAuthority"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="RestrictionForVehicles" substitutionGroup="tn:TransportProperty" type="tn:RestrictionForVehiclesType">
+    <annotation>
+      <documentation>-- Definition --
+Restriction on vehicles on a transport element.</documentation>
+    </annotation>
+  </element>
+  <complexType name="RestrictionForVehiclesType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="measure" type="gml:MeasureType">
+            <annotation>
+              <documentation>-- Definition --
+The measure for the restriction .
+
+-- Description --
+SOURCE [Euroroads].</documentation>
+            </annotation>
+          </element>
+          <element name="restrictionType" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The type of restriction .
+
+-- Description --
+SOURCE [Euroroads].</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="RestrictionForVehiclesPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:RestrictionForVehicles"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="TrafficFlowDirection" substitutionGroup="tn:TransportProperty" type="tn:TrafficFlowDirectionType">
+    <annotation>
+      <documentation>-- Definition --
+Indicates the direction of the flow of traffic in relation to the direction of the transport link vector.</documentation>
+    </annotation>
+  </element>
+  <complexType name="TrafficFlowDirectionType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="direction" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Indicates the direction of the flow of traffic.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TrafficFlowDirectionPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TrafficFlowDirection"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportArea" substitutionGroup="net:NetworkArea" type="tn:TransportAreaType">
+    <annotation>
+      <documentation>-- Definition --
+Surface that represents the spatial extent of an element of a transport network.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportAreaType">
+    <complexContent>
+      <extension base="net:NetworkAreaType">
+        <sequence>
+          <element minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+A geographical name that is used to identify the transport network object in the real world. It provides a 'key' for implicitly associating different representations of the object.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport area started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport area no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportAreaPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportArea"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportLink" substitutionGroup="net:Link" type="tn:TransportLinkType">
+    <annotation>
+      <documentation>-- Definition --
+A linear spatial object that describes the geometry and connectivity of a transport network between two points in the network.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportLinkType">
+    <complexContent>
+      <extension base="net:LinkType">
+        <sequence>
+          <element minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+A geographical name that is used to identify the transport network object in the real world. It provides a 'key' for implicitly associating different representations of the object.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport link started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport link no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportLinkPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportLink"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportLinkSequence" substitutionGroup="net:LinkSequence" type="tn:TransportLinkSequenceType">
+    <annotation>
+      <documentation>-- Definition --
+A linear spatial object, composed of an ordered collection of transport links, which represents a continuous path in the transport network without any branches. The element has a defined beginning and end and every position on the transport link sequence is identifiable with one single parameter such as length. It describes an element of the transport network, characterized by one or more thematical identifiers and/or properties.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportLinkSequenceType">
+    <complexContent>
+      <extension base="net:LinkSequenceType">
+        <sequence>
+          <element minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+A geographical name that is used to identify the transport network object in the real world. It provides a 'key' for implicitly associating different representations of the object.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport link sequence started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport link sequence no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportLinkSequencePropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportLinkSequence"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportLinkSet" substitutionGroup="net:LinkSet" type="tn:TransportLinkSetType">
+    <annotation>
+      <documentation>-- Definition --
+A collection of transport link sequences and or individual transport links that has a specific function or significance in a transport network. 
+
+-- Description --
+NOTE
+This spatial object type supports the aggregation of links to form objects with branches, loops, parallel sequences of links, gaps, etc.
+
+EXAMPLE
+A dual carriageway road, as a collection of the two link sequences that represent each carriageway.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportLinkSetType">
+    <complexContent>
+      <extension base="net:LinkSetType">
+        <sequence>
+          <element minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+A geographical name that is used to identify the transport network object in the real world. It provides a 'key' for implicitly associating different representations of the object.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport link set started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport link set no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="post" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Marker post along a route in a transport network.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">tn:MarkerPost</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">tn:route</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportLinkSetPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportLinkSet"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="TransportNetwork" substitutionGroup="net:Network" type="tn:TransportNetworkType">
+    <annotation>
+      <documentation>-- Definition --
+Collection of network elements that belong to a single mode of transport.
+
+-- Description --
+NOTE Road, rail, water and air transport are always considered separate transport modes. Even within these four categories, multiple modes of transport can be defined, based on infrastructure, vehicle types, propulsion system, operation and/or other defining characteristics.
+
+EXAMPLE All road transport can be considered one mode of transport for some applications. For other applications, it might be necessary to distinguish between different public road transport networks. Within water transport, marine and inland water transport can be considered to be separate modes of transport for some applications, as they use different types of ships.</documentation>
+    </annotation>
+  </element>
+  <complexType name="TransportNetworkType">
+    <complexContent>
+      <extension base="net:NetworkType">
+        <sequence>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.</documentation>
+            </annotation>
+          </element>
+          <element name="typeOfTransport" type="tn:TransportTypeValueType">
+            <annotation>
+              <documentation>-- Definition --
+Type of transport network, based on the type of infrastructure the network uses.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportNetworkPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportNetwork"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportNode" substitutionGroup="net:Node" type="tn:TransportNodeType">
+    <annotation>
+      <documentation>-- Definition --
+A point spatial object which is used for connectivity.
+
+-- Description --
+Nodes are found at either end of the TransportLink.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportNodeType">
+    <complexContent>
+      <extension base="net:NodeType">
+        <sequence>
+          <element minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+A geographical name that is used to identify the transport network object in the real world. It provides a 'key' for implicitly associating different representations of the object.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport node started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport node no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportNodePropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportNode"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <complexType name="TransportObjectPropertyType">
+    <choice minOccurs="0">
+      <element ref="tn:TransportArea"/>
+      <element ref="tn:TransportLink"/>
+      <element ref="tn:TransportLinkSequence"/>
+      <element ref="tn:TransportLinkSet"/>
+      <element ref="tn:TransportNode"/>
+      <element ref="tn:TransportPoint"/>
+    </choice>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportPoint" substitutionGroup="net:NetworkElement" type="tn:TransportPointType">
+    <annotation>
+      <documentation>-- Definition --
+A point spatial object - which is not a node - that represents the position of an element of a transport network.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportPointType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence>
+          <element minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+A geographical name that is used to identify the transport network object in the real world. It provides a 'key' for implicitly associating different representations of the object.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element name="geometry" type="gml:PointPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+The location of the transport point.</documentation>
+            </annotation>
+          </element>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport point started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport point no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportPointPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportPoint"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="TransportProperty" substitutionGroup="net:NetworkProperty" type="tn:TransportPropertyType">
+    <annotation>
+      <documentation>-- Definition --
+A reference to a property that falls upon the network. This property can apply to the whole of the network element it is associated with or - for linear spatial objects - be described using linear referencing.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="TransportPropertyType">
+    <complexContent>
+      <extension base="net:NetworkPropertyType">
+        <sequence>
+          <element name="validFrom" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time when the transport property started to exist in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="validTo" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+The time from which the transport property no longer exists in the real world.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="TransportPropertyPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:TransportProperty"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <simpleType name="TransportTypeValueType">
+    <annotation>
+      <documentation>-- Definition --
+Possible types on transport networks.</documentation>
+    </annotation>
+    <restriction base="string">
+      <enumeration value="air">
+        <annotation>
+          <documentation>-- Definition --
+The transport network consists of transport by air.</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="cable">
+        <annotation>
+          <documentation>-- Definition --
+The transport network consists of transport by cable.</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="rail">
+        <annotation>
+          <documentation>-- Definition --
+The transport network consists of transport by rail.</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="road">
+        <annotation>
+          <documentation>-- Definition --
+The transport network consists of transport by road.</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="water">
+        <annotation>
+          <documentation>-- Definition --
+The transport network consists of transport by water.</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+  <element name="VerticalPosition" substitutionGroup="tn:TransportProperty" type="tn:VerticalPositionType">
+    <annotation>
+      <documentation>-- Definition --
+Vertical level relative to other transport network elements.</documentation>
+    </annotation>
+  </element>
+  <complexType name="VerticalPositionType">
+    <complexContent>
+      <extension base="tn:TransportPropertyType">
+        <sequence>
+          <element name="verticalPosition" type="base:VerticalPositionValueType">
+            <annotation>
+              <documentation>-- Definition --
+Relative vertical position of the transport element.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="VerticalPositionPropertyType">
+    <sequence minOccurs="0">
+      <element ref="tn:VerticalPosition"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/GeographicalNames.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/GeographicalNames.xsd
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/gn/4.0" version="4.0">
+  <import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+  <import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element name="GeographicalName" substitutionGroup="gml:AbstractObject" type="gn:GeographicalNameType">
+    <annotation>
+      <documentation>-- Definition --
+Proper noun applied to a real world entity.</documentation>
+    </annotation>
+  </element>
+  <complexType name="GeographicalNameType">
+    <sequence>
+      <element name="language" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Language of the name, given as a three letters code, in accordance with either ISO 639-3 or ISO 639-5.
+
+-- Description --
+NOTE 1More precisely, this definition refers to the language used by the community that uses the name.
+
+NOTE 2 The code "mul" for "multilingual" should not be used in general. However it can be used in rare cases like official names composed of two names in different languages. For example, "Vitoria-Gasteiz" is such a multilingual official name in Spain.
+
+NOTE 3 Even if this attribute is "voidable" for pragmatic reasons, it is of first importance in several use cases in the multi-language context of Europe.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element name="nativeness" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+Information enabling to acknowledge if the name is the one that is/was used in the area where the spatial object is situated at the instant when the name is/was in use.</documentation>
+        </annotation>
+      </element>
+      <element name="nameStatus" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+Qualitative information enabling to discern which credit should be given to the name with respect to its standardisation and/or its topicality.
+
+-- Description --
+NOTE The Geographical Names application schema does not explicitly make a preference between different names (e.g. official endonyms) of a specific real world entity. The necessary information for making the preference (e.g. the linguistic status of the administrative or geographic area in question), for a certain use case, must be obtained from other data or information sources. For example, the status of the language of the name may be known through queries on the geometries of named places against the geometry of administrative units recorded in a certain source with the language statuses information.</documentation>
+        </annotation>
+      </element>
+      <element name="sourceOfName" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Original data source from which the geographical name is taken from and integrated in the data set providing/publishing it. For some named spatial objects it might refer again to the publishing data set if no other information is available.
+
+-- Description --
+EXAMPLES Gazetteer, geographical names data set.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element name="pronunciation" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Proper, correct or standard (standard within the linguistic community concerned) pronunciation of the geographical name.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2006].</documentation>
+        </annotation>
+        <complexType>
+          <sequence>
+            <element ref="gn:PronunciationOfName"/>
+          </sequence>
+          <attribute name="nilReason" type="gml:NilReasonType"/>
+        </complexType>
+      </element>
+      <element maxOccurs="unbounded" name="spelling" type="gn:SpellingOfNamePropertyType">
+        <annotation>
+          <documentation>-- Definition --
+A proper way of writing the geographical name.
+
+-- Description --
+NOTE 1 Different spellings should only be used for names rendered in different scripts. .
+
+NOTE 2 While a particular GeographicalName should only have one spelling in a given script, providing different spellings in the same script should be done through the provision of different geographical names associated with the same named place.</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="grammaticalGender" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+Class of nouns reflected in the behaviour of associated words.
+
+-- Description --
+NOTE the attribute has cardinality [0..1] and is voidable, which means that:
+&lt;ul&gt;
+	&lt;li&gt;in case the concept of grammatical gender has no sense for a given name (i.e. the attribute is not applicable), the attribute should not be provided.&lt;/li&gt;
+	&lt;li&gt;in case the concept of grammatical gender has some sense for the name but is unknown, the attribute should be provided but &lt;i&gt;void&lt;/i&gt;.  &lt;/li&gt;
+&lt;/ul&gt;</documentation>
+        </annotation>
+      </element>
+      <element minOccurs="0" name="grammaticalNumber" nillable="true" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+Grammatical category of nouns that expresses count distinctions.
+
+-- Description --
+NOTE the attribute has cardinality [0..1] and is voidable, which means that:
+&lt;ul&gt;
+	&lt;li&gt;in case the concept of grammatical number has no sense for a given name (i.e. the attribute is not applicable), the attribute should not be provided.&lt;/li&gt;
+	&lt;li&gt;in case the concept of grammatical number has some sense for the name but is unknown, the attribute should be provided but &lt;i&gt;void&lt;/i&gt;.&lt;/li&gt;
+&lt;/ul&gt;</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="GeographicalNamePropertyType">
+    <sequence>
+      <element ref="gn:GeographicalName"/>
+    </sequence>
+  </complexType>
+  <element name="NamedPlace" substitutionGroup="gml:AbstractFeature" type="gn:NamedPlaceType">
+    <annotation>
+      <documentation>-- Definition --
+Any real world entity referred to by one or several proper nouns.</documentation>
+    </annotation>
+  </element>
+  <complexType name="NamedPlaceType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="geometry" type="gml:GeometryPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Geometry associated to the named place. This data specification does not restrict the geometry types. 
+
+-- Description --
+NOTE 1 The most common geometry types for a named place are a reference point (modelled as GM_Point), a more precise geometry of the footprint (typically modelled as GM_Curve or GM_Surface), or a bounding box (to be modelled as a GM_Surface).
+
+NOTE 2 If the geometry depicts the spatial footprint of the named place, a reference point and a bounding box could be derived from it. However, this specification does not require the explicit provision of any specific type of geometry such as bounding boxes or reference points.
+
+NOTE 3 To avoid any misunderstanding, note that null geometry is not allowed by this specification.
+
+NOTE 4 3D geometries are not really required for Geographical Names, but the model allows for it, so a data provider may publish it.</documentation>
+            </annotation>
+          </element>
+          <element name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="leastDetailedViewingResolution" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Resolution, expressed as the inverse of an indicative scale or a ground distance, above which the named place and its associated name(s) should no longer be displayed in a basic viewing service.
+
+-- Description --
+NOTE 1This information may be used to determine if the names of the named place should be displayed at a given scale of display, only in the context of basic viewing services intending to show the content of the data set containing names. Even if this information is a valuable one for mapping in general, it is only approximate; cartographic services intending to produce high quality maps should certainly rely on other criteria and techniques for selecting names for the map.
+
+NOTE 2 Even if this attribute is "voidable" for practical reasons linked to its availability in data sources, this information may be of first importance for viewing services. There are great chances that viewing services will inefficiently manage named places having this attribute void.
+
+EXAMPLES The following examples use the equivalentScale attribute of MD_Resolution to express the attribute value.
+- Names of important cities in Europe may be displayed at all viewing scales greater than 1/5,000,000. In this case, the value of the attribute is 5,000,000
+- Names of small hamlets may only be displayed from all viewing scale greater than 1/25,000. In this case, the value of the attribute is 25,000
+- Names of countries may be displayed at any small scale. In this case, this attribute is not filled.
+
+NOTE 3 If the data set contain multiple representations of the same real world entity represented at different levels of detail, the scale ranges defined by the attributes leastDetailedViewingResolution and mostDetailedViewingResolution should not overlap, in order to avoid displaying the same names several times.
+
+NOTE 4 The geometry of the named place should have a level of detail (i.e. resolution, granularity, precision, etc.) roughly compatible with its associated viewing scales.</documentation>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMetadataPropertyType">
+                  <sequence>
+                    <element ref="gmd:MD_Resolution"/>
+                  </sequence>
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="localType" nillable="true" type="gmd:LocalisedCharacterString_PropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Characterisation of the kind of entity designated by geographical name(s), as defined by the data provider, given in at least in one official language of the European Union.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2007].
+
+NOTE Local types may be defined in additional European languages, either EU official languages or other languages such as the language(s) of the geographical names provided.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="mostDetailedViewingResolution" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Resolution, expressed as the inverse of an indicative scale or a ground distance, below which the named place and its associated name(s) should no longer be displayed in a basic viewing service.
+
+-- Description --
+NOTE See Description of leastDetailedViewingResolution
+
+EXAMPLES The following examples use the equivalentScale attribute of MD_Resolution to express the attribute value.
+- Names of wide areas like mountain ranges may not be displayed at all in viewing scales greater than 1/100,000. In this case, the value of the attribute is 100,000
+- Names of small hamlets may be displayed at any large scale. In this case, this attribute is not filled.</documentation>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMetadataPropertyType">
+                  <sequence>
+                    <element ref="gmd:MD_Resolution"/>
+                  </sequence>
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="name" type="gn:GeographicalNamePropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Name of the named place.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="relatedSpatialObject" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Identifier of a spatial object representing the same entity but appearing in other themes of INSPIRE, if any.
+
+-- Description --
+NOTE If no identifier is provided with features of other INSPIRE themes, those features can of course not be referred by the NamedPlace.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="base:Identifier"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="type" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Characterisation of the kind of entity designated by geographical name(s).
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2007].
+
+NOTE 1 This attribute should be consistent with the attribute 'relatedSpatialObject'. More precisely, if the attribute 'relatedSpatialObject' is filled in, the attribute 'type' should be filled in, and its value(s) should be consistent with the spatial data theme(s) of the related object(s).
+
+NOTE 2 Even if this attribute may introduce some redundancy with the attribute 'relatedSpatialObject', it has to be filled in order to allow to use geographical names on their own without accessing to any other INSPIRE data set, which may be necessary in most cases.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="NamedPlacePropertyType">
+    <sequence minOccurs="0">
+      <element ref="gn:NamedPlace"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="PronunciationOfName" substitutionGroup="gml:AbstractObject" type="gn:PronunciationOfNameType">
+    <annotation>
+      <documentation>-- Definition --
+Proper, correct or standard (standard within the linguistic community concerned) pronunciation of a name.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2006].</documentation>
+    </annotation>
+  </element>
+  <complexType name="PronunciationOfNameType">
+    <sequence>
+      <element minOccurs="0" name="pronunciationSoundLink" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Proper, correct or standard (standard within the linguistic community concerned) pronunciation of a name, expressed by a link to any sound file.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2006].</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="anyURI">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="pronunciationIPA" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Proper, correct or standard (standard within the linguistic community concerned) pronunciation of a name, expressed in International Phonetic Alphabet (IPA).
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2006].</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="PronunciationOfNamePropertyType">
+    <sequence>
+      <element ref="gn:PronunciationOfName"/>
+    </sequence>
+  </complexType>
+  <element name="SpellingOfName" substitutionGroup="gml:AbstractObject" type="gn:SpellingOfNameType">
+    <annotation>
+      <documentation>-- Definition --
+Proper way of writing a name.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Manual 2006].
+
+NOTE Proper spelling means the writing of a name with the correct capitalisation and the correct letters and diacritics present in an accepted standard order.</documentation>
+    </annotation>
+  </element>
+  <complexType name="SpellingOfNameType">
+    <sequence>
+      <element name="text" type="string">
+        <annotation>
+          <documentation>-- Definition --
+Way the name is written.</documentation>
+        </annotation>
+      </element>
+      <element name="script" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Set of graphic symbols (for example an alphabet) employed in writing the name, expressed using the four letters codes defined in ISO 15924, where applicable.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Glossary 2007].
+
+EXAMPLES Cyrillic, Greek, Roman/Latin scripts.
+
+NOTE 1The four letter codes for Latin (Roman), Cyrillic and Greek script are "Latn", "Cyrl" and "Grek", respectively.
+
+NOTE 2 In rare cases other codes could be used (for other scripts than Latin, Greek and Cyrillic). However, this should mainly apply for historical names in historical scripts.
+
+NOTE 3 This attribute is of first importance in the multi-scriptual context of Europe.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+      <element minOccurs="0" name="transliterationScheme" nillable="true">
+        <annotation>
+          <documentation>-- Definition --
+Method used for the names conversion between different scripts.
+
+-- Description --
+SOURCE Adapted from [UNGEGN Glossary 2007].
+
+NOTE 1 This attribute should be filled for any transliterated spellings. If the transliteration scheme used is recorded in codelists maintained by ISO or UN, those codes should be preferred.</documentation>
+        </annotation>
+        <complexType>
+          <simpleContent>
+            <extension base="string">
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </extension>
+          </simpleContent>
+        </complexType>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="SpellingOfNamePropertyType">
+    <sequence>
+      <element ref="gn:SpellingOfName"/>
+    </sequence>
+  </complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/GeophysicsCore.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/GeophysicsCore.xsd
@@ -1,0 +1,492 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:base2="http://inspire.ec.europa.eu/schemas/base2/2.0" xmlns:ge_gp="http://inspire.ec.europa.eu/schemas/ge_gp/4.0" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:sams="http://www.opengis.net/samplingSpatial/2.0" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/ge_gp/4.0" version="4.0.1">
+	<import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+	<import namespace="http://inspire.ec.europa.eu/schemas/base2/2.0" schemaLocation="BaseTypes2.xsd"/>
+	<import namespace="http://www.interactive-instruments.de/ShapeChange/AppInfo" schemaLocation="ShapeChangeAppinfo.xsd"/>
+	<import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+	<import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<import namespace="http://www.opengis.net/samplingSpatial/2.0" schemaLocation="spatialSamplingFeature.xsd"/>
+	<!-- v4.0.1 of this schema released in INSPIRE schema release v.2021.2.
+	     Change performed: Added type and nilReason to the distributioninfo - non breaking change - bugfix.
+	     See https://github.com/INSPIRE-MIF/helpdesk-validator/releases/v2021.2 -->
+	<element name="Campaign" substitutionGroup="ge_gp:GeophObjectSet" type="ge_gp:CampaignType">
+
+		<annotation>
+			<documentation>-- Definition --
+Geophysical activity extending over a limited time range and limited area for producing similar geophysical measurements, processing results or models.
+
+-- Description --
+Campaigns can be considered as parents of geophysical measurements or models. Children may refer to parent campaigns through the largerWork  identifier.</documentation>
+		</annotation>
+	</element>
+	<complexType name="CampaignType">
+		<complexContent>
+			<extension base="ge_gp:GeophObjectSetType">
+				<sequence>
+					<element name="campaignType" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Type of activity to produce data
+
+-- Description --
+Value shall be one of the items defined in codelist CampaignTypeValue</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+					<element name="surveyType" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Type of geophysical survey
+
+-- Description --
+The geophysical method is specified by this attribute. Value shall be one of the items defined in codelist SurveyTypeValue.</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+					<element name="client" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Party for which data was created.</documentation>
+						</annotation>
+						<complexType>
+							<sequence>
+								<element ref="base2:RelatedParty"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>
+					</element>
+					<element name="contractor" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Party by which data was created
+
+-- Description --
+Party responsible for creating the data related to the campaign</documentation>
+						</annotation>
+						<complexType>
+							<sequence>
+								<element ref="base2:RelatedParty"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="CampaignPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:Campaign"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element abstract="true" name="GeophMeasurement" substitutionGroup="ge_gp:GeophObject" type="ge_gp:GeophMeasurementType">
+		<annotation>
+			<documentation>-- Definition --
+Generic spatial object type for geophysical measurements.
+
+-- Description --
+Geophysical measurements collect data outside or on the boundary of the observed spatial domain.</documentation>
+		</annotation>
+	</element>
+	<complexType abstract="true" name="GeophMeasurementType">
+		<complexContent>
+			<extension base="ge_gp:GeophObjectType">
+				<sequence>
+					<element maxOccurs="unbounded" name="relatedModel" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Identifier of the geophysical model that was created from the measurement
+
+-- Description --
+Results of the measurement can be referenced by these identifiers.</documentation>
+						</annotation>
+						<complexType>
+							<sequence>
+								<element ref="base:Identifier"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>
+					</element>
+					<element name="platformType" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Platform from which the measurement was carried out
+
+-- Description --
+Values to be used are defined in codelist  PlatformTypeValue.</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+					<element maxOccurs="unbounded" name="relatedNetwork" nillable="true" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Name of a national or international observation network to which the facility belongs, or  to which measured data is reported.
+
+-- Description --
+Permanent measuring installations maz be part of larger observation networks. It means that observation data is regularly sent to the archives of the related network in an official way.</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GeophMeasurementPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:GeophMeasurement"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element abstract="true" name="GeophObject" substitutionGroup="sams:SF_SpatialSamplingFeature" type="ge_gp:GeophObjectType">
+		<annotation>
+			<documentation>-- Definition --
+A generic class for  geophysical objects. 
+
+-- Description --
+GeophObject models single geophysical entities that are used for spatial sampling either by means of data acquisition or data processing.</documentation>
+		</annotation>
+	</element>
+	<complexType abstract="true" name="GeophObjectType">
+		<complexContent>
+			<extension base="sams:SF_SpatialSamplingFeatureType">
+				<sequence>
+					<element name="inspireId" type="base:IdentifierPropertyType">
+						<annotation>
+							<documentation>-- Definition --
+External object identifier of the measurement.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+						</annotation>
+					</element>
+					<element name="citation">
+						<annotation>
+							<documentation>-- Definition --
+Citation of geophysical documentation
+
+-- Description --
+Used for title,  date of related documentation and URL for  online access. At the minimum a short name (title) shall be given.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence minOccurs="0">
+										<element ref="base2:DocumentCitation"/>
+									</sequence>
+									<attributeGroup ref="gml:AssociationAttributeGroup"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element maxOccurs="unbounded" name="projectedGeometry" type="gml:GeometryPropertyType">
+						<annotation>
+							<documentation>-- Definition --
+2D projection of the feature to the ground surface (as a representative point, curve or bounding polygon) to be used by an INSPIRE view service to display the spatial object location on a map. 
+
+-- Description --
+When measurement setup is 3 dimensional, it is necessary to define a 2D geometry for displaying purposes. It shall be the 2D projection of the spatial object on the ground surface. Allowed types: point, track and outline. Examples: projected geometry of a borehole logging measurement is a point coincident with the borehole collar location. Projected geometry of a 3D multielectrode DC measurement is a polygon</documentation>
+						</annotation>
+					</element>
+					<element name="verticalExtent" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Vertical extent of the range of interest. 
+
+-- Description --
+This parameter serves discovery purposes. It may refer both to the vertical extent of the measurement setup (p.e. borehole logging) or the extent of the range where processed data is spatially referenced to (Vertical Electric Sounding). The aim is to give an idea to the user about the estimated depth of investigation.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMetadataPropertyType">
+									<sequence minOccurs="0">
+										<element ref="gmd:EX_VerticalExtent"/>
+									</sequence>
+									<attributeGroup ref="gml:AssociationAttributeGroup"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element name="distributionInfo" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Distribution metadata
+
+-- Description --
+Data providers may use external services to provide information on a geophysical measurement. Links to the access points, description of ordering procedures or external services can be added in distributionInfo, that is an ISO MD_Distributor record.</documentation>
+						</annotation>
+<!--SM-Oct 2021 added type for the distributioninfo element -->
+						<complexType>
+							<sequence>
+								<element ref="gmd:MD_Distributor"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>						
+					</element>
+					<element maxOccurs="unbounded" name="largerWork" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Identifier of a larger work dataset, typically a campaign or project
+
+-- Description --
+Measurements are usually made in campaigns. The largerWork identifier points to the parent Campaign or Project</documentation>
+						</annotation>
+						<complexType>
+							<sequence>
+								<element ref="base:Identifier"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GeophObjectPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:GeophObject"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="GeophObjectSet" substitutionGroup="sams:SF_SpatialSamplingFeature" type="ge_gp:GeophObjectSetType">
+		<annotation>
+			<documentation>-- Definition --
+Generic class for collections of geophysical objects
+
+-- Description --
+It is a set of geophysical objects that are grouped by some common property. p.e: created in the same measuring campaign. GeophObjectSets are used for spatial sampling either by means of data acquisition or data processing. The produced  result of a geophObjectSet is always collective, e.g. a map constructed from the results of the individual member objects.</documentation>
+		</annotation>
+	</element>
+	<complexType name="GeophObjectSetType">
+		<complexContent>
+			<extension base="sams:SF_SpatialSamplingFeatureType">
+				<sequence>
+					<element name="inspireId" type="base:IdentifierPropertyType">
+						<annotation>
+							<documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+						</annotation>
+					</element>
+					<element name="citation">
+						<annotation>
+							<documentation>-- Definition --
+Citation of geophysical documentation
+
+-- Description --
+Used for title,  date of related documentation and URL for  online access. At the minimum a short name (title) shall be given.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMemberType">
+									<sequence minOccurs="0">
+										<element ref="base2:DocumentCitation"/>
+									</sequence>
+									<attributeGroup ref="gml:AssociationAttributeGroup"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element name="verticalExtent" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Vertical extent of the range of interest. 
+
+-- Description --
+This parameter serves discovery purposes. It may refer both to the vertical extent of the setup of measurements within the survey, or the extent of the range where processed data is spatially referenced to (estimated depth of investigation). The aim is to give an idea to the user about the estimated depth of investigation.</documentation>
+						</annotation>
+						<complexType>
+							<complexContent>
+								<extension base="gml:AbstractMetadataPropertyType">
+									<sequence minOccurs="0">
+										<element ref="gmd:EX_VerticalExtent"/>
+									</sequence>
+									<attributeGroup ref="gml:AssociationAttributeGroup"/>
+								</extension>
+							</complexContent>
+						</complexType>
+					</element>
+					<element name="distributionInfo" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Distribution metadata
+
+-- Description --
+Data providers may use external services to provide access to data or information on a survey. Links to the access points, description of ordering procedures, fees can be added in distributionInfo that is an ISO MD_Distributor record.</documentation>
+						</annotation>
+<!--SM-Oct 2021 added type for the distributioninfo element -->
+						<complexType>
+							<sequence>
+								<element ref="gmd:MD_Distributor"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>
+												
+						
+					</element>
+					<element maxOccurs="unbounded" name="projectedGeometry" type="gml:GeometryPropertyType">
+						<annotation>
+							<documentation>-- Definition --
+2D projection of the feature to the ground surface (as a representative point, curve or bounding polygon) to be used by an INSPIRE view service to display the spatial object on a map.. 
+
+-- Description --
+Projected geometry of the object set  (survey), that is usually the bounding polygon of the working area.</documentation>
+						</annotation>
+					</element>
+					<element maxOccurs="unbounded" name="largerWork" nillable="true">
+						<annotation>
+							<documentation>-- Definition --
+Identifier of a larger work dataset
+
+-- Description --
+The largerWork identifier points to the parent Campaign or Project</documentation>
+						</annotation>
+						<complexType>
+							<sequence>
+								<element ref="base:Identifier"/>
+							</sequence>
+							<attribute name="nilReason" type="gml:NilReasonType"/>
+						</complexType>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GeophObjectSetPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:GeophObjectSet"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="GeophProfile" substitutionGroup="ge_gp:GeophMeasurement" type="ge_gp:GeophProfileType">
+		<annotation>
+			<documentation>-- Definition --
+Geophysical measurement spatially referenced to a curve
+
+-- Description --
+Used to collect data along a curve. Examples: 2D seismic line (field measurement), borehole logging, airborne geophysical flight line
+
+NOTE1. Processing results of geophProfiles are often vertical surface coverages</documentation>
+		</annotation>
+	</element>
+	<complexType name="GeophProfileType">
+		<complexContent>
+			<extension base="ge_gp:GeophMeasurementType">
+				<sequence>
+					<element name="profileType" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Type of geophysical profile</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GeophProfilePropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:GeophProfile"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="GeophStation" substitutionGroup="ge_gp:GeophMeasurement" type="ge_gp:GeophStationType">
+		<annotation>
+			<documentation>-- Definition --
+Geophysical measurement spatially referenced to a single point location
+
+-- Description --
+Used to collect data at a single location. The source-sensor setup may be elongated or two dimensional, but the collected data is spatially referenced to a single point. Example: Gravity station, Magnetic station
+
+NOTE 1. Processing results of geophStations are often vertical curve coverages</documentation>
+		</annotation>
+	</element>
+	<complexType name="GeophStationType">
+		<complexContent>
+			<extension base="ge_gp:GeophMeasurementType">
+				<sequence>
+					<element name="stationType" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Type of geophysical station</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+					<element maxOccurs="unbounded" name="stationRank" nillable="true" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Geophysical stations may be part of a hierarchical system. Rank is proportional to the importance of a station 
+
+-- Description --
+Significance of stations can be very different even for the same geophysical method. Rank maz take the following values: 1stOrderBase, 2ndOrderBase, secularStation, observatory. Base stations are used to tie local measurements to higher level networks. Secular stations are visited from time to time to detect long term temporal changes of physical parameters. Observatories are important facilities that collect data continuously, or on a regular basis.</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GeophStationPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:GeophStation"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+	<element name="GeophSwath" substitutionGroup="ge_gp:GeophMeasurement" type="ge_gp:GeophSwathType">
+		<annotation>
+			<documentation>-- Definition --
+Geophysical measurement spatially referenced to a surface
+
+-- Description --
+Used to collect data over a surface. Example: 3D seismic swath
+
+NOTE1. Processing results of geophSwaths can be both surface and solid coverages</documentation>
+		</annotation>
+	</element>
+	<complexType name="GeophSwathType">
+		<complexContent>
+			<extension base="ge_gp:GeophMeasurementType">
+				<sequence>
+					<element name="swathType" type="gml:ReferenceType">
+						<annotation>
+							<documentation>-- Definition --
+Type of geophysical swath</documentation>
+							<appinfo>
+								<taggedValue xmlns="http://www.interactive-instruments.de/ShapeChange/AppInfo" tag="obligation">implementingRule</taggedValue>
+							</appinfo>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GeophSwathPropertyType">
+		<sequence minOccurs="0">
+			<element ref="ge_gp:GeophSwath"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+		<attributeGroup ref="gml:OwnershipAttributeGroup"/>
+	</complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/Network.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/Network.xsd
@@ -1,0 +1,690 @@
+<?xml version="1.0" encoding="UTF-8"?><schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:base="http://inspire.ec.europa.eu/schemas/base/3.3" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gn="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" elementFormDefault="qualified" targetNamespace="http://inspire.ec.europa.eu/schemas/net/4.0" version="4.0">
+  <annotation>
+    <documentation>Generic application schema for networks.</documentation>
+  </annotation>
+  <import namespace="http://inspire.ec.europa.eu/schemas/base/3.3" schemaLocation="BaseTypes.xsd"/>
+  <import namespace="http://inspire.ec.europa.eu/schemas/gn/4.0" schemaLocation="GeographicalNames.xsd"/>
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+  <!--XML Schema document created by ShapeChange-->
+  <element name="CrossReference" substitutionGroup="gml:AbstractFeature" type="net:CrossReferenceType">
+    <annotation>
+      <documentation>-- Definition --
+Represents a reference between two elements in the same network. 
+
+-- Description --
+The cross reference may represent the case where two elements are different representations of the same spatial object.</documentation>
+    </annotation>
+  </element>
+  <complexType name="CrossReferenceType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element maxOccurs="2" minOccurs="2" name="element" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The cross referenced elements</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:NetworkElement</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="CrossReferencePropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:CrossReference"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="DirectedLink" substitutionGroup="gml:AbstractObject" type="net:DirectedLinkType">
+    <annotation>
+      <documentation>-- Definition --
+A link either in its positive or negative direction.</documentation>
+    </annotation>
+  </element>
+  <complexType name="DirectedLinkType">
+    <sequence>
+      <element name="direction" type="gml:SignType">
+        <annotation>
+          <documentation>-- Definition --
+Indicates if the directed link agrees (positive) or disagrees (negative) with the positive direction of the link.</documentation>
+        </annotation>
+      </element>
+      <element name="link" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+The link</documentation>
+          <appinfo>
+            <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Link</targetElement>
+          </appinfo>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="DirectedLinkPropertyType">
+    <sequence>
+      <element ref="net:DirectedLink"/>
+    </sequence>
+  </complexType>
+  <element abstract="true" name="GeneralisedLink" substitutionGroup="net:NetworkElement" type="net:GeneralisedLinkType">
+    <annotation>
+      <documentation>-- Definition --
+Abstract base type representing a linear network element that may be used as a target in linear referencing.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="GeneralisedLinkType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="GeneralisedLinkPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:GeneralisedLink"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="GradeSeparatedCrossing" substitutionGroup="net:NetworkElement" type="net:GradeSeparatedCrossingType">
+    <annotation>
+      <documentation>-- Definition --
+Indicator which of two or more intersecting elements is/are below and which is/are above, to be used if elevation coordinates are not present or cannot be trusted.
+
+-- Description --
+NOTE 1 In most cases, the number of elements will be two.
+
+NOTE 2 In the normal case this is when elements intersect in the x/y-plane when the z coordinate is not present or is not accurate enough.</documentation>
+    </annotation>
+  </element>
+  <complexType name="GradeSeparatedCrossingType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="2" name="element" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Sequence of crossing links. The order reflects their elevation; the first link is the lower link.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Link</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="GradeSeparatedCrossingPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:GradeSeparatedCrossing"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="Link" substitutionGroup="net:GeneralisedLink" type="net:LinkType">
+    <annotation>
+      <documentation>-- Definition --
+Curvilinear network element that connects two positions and represents a homogeneous path in the network. The connected positions may be represented as nodes.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="LinkType">
+    <complexContent>
+      <extension base="net:GeneralisedLinkType">
+        <sequence>
+          <element name="centrelineGeometry" type="gml:CurvePropertyType">
+            <annotation>
+              <documentation>-- Definition --
+The geometry that represents the centreline of the link.</documentation>
+            </annotation>
+          </element>
+          <element name="fictitious" type="boolean">
+            <annotation>
+              <documentation>-- Definition --
+Indicator that the centreline geometry of the link is a straight line with no intermediate control points &amp;ndash; unless the straight line represents the geography in the resolution of the data set appropriately.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="endNode" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The optional end node for this link. The end node may be the same instance as the start node.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Node</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">net:spokeEnd</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="startNode" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The optional start node for this link.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Node</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">net:spokeStart</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="LinkPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:Link"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="LinkReference" substitutionGroup="net:NetworkReference" type="net:LinkReferenceType">
+    <annotation>
+      <documentation>-- Definition --
+A network reference to a linear network element.</documentation>
+    </annotation>
+  </element>
+  <complexType name="LinkReferenceType">
+    <complexContent>
+      <extension base="net:NetworkReferenceType">
+        <sequence>
+          <element name="applicableDirection" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The directions of the generalised link to which the reference applies.
+
+In cases where a property does not apply &lt;i&gt;to&lt;/i&gt; a direction along a link, but represents a phenomenon &lt;i&gt;along&lt;/i&gt; a link, &amp;ldquo;inDirection&amp;rdquo; refers to the right side in the direction of the link.
+
+-- Description --
+EXAMPLE A speed limit is a property that applies to a direction of the link (or both directions) while a house number is a phenomenon along a link.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="LinkReferencePropertyType">
+    <sequence>
+      <element ref="net:LinkReference"/>
+    </sequence>
+  </complexType>
+  <element abstract="true" name="LinkSequence" substitutionGroup="net:GeneralisedLink" type="net:LinkSequenceType">
+    <annotation>
+      <documentation>-- Definition --
+A network element which represents a continuous path in the network without any branches. The element has a defined beginning and end and every position on the link sequence is identifiable with one single parameter such as length. 
+
+-- Description --
+EXAMPLE A link sequence may represent a route.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="LinkSequenceType">
+    <complexContent>
+      <extension base="net:GeneralisedLinkType">
+        <sequence>
+          <element maxOccurs="unbounded" name="link" type="net:DirectedLinkPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+The ordered collection of directed links that constitute the link sequence.</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="LinkSequencePropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:LinkSequence"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="LinkSet" substitutionGroup="net:NetworkElement" type="net:LinkSetType">
+    <annotation>
+      <documentation>-- Definition --
+A collection of link sequences and/or individual links that has a specific function or significance in a network. 
+
+-- Description --
+NOTE This spatial object type supports the aggregation of links to form objects with branches, loops, parallel sequences of links, gaps, etc.
+
+EXAMPLE A dual carriageway road, as a collection of the two link sequences that represent each carriageway.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="LinkSetType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence>
+          <element maxOccurs="unbounded" name="link">
+            <annotation>
+              <documentation>-- Definition --
+The set of links and link sequences that constitute the link set.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:GeneralisedLink</targetElement>
+              </appinfo>
+            </annotation>
+            <complexType>
+              <complexContent>
+                <extension base="gml:AbstractMemberType">
+                  <sequence/>
+                  <attributeGroup ref="gml:AssociationAttributeGroup"/>
+                </extension>
+              </complexContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="LinkSetPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:LinkSet"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="Network" substitutionGroup="gml:AbstractFeature" type="net:NetworkType">
+    <annotation>
+      <documentation>-- Definition --
+A network is a collection of network elements.
+
+-- Description --
+The reason for collecting certain elements in a certain network may vary (e.g. connected elements for the same mode of transport)</documentation>
+    </annotation>
+  </element>
+  <complexType name="NetworkType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="geographicalName" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Geographical name for this network.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="gn:GeographicalName"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="elements" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The collection of elements that constitutes the network.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:NetworkElement</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">net:inNetwork</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element abstract="true" name="NetworkArea" substitutionGroup="net:NetworkElement" type="net:NetworkAreaType">
+    <annotation>
+      <documentation>-- Definition --
+A 2-dimensional element in a network.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="NetworkAreaType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence>
+          <element name="geometry" type="gml:SurfacePropertyType">
+            <annotation>
+              <documentation>-- Definition --
+Represents the geometric properties of the area</documentation>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="NetworkAreaPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:NetworkArea"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="NetworkConnection" substitutionGroup="net:NetworkElement" type="net:NetworkConnectionType">
+    <annotation>
+      <documentation>-- Definition --
+Represents a logical connection between two or more network elements in different networks.
+
+-- Description --
+In the case where the networks are in different spatial data sets, a network connection object may exist in both data sets.</documentation>
+    </annotation>
+  </element>
+  <complexType name="NetworkConnectionType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence>
+          <element name="type" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Categorisation of the network connection.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="2" name="element" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+Network elements in different networks</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:NetworkElement</targetElement>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="NetworkConnectionPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:NetworkConnection"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="NetworkElement" substitutionGroup="gml:AbstractFeature" type="net:NetworkElementType">
+    <annotation>
+      <documentation>-- Definition --
+Abstract base type representing an element in a network. Every element in a network provides some function that is of interest in the network.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="NetworkElementType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element maxOccurs="unbounded" name="inNetwork" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The networks in which a network element is a member.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Network</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">net:elements</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="NetworkElementPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:NetworkElement"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element abstract="true" name="NetworkProperty" substitutionGroup="gml:AbstractFeature" type="net:NetworkPropertyType">
+    <annotation>
+      <documentation>-- Definition --
+Abstract base type representing phenomena located at or along a network element. This base type provides general properties to associate the network-related phenomena (network properties) with the network elements.
+
+-- Description --
+In the simplest case (NetworkReference), the network property applies to the whole network element. In the case of a Link, the spatial reference may be restricted to part of the Link by using a linear reference. ISO/TC 211 is currently in the early stages of developing a standard for Linear Referencing (ISO 19148). A simple mechanism to express linear references is provided in this version of the network model; it is expected that the model will be extended once ISO 19148 is stable. The current simple model requires for all linear references two expressions representing a distance from the start of the Link along its curve geometry. The network property applies to the part of the Link between fromPosition and toPosition.</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="NetworkPropertyType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element maxOccurs="unbounded" name="networkRef" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Spatial reference of the network-related property.
+
+-- Description --
+This attribute provides an indirect spatial reference based on a reference to an element of an underlying network. See the chapter on Object Referencing in the Generic Conceptual Model for a discussion on modelling object references.</documentation>
+            </annotation>
+            <complexType>
+              <sequence>
+                <element ref="net:NetworkReference"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="inspireId" type="base:IdentifierPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+External object identifier of the spatial object.
+
+-- Description --
+NOTE An external object identifier is a unique object identifier published by the responsible body, which may be used by external applications to reference the spatial object. The identifier is an identifier of the spatial object, not an identifier of the real-world phenomenon.</documentation>
+            </annotation>
+          </element>
+          <element name="beginLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was inserted or changed in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element minOccurs="0" name="endLifespanVersion" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+Date and time at which this version of the spatial object was superseded or retired in the spatial data set.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="dateTime">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="NetworkPropertyPropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:NetworkProperty"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="NetworkReference" substitutionGroup="gml:AbstractObject" type="net:NetworkReferenceType">
+    <annotation>
+      <documentation>-- Definition --
+A reference to a network element.</documentation>
+    </annotation>
+  </element>
+  <complexType name="NetworkReferenceType">
+    <sequence>
+      <element name="element" type="gml:ReferenceType">
+        <annotation>
+          <documentation>-- Definition --
+The referenced network element.</documentation>
+          <appinfo>
+            <targetElement xmlns="http://www.opengis.net/gml/3.2">net:NetworkElement</targetElement>
+          </appinfo>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+  <complexType name="NetworkReferencePropertyType">
+    <sequence>
+      <element ref="net:NetworkReference"/>
+    </sequence>
+  </complexType>
+  <element abstract="true" name="Node" substitutionGroup="net:NetworkElement" type="net:NodeType">
+    <annotation>
+      <documentation>-- Definition --
+Represents a significant position in the network that always occurs at the beginning or the end of a link.
+
+-- Description --
+NOTE if a topological representation of the network is used the road node is either a topological connection between two or more links or the termination of a ink. If a geometric representation of the network is used road nodes are represented by points or alternatively another geometric shape. [EuroRoadS]</documentation>
+    </annotation>
+  </element>
+  <complexType abstract="true" name="NodeType">
+    <complexContent>
+      <extension base="net:NetworkElementType">
+        <sequence>
+          <element name="geometry" type="gml:PointPropertyType">
+            <annotation>
+              <documentation>-- Definition --
+The location of the node.</documentation>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="spokeEnd" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The links that enter the node.
+
+-- Description --
+NOTE In the INSPIRE context, this spoke property is to be published when this information is published in current exchange formats of the data set.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Link</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">net:endNode</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+          <element maxOccurs="unbounded" minOccurs="0" name="spokeStart" nillable="true" type="gml:ReferenceType">
+            <annotation>
+              <documentation>-- Definition --
+The links that leave the node.
+
+-- Description --
+NOTE In the INSPIRE context, this spoke property is to be published when this information is published in current exchange formats of the data set.</documentation>
+              <appinfo>
+                <targetElement xmlns="http://www.opengis.net/gml/3.2">net:Link</targetElement>
+                <reversePropertyName xmlns="http://www.opengis.net/gml/3.2">net:startNode</reversePropertyName>
+              </appinfo>
+            </annotation>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="NodePropertyType">
+    <sequence minOccurs="0">
+      <element ref="net:Node"/>
+    </sequence>
+    <attributeGroup ref="gml:AssociationAttributeGroup"/>
+    <attributeGroup ref="gml:OwnershipAttributeGroup"/>
+  </complexType>
+  <element name="SimpleLinearReference" substitutionGroup="net:LinkReference" type="net:SimpleLinearReferenceType">
+    <annotation>
+      <documentation>-- Definition --
+A network reference that is restricted to part of a linear network element. The part is the part of the network element between fromPosition and toPosition.</documentation>
+    </annotation>
+  </element>
+  <complexType name="SimpleLinearReferenceType">
+    <complexContent>
+      <extension base="net:LinkReferenceType">
+        <sequence>
+          <element name="fromPosition" type="gml:LengthType">
+            <annotation>
+              <documentation>-- Definition --
+The start position of the linear element, expressed as the distance from the start of the linear network element along its curve geometry.</documentation>
+            </annotation>
+          </element>
+          <element name="toPosition" type="gml:LengthType">
+            <annotation>
+              <documentation>-- Definition --
+The end position of the linear element, expressed as the distance from the start of the linear network element along its curve geometry.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="offset" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+An offset from the centerline geometry of the generalised link, where applicable; a positive offset is to the right in the direction of the link, a negative offset is to the left.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="gml:LengthType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="SimpleLinearReferencePropertyType">
+    <sequence>
+      <element ref="net:SimpleLinearReference"/>
+    </sequence>
+  </complexType>
+  <element name="SimplePointReference" substitutionGroup="net:LinkReference" type="net:SimplePointReferenceType">
+    <annotation>
+      <documentation>-- Definition --
+A network reference that is restricted to a point on a linear network element. The point is the location on the network element at the position atPosition along the network.</documentation>
+    </annotation>
+  </element>
+  <complexType name="SimplePointReferenceType">
+    <complexContent>
+      <extension base="net:LinkReferenceType">
+        <sequence>
+          <element name="atPosition" type="gml:LengthType">
+            <annotation>
+              <documentation>-- Definition --
+Position of the point, expressed as the distance from the start of the linear network element along its curve geometry.</documentation>
+            </annotation>
+          </element>
+          <element minOccurs="0" name="offset" nillable="true">
+            <annotation>
+              <documentation>-- Definition --
+An offset from the centerline geometry of the generalised link, where applicable; a positive offset is to the right in the direction of the link, a negative offset is to the left.</documentation>
+            </annotation>
+            <complexType>
+              <simpleContent>
+                <extension base="gml:LengthType">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="SimplePointReferencePropertyType">
+    <sequence>
+      <element ref="net:SimplePointReference"/>
+    </sequence>
+  </complexType>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/ShapeChangeAppinfo.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/ShapeChangeAppinfo.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.interactive-instruments.de/ShapeChange/AppInfo"
+ xmlns="http://www.w3.org/2001/XMLSchema"
+ xmlns:sc="http://www.interactive-instruments.de/ShapeChange/AppInfo" elementFormDefault="qualified"
+ attributeFormDefault="unqualified">
+ <element name="profiles" type="string"/>
+ <element name="name" type="string"/>
+ <element name="code" type="string"/>
+ <element name="taggedValue">
+  <complexType>
+   <simpleContent>
+    <extension base="string">
+     <attribute name="tag" type="string"/>
+    </extension>
+   </simpleContent>
+  </complexType>
+ </element>
+ <element name="targetCodeListURI" type="string"/>
+ <element name="globalIdentifier" type="string"/>
+ <element name="descriptor">
+  <complexType>
+   <simpleContent>
+    <extension base="string">
+     <attribute name="name" type="string" use="required"/>
+     <attribute name="lang" type="string"/>
+    </extension>
+   </simpleContent>
+  </complexType>
+ </element>
+ <element name="geometryType" type="string"/>
+ <element name="srid" type="positiveInteger"/>
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/samplingFeature.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/samplingFeature.xsd
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+	xmlns:gml="http://www.opengis.net/gml/3.2"
+	xmlns:gmd="http://www.isotc211.org/2005/gmd"
+	xmlns:om="http://www.opengis.net/om/2.0"
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:sam="http://www.opengis.net/sampling/2.0"
+	targetNamespace="http://www.opengis.net/sampling/2.0"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	version="2.0.2">
+	<annotation>
+		<documentation> samplingFeature.xsd 
+			
+			Observations and Measurements - XML Implementation is an OGC Standard.
+			
+			Copyright (c) [2010] Open Geospatial Consortium.
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
+		</documentation>
+	</annotation>
+	<!-- ====================================================================== -->
+	<!-- bring in other schemas -->
+	<import
+		namespace="http://www.opengis.net/gml/3.2"
+		schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<import
+		namespace="http://www.isotc211.org/2005/gmd"
+		schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+	<import
+		namespace="http://www.opengis.net/om/2.0"
+		schemaLocation="2.0_observation.xsd"/>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- Common properties of spatial sampling features -->
+	<!-- ====================================================================== -->
+	<group
+		name="SF_CommonProperties">
+		<sequence>
+			<element
+				name="type"
+				type="gml:ReferenceType"
+				minOccurs="0">
+				<annotation>
+					<documentation>If present, the sub-element 'type' shall indicate the class of
+						spatial sampling feature. A register of type identifiers corresponding with
+						the sampling feature types in ISO 19156 is provided by OGC at
+						http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/ </documentation>
+				</annotation>
+			</element>
+			<element
+				name="sampledFeature"
+				type="gml:FeaturePropertyType"
+				maxOccurs="unbounded"
+				nillable="true"
+				block="#all">
+				<annotation>
+					<documentation> A sampling feature is established in order to make observations
+						concerning some domain feature. The association Intention shall link the
+						SF_SamplingFeature to the feature which the sampling feature was designed to
+						sample. The target of this association has the role sampledFeature with
+						respect to the sampling feature, and shall not be a sampling feature. It is
+						usually a real-world feature from an application domain (Figures 5 and 10).
+					</documentation>
+				</annotation>
+			</element>
+			<element
+				name="lineage"
+				minOccurs="0"
+				type="gmd:LI_Lineage_PropertyType">
+				<annotation>
+					<documentation> If present, the attribute lineage:LI_Lineage shall describe the
+						history and provenance of the SF_SamplingFeature. This might include
+						information relating to the handling of the specimen, or details of the
+						survey procedure of a spatial sampling feature. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="relatedObservation"
+				type="om:OM_ObservationPropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> Sampling features are distinctive compared with other features
+						from application domains by having navigable associations to observations.
+						If present, the association Design shall link the SF_SamplingFeature to an
+						OM_Observation that was made utilizing the sampling feature, and the
+						description of the sampling feature provides an intrinsic element of the
+						observation protocol, along with the observation procedure (6.2.2.10) and
+						the decomposition of the domain geometry in the case of a coverage-valued
+						result (7.3.1). The OM_Observation has the role relatedObservation with
+						respect to the sampling feature. Multiple observations may be made on a
+						single sampling feature. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="relatedSamplingFeature"
+				type="sam:SamplingFeatureComplexPropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> Sampling features are frequently related to each other, as parts
+						of complexes, through sub-sampling, and in other ways. If present, the
+						association class SamplingFeatureComplex (Figure 9) shall link a
+						SF_SamplingFeature to another SF_SamplingFeature. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="parameter"
+				type="om:NamedValuePropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> If present, the attributes parameter:NamedValue shall describe
+						an arbitrary parameter associated with the SF_SamplingFeature. This might be
+						a parameter that qualifies the interaction with the sampled feature, or an
+						environmental parameter associated with the sampling process.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</group>
+	<!-- ====================================================================== -->
+	<!-- ===== Feature types in Site hierarchy ====== -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="SF_SamplingFeatureType">
+		<annotation>
+			<documentation>A "SamplingFeature" is a feature used primarily for taking
+				observations.</documentation>
+		</annotation>
+		<complexContent>
+			<extension
+				base="gml:AbstractFeatureType">
+				<sequence>
+					<group
+						ref="sam:SF_CommonProperties"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- .................. -->
+	<element
+		name="SF_SamplingFeature"
+		type="sam:SF_SamplingFeatureType"
+		abstract="true"
+		substitutionGroup="gml:AbstractFeature"/>
+	<!-- .................. -->
+	<complexType
+		name="SF_SamplingFeaturePropertyType">
+		<sequence
+			minOccurs="0">
+			<element
+				ref="sam:SF_SamplingFeature"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<complexType
+		name="SamplingFeatureComplexType">
+		<annotation>
+			<documentation>A "SamplingFeatureRelation" is used to describe relationships between
+				sampling features, including part-whole, siblings, etc.</documentation>
+		</annotation>
+		<sequence>
+			<element
+				name="role"
+				type="gml:ReferenceType"/>
+			<element
+				name="relatedSamplingFeature"
+				type="sam:SF_SamplingFeaturePropertyType"/>
+		</sequence>
+	</complexType>
+	<!-- .................. -->
+	<element
+		name="SamplingFeatureComplex"
+		type="sam:SamplingFeatureComplexType"/>
+	<!-- .................. -->
+	<complexType
+		name="SamplingFeatureComplexPropertyType">
+		<sequence>
+			<element
+				ref="sam:SamplingFeatureComplex"/>
+		</sequence>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- Collection -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="SF_SamplingFeatureCollectionType">
+		<annotation>
+			<documentation> The class SF_SamplingFeatureCollection (Figure 9) is an instance of the
+				«metaclass» GF_FeatureType (ISO 19109:2005), which therefore represents a feature
+				type. SF_SamplingFeatureCollection shall support one association. </documentation>
+		</annotation>
+		<complexContent>
+			<extension
+				base="gml:AbstractFeatureType">
+				<sequence>
+					<element
+						name="member"
+						type="sam:SF_SamplingFeaturePropertyType"
+						maxOccurs="unbounded">
+						<annotation>
+							<documentation>The association Collection shall link a
+								SF_SamplingFeatureCollection to member SF_SamplingFeatures.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- .................. -->
+	<element
+		name="SF_SamplingFeatureCollection"
+		type="sam:SF_SamplingFeatureCollectionType"
+		substitutionGroup="gml:AbstractFeature"/>
+	<!-- .................. -->
+	<complexType
+		name="SF_SamplingFeatureCollectionPropertyType">
+		<sequence
+			minOccurs="0">
+			<element
+				ref="sam:SF_SamplingFeatureCollection"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ===== Sampling feature process  ======= -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="SF_ProcessPropertyType">
+		<annotation>
+			<documentation> The purpose of a sampling feature process is to generate or transform a
+				sampling feature. The model for SF_Process is abstract, and has no attributes,
+				operations, or associations. Any suitable XML may be used to describe the sampling
+				feature process in line, provided that it is contained in a single XML element. If
+				reference to a schema is provided it must also be valid. </documentation>
+		</annotation>
+		<sequence
+			minOccurs="0">
+			<any
+				namespace="##any"
+				processContents="lax">
+				<annotation>
+					<documentation> Any suitable XML may be used to describe the sampling feature
+						process in line, provided that it is contained in a single XML element. If
+						refernece to a schema is provided it must also be valid. </documentation>
+				</annotation>
+			</any>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+</schema>

--- a/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/spatialSamplingFeature.xsd
+++ b/deegree-core/deegree-core-base/src/test/resources/org/deegree/gml/inspire/schema/geophysicsCore/spatialSamplingFeature.xsd
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+	xmlns:gml="http://www.opengis.net/gml/3.2"
+	xmlns:gmd="http://www.isotc211.org/2005/gmd"
+	xmlns:om="http://www.opengis.net/om/2.0"
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:sam="http://www.opengis.net/sampling/2.0"
+	xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+	targetNamespace="http://www.opengis.net/samplingSpatial/2.0"
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	version="2.0.0">
+	<annotation>
+		<documentation> spatialSamplingFeature.xsd 
+			
+			Observations and Measurements - XML Implementation is an OGC Standard.
+			
+			Copyright (c) [2010] Open Geospatial Consortium. 
+			To obtain additional rights of use, visit http://www.opengeospatial.org/legal/.
+		</documentation>
+	</annotation>
+	<!-- ====================================================================== -->
+	<!-- bring in other schemas -->
+	<import
+		namespace="http://www.opengis.net/gml/3.2"
+		schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+	<import
+		namespace="http://www.isotc211.org/2005/gmd"
+		schemaLocation="http://schemas.opengis.net/iso/19139/20070417/gmd.xsd"/>
+	<import
+		namespace="http://www.opengis.net/sampling/2.0"
+		schemaLocation="samplingFeature.xsd"/>
+	<import
+		namespace="http://www.opengis.net/om/2.0"
+		schemaLocation="2.0_observation.xsd"/>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- Common properties of spatial sampling features -->
+	<!-- ====================================================================== -->
+	<group
+		name="SF_SpatialCommonProperties">
+		<annotation>
+			<documentation> When observations are made to estimate properties of a geospatial
+				feature, in particular where the value of a property varies within the scope of the
+				feature, a spatial sampling feature is used. Depending on accessibility and on the
+				nature of the expected property variation, the sampling feature may be extensive in
+				one, two or three spatial dimensions. Processing and visualization methods are often
+				dependent on the topological dimension of the sampling manifold, so this provides a
+				natural classification system for sampling features. This classification follows
+				common practice in focussing on conventional spatial dimensions. Properties observed
+				on sampling features may be time-dependent, but the temporal axis does not generally
+				contribute to the classification of sampling feature classes. Sampling feature
+				identity is usually less time-dependent than is the property value. </documentation>
+		</annotation>
+		<sequence>
+			<element
+				name="hostedProcedure"
+				type="om:OM_ProcessPropertyType"
+				minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation> A common role for a spatial sampling feature is to host
+						instruments or procedures deployed repetitively or permanently. If present,
+						the association Platform shall link the SF_SpatialSamplingFeature to an
+						OM_Process deployed at it. The OM_Process has the role hostedProcedure with
+						respect to the sampling feature. </documentation>
+				</annotation>
+			</element>
+			<element
+				name="positionalAccuracy"
+				type="gmd:DQ_PositionalAccuracy_PropertyType"
+				minOccurs="0"
+				maxOccurs="2">
+				<annotation>
+					<documentation> Positioning metadata is commonly associated with sampling
+						features defined in the context of field surveys. If present,
+						positionalAccuracy:DQ_PositionalAccuracy shall describe the accuracy of the
+						positioning of the sampling feature. Up to two instances of the attribute
+						support the independent description of horizontal and vertical accuracy.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</group>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- Generic shape -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="shapeType">
+		<sequence
+			minOccurs="0">
+			<element
+				ref="gml:AbstractGeometry"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<element
+		name="shape"
+		type="sams:shapeType"/> 
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+	<!-- Spatial sampling feature -->
+	<!-- ====================================================================== -->
+	<complexType
+		name="SF_SpatialSamplingFeatureType">
+		<annotation>
+			<documentation> When observations are made to estimate properties of a geospatial
+				feature, in particular where the value of a property varies within the scope of the
+				feature, a spatial sampling feature is used. Depending on accessibility and on the
+				nature of the expected property variation, the sampling feature may be extensive in
+				one, two or three spatial dimensions. Processing and visualization methods are often
+				dependent on the topological dimension of the sampling manifold, so this provides a
+				natural classification system for sampling features. This classification follows
+				common practice in focussing on conventional spatial dimensions. Properties observed
+				on sampling features may be time-dependent, but the temporal axis does not generally
+				contribute to the classification of sampling feature classes. Sampling feature
+				identity is usually less time-dependent than is the property value. </documentation>
+		</annotation>
+		<complexContent>
+			<extension
+				base="sam:SF_SamplingFeatureType">
+				<sequence>
+					<group
+						ref="sams:SF_SpatialCommonProperties"/>
+					<element
+						ref="sams:shape">
+						<annotation>
+							<documentation> The association Geometry shall link a
+								SF_SpatialSamplingFeature to a GM_Object that describes its shape.
+							</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- .................. -->
+	<element
+		name="SF_SpatialSamplingFeature"
+		type="sams:SF_SpatialSamplingFeatureType"
+		substitutionGroup="sam:SF_SamplingFeature"/>
+	<!-- .................. -->
+	<complexType
+		name="SF_SpatialSamplingFeaturePropertyType">
+		<sequence
+			minOccurs="0">
+			<element
+				ref="sams:SF_SpatialSamplingFeature"/>
+		</sequence>
+		<attributeGroup
+			ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ====================================================================== -->
+	<!-- ====================================================================== -->
+</schema>

--- a/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
+++ b/deegree-services/deegree-webservices-handbook/src/main/asciidoc/appendix.adoc
@@ -59,6 +59,8 @@ f
 
 |deegree.config.apikey.warn-when-disabled |java.lang.Boolean |true |Log warning if security on REST api is disabled by specifying `*` in _config.apikey_.
 
+|deegree.gml.parse.recognize-deprecated-types |java.lang.Boolean |true |When deegree reads application schemas feature types not in GML 3.2 namespace with at least one property derived from FeaturePropertyType are recognized as feature collection. If false only feature types in GML 3.2 namespace with at least one property derived from FeaturePropertyType are recognized as feature collection.
+
 |===
 
 === Interception points


### PR DESCRIPTION
This PR fixes #1752 by introducing a new tunable `deegree.gml.parse.recognize-deprecated-types`. If the tunable is set to true (default) the feature types, not in GML 3.2 namespace with at least one property derived from FeaturePropertyType, are recognized as feature collection. If false only feature types in GML 3.2 namespace with at least one property derived from FeaturePropertyType are recognized as feature collection.