### PR TITLE
Fix missing JobBuilderFactory bean in GmlLoaderConfiguration

### DIFF
--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -224,6 +224,11 @@
       <version>${spring-batch.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/ReportWriter.java
+++ b/deegree-tools/deegree-tools-gml/src/main/java/org/deegree/tools/featurestoresql/loader/ReportWriter.java
@@ -32,7 +32,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 
@@ -51,7 +53,7 @@ public class ReportWriter extends JobExecutionListenerSupport {
 
 	private static final Logger LOG = getLogger(ReportWriter.class);
 
-	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
 
 	private final Summary summary;
 
@@ -134,13 +136,13 @@ public class ReportWriter extends JobExecutionListenerSupport {
 
 	private String getStartTime(StepExecution stepExecution) {
 		if (stepExecution != null && stepExecution.getStartTime() != null)
-			return DATE_FORMAT.format(stepExecution.getStartTime());
+			return stepExecution.getStartTime().format(DATE_FORMAT);
 		return "UNKNOWN";
 	}
 
 	private String getEndTime(StepExecution stepExecution) {
 		if (stepExecution != null && stepExecution.getEndTime() != null)
-			return DATE_FORMAT.format(stepExecution.getEndTime());
+			return stepExecution.getEndTime().format(DATE_FORMAT);
 		return "UNKNOWN";
 	}
 

--- a/deegree-tools/deegree-tools-gml/src/test/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfigurationTest.java
+++ b/deegree-tools/deegree-tools-gml/src/test/java/org/deegree/tools/featurestoresql/loader/GmlLoaderConfigurationTest.java
@@ -1,0 +1,19 @@
+package org.deegree.tools.featurestoresql.loader;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class GmlLoaderConfigurationTest {
+
+	@Test
+	public void testLoadApplicationContextAndInitializeBeans() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(GmlLoaderConfiguration.class);
+		context.refresh();
+		context.close();
+	}
+
+}

--- a/deegree-tools/deegree-tools-gml/src/test/java/org/deegree/tools/featurestoresql/loader/ReportWriterTest.java
+++ b/deegree-tools/deegree-tools-gml/src/test/java/org/deegree/tools/featurestoresql/loader/ReportWriterTest.java
@@ -1,0 +1,40 @@
+package org.deegree.tools.featurestoresql.loader;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class ReportWriterTest {
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	@Test
+	public void test() throws IOException {
+		Summary summary = new Summary();
+		ReportWriter reportWriter = new ReportWriter(summary, tmpFolder.newFile().toPath());
+
+		JobExecution jobExecution = mock(JobExecution.class);
+		StepExecution stepExecution = mock(StepExecution.class);
+		when(jobExecution.getStepExecutions()).thenReturn(Collections.singletonList(stepExecution));
+		when(stepExecution.getStartTime()).thenReturn(LocalDateTime.now().minusDays(1));
+		when(stepExecution.getEndTime()).thenReturn(LocalDateTime.now().minusDays(1));
+		when(stepExecution.getExitStatus()).thenReturn(ExitStatus.COMPLETED);
+
+		reportWriter.afterJob(jobExecution);
+	}
+
+}


### PR DESCRIPTION
This PR fixes an exception caused by a missing JobBuilderFactory bean in the GmlLoaderConfiguration class.

The initial stack trace of the exception that was thrown when using the GmlLoader:
```
024-11-06 13:08:24 [main] WARN o.s.c.a.AnnotationConfigApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'gmlLoaderConfiguration': Unsatisfied dependency expressed through field 'jobBuilderFactory': No qualifying bean of type 'org.springframework.batch.core.configuration.annotation.JobBuilderFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
2024-11-06 13:08:24 [main] WARN o.s.c.a.AnnotationConfigApplicationContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'gmlLoaderConfiguration': Unsatisfied dependency expressed through field 'jobBuilderFactory': No qualifying bean of type 'org.springframework.batch.core.configuration.annotation.JobBuilderFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:91)
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:53)
	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:58)
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'gmlLoaderConfiguration': Unsatisfied dependency expressed through field 'jobBuilderFactory': No qualifying bean of type 'org.springframework.batch.core.configuration.annotation.JobBuilderFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:787)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:767)
	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:145)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:508)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1421)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:599)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:522)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:337)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:335)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:975)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:962)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:624)
	at org.springframework.context.annotation.AnnotationConfigApplicationContext.<init>(AnnotationConfigApplicationContext.java:93)
	at org.deegree.tools.featurestoresql.loader.GmlLoaderApp.run(GmlLoaderApp.java:46)
	at org.deegree.tools.featurestoresql.GmlToolsApp.main(GmlToolsApp.java:23)
	... 7 more
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.batch.core.configuration.annotation.JobBuilderFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1880)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1406)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1353)
	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.resolveFieldValue(AutowiredAnnotationBeanPostProcessor.java:784)
	... 23 more
```

Closes #1760