### PR TITLE
Upgraded postgis, postgresql, and primefaces to latest bugfix version

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISDialect.java
@@ -61,7 +61,7 @@ import org.deegree.sqldialect.SortCriterion;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
 import org.deegree.sqldialect.filter.PropertyNameMapper;
 import org.deegree.sqldialect.filter.UnmappableException;
-import org.postgis.PGboxbase;
+import net.postgis.jdbc.PGboxbase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,7 +207,7 @@ public class PostGISDialect extends AbstractSQLDialect implements SQLDialect {
 		return env;
 	}
 
-	private org.deegree.geometry.primitive.Point buildPoint(org.postgis.Point p, ICRS crs) {
+	private org.deegree.geometry.primitive.Point buildPoint(net.postgis.jdbc.geometry.Point p, ICRS crs) {
 		double[] coords = new double[p.getDimension()];
 		coords[0] = p.getX();
 		coords[1] = p.getY();

--- a/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/db/PostgisBackend.java
+++ b/deegree-services/deegree-services-wpvs/src/main/java/org/deegree/services/wpvs/io/db/PostgisBackend.java
@@ -47,12 +47,12 @@ import org.deegree.geometry.Envelope;
 import org.deegree.rendering.r3d.persistence.RenderableStore;
 import org.deegree.workspace.ResourceMetadata;
 import org.deegree.workspace.Workspace;
-import org.postgis.Geometry;
-import org.postgis.LinearRing;
-import org.postgis.PGbox3d;
-import org.postgis.PGgeometry;
-import org.postgis.Point;
-import org.postgis.Polygon;
+import net.postgis.jdbc.geometry.Geometry;
+import net.postgis.jdbc.geometry.LinearRing;
+import net.postgis.jdbc.PGbox3d;
+import net.postgis.jdbc.PGgeometry;
+import net.postgis.jdbc.geometry.Point;
+import net.postgis.jdbc.geometry.Polygon;
 
 /**
  * The <code>PostgisBackend</code> class adds postgis specific methods to the model
@@ -85,7 +85,7 @@ public class PostgisBackend extends DBBackend<PGgeometry> {
 			}
 			Polygon pgPolygon = (Polygon) geom;
 			ICRS crs = CRSManager.getCRSRef("EPSG:" + pgPolygon.getSrid());
-			org.postgis.LinearRing ring = pgPolygon.getRing(0);
+			net.postgis.jdbc.geometry.LinearRing ring = pgPolygon.getRing(0);
 			Point min = ring.getPoint(0);
 			Point max = ring.getPoint(2);
 			double[] mi = null;
@@ -145,7 +145,7 @@ public class PostgisBackend extends DBBackend<PGgeometry> {
 			points[4] = new Point(minD[0], minD[1], minD[2]);
 		}
 		linRing[0] = new LinearRing(points);
-		org.postgis.Polygon pgPoly = new org.postgis.Polygon(linRing);
+		net.postgis.jdbc.geometry.Polygon pgPoly = new net.postgis.jdbc.geometry.Polygon(linRing);
 		pgPoly.setSrid(parseSRID(geometry.getCoordinateSystem()));
 		return new PGgeometry(pgPoly);
 

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -278,12 +278,12 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>14.0.6</version>
+      <version>14.0.10</version>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>14.0.6</version>
+      <version>14.0.10</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/coverage/gridifier/index/MultiLevelMemoryTileGridIndex.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/coverage/gridifier/index/MultiLevelMemoryTileGridIndex.java
@@ -50,9 +50,9 @@ import org.deegree.coverage.raster.geom.RasterGeoReference.OriginLocation;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.tools.coverage.gridifier.RasterLevel;
-import org.postgis.PGgeometry;
-import org.postgis.Point;
-import org.postgis.Polygon;
+import net.postgis.jdbc.PGgeometry;
+import net.postgis.jdbc.geometry.Point;
+import net.postgis.jdbc.geometry.Polygon;
 
 public class MultiLevelMemoryTileGridIndex implements MultiLevelRasterTileIndex {
 

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/coverage/gridifier/index/PostGISRasterTileIndex.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/coverage/gridifier/index/PostGISRasterTileIndex.java
@@ -49,9 +49,9 @@ import org.deegree.coverage.raster.geom.RasterGeoReference.OriginLocation;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.tools.coverage.gridifier.RasterLevel;
-import org.postgis.PGgeometry;
-import org.postgis.Point;
-import org.postgis.Polygon;
+import net.postgis.jdbc.PGgeometry;
+import net.postgis.jdbc.geometry.Point;
+import net.postgis.jdbc.geometry.Polygon;
 
 public class PostGISRasterTileIndex implements MultiLevelRasterTileIndex {
 

--- a/pom.xml
+++ b/pom.xml
@@ -823,17 +823,17 @@
       <dependency>
         <groupId>net.postgis</groupId>
         <artifactId>postgis-jdbc</artifactId>
-        <version>2.5.1</version>
+        <version>2024.1.0</version>
       </dependency>
       <dependency>
         <groupId>net.postgis</groupId>
         <artifactId>postgis-geometry</artifactId>
-        <version>2.5.1</version>
+        <version>2024.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.3</version>
+        <version>42.7.4</version>
       </dependency>
       <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>


### PR DESCRIPTION
This PR upgrades postgis to v2024.1.0, postgresql to v42.7.4, and primefaces to v14.0.10 which fixes known CVE's.