### PR TITLE
Upgraded Primefaces and other dependencies to latest bugfix version (3.6)

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -283,13 +283,13 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>14.0.4</version>
+      <version>14.0.7</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>14.0.4</version>
+      <version>14.0.7.1</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.0</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -530,7 +530,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.16.1</version>
+        <version>2.17.0</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -571,7 +571,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
+        <version>4.5.14</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -615,13 +615,13 @@
       <dependency>
         <groupId>jakarta.servlet.jsp</groupId>
         <artifactId>jakarta.servlet.jsp-api</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet.jsp.jstl</groupId>
         <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.2</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -640,7 +640,7 @@
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.faces</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.9</version>
       </dependency>
       <dependency>
         <groupId>jakarta.enterprise</groupId>
@@ -837,7 +837,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.3</version>
+        <version>42.7.4</version>
       </dependency>
       <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>
@@ -1098,7 +1098,7 @@
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>
         <artifactId>imageio-ext-utilities</artifactId>
-        <version>1.4.12</version>
+        <version>1.4.14</version>
         <exclusions>
           <exclusion>
             <groupId>javax.media</groupId>
@@ -1125,7 +1125,7 @@
       <dependency>
         <groupId>it.geosolutions.imageio-ext</groupId>
         <artifactId>imageio-ext-tiff</artifactId>
-        <version>1.4.12</version>
+        <version>1.4.14</version>
         <exclusions>
           <exclusion>
             <groupId>javax.media</groupId>
@@ -1173,7 +1173,7 @@
       <dependency>
         <groupId>jakarta.mail</groupId>
         <artifactId>jakarta.mail-api</artifactId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -1214,7 +1214,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.7.3</version>
+        <version>2.7.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR fixes a critical issue in primeface CVSS 10 and also extra-enforcer-rules, commons-io and other.

