### PR TITLE
Upgraded dependencies: json-smart to v2.5.2, postgresql to v42.7.5 (3.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1321,7 +1321,7 @@
             <artifactId>dependency-check-maven</artifactId>
             <version>12.1.0</version>
             <configuration>
-              <cveValidForHours>24</cveValidForHours>
+              <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>
             </configuration>
             <reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -1319,7 +1319,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.0.2</version>
+            <version>12.1.0</version>
             <configuration>
               <cveValidForHours>24</cveValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -1235,7 +1235,7 @@
     <batik.version>1.17</batik.version>
     <axoim.version>1.2.22</axoim.version>
     <jsonpath.version>2.9.0</jsonpath.version>
-    <jsonsmart.version>2.5.1</jsonsmart.version>
+    <jsonsmart.version>2.5.2</jsonsmart.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1319,7 +1319,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>11.1.0</version>
+            <version>12.0.2</version>
             <configuration>
               <cveValidForHours>24</cveValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -833,7 +833,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.4</version>
+        <version>42.7.5</version>
       </dependency>
       <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -559,7 +559,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.16.1</version>
+        <version>1.17.2</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
This PR upgrades json-smart to latest bugfix version v2.5.2 which fixes https://github.com/advisories/GHSA-pq2g-wx69-c263
- https://github.com/netplex/json-smart-v2/releases/tag/2.5.2

Also postgresql upgraded to postgresql to 42.7.5 and commons-codes as in PR #1779, owasp dependency-check-maven updated to [12.1.0](https://github.com/jeremylong/DependencyCheck/releases/tag/v12.1.0)