### PR TITLE
Fixed release pipeline to use managed credentials from jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,19 @@
 pipeline {
-    agent {
-        label 'openjdk11bot'
-    }
-    options { 
+    agent any
+    options {
         disableConcurrentBuilds()
     }
     tools {
         maven 'maven-3.9'
         jdk 'temurin-jdk17'
+        git 'git-default'
     }
     environment {
         MAVEN_OPTS='-Djava.awt.headless=true -Xmx4096m'
     }
     parameters {
-          string name: 'REL_VERSION', defaultValue: "3.5.x", description: 'Next release version'
-          string name: 'DEV_VERSION', defaultValue: "3.5.x-SNAPSHOT", description: 'Next snapshot version'
+          string name: 'REL_VERSION', defaultValue: "3.6.x", description: 'Next release version'
+          string name: 'DEV_VERSION', defaultValue: "3.6.x-SNAPSHOT", description: 'Next snapshot version'
           booleanParam name: 'PERFORM_RELEASE', defaultValue: false, description: 'Perform release build (on main branch only)'
     }
     stages {
@@ -56,8 +55,7 @@ pipeline {
             }
             post {
                 always {
-                    recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc()]
-                    recordIssues enabledForFailure: true, tool: spotBugs()
+                    recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc(), spotBugs()]
                 }
             }
         }
@@ -70,7 +68,13 @@ pipeline {
             }
             steps {
                 echo 'Prepare release version ${REL_VERSION}'
-                sh 'mvn -Dresume=false -DreleaseVersion=${REL_VERSION} -DdevelopmentVersion=${DEV_VERSION} -DdeployAtEnd=true -Dgoals=deploy release:prepare release:perform -P integration-tests,oracle,handbook'
+                withMaven(mavenSettingsConfig: 'mvn-server-settings', options: [junitPublisher(healthScaleFactor: 1.0)], publisherStrategy: 'EXPLICIT') {
+                  withCredentials([usernamePassword(credentialsId:'nexus-deploy', passwordVariable: 'PASSWORD_VAR', usernameVariable: 'USERNAME_VAR')]) {
+                    sshagent(credentials: ['jenkins-deegree-ssh-key']) {
+                      sh 'mvn -Dresume=false -DreleaseVersion=${REL_VERSION} -DdevelopmentVersion=${DEV_VERSION} -Darguments="-Drepo.username=${USERNAME_VAR} -Drepo.password=${PASSWORD_VAR}" -DdeployAtEnd=true -Dgoals=deploy release:prepare release:perform -P integration-tests,oracle,handbook'
+                    }
+                  }
+                }
             }
             post {
                 success {


### PR DESCRIPTION
This PR fixes the release pipeline to use the managed credentials from jenkins ci for connecting to github and nexus.

It also removes the agent label for JDK 11, which is obsolete. It changes the default version number from 3.5.x to 3.6.x and optimises the quality pipeline step for collecting the reports.