### PR TITLE
Upgraded dependency json-smart to v2.5.2 (3.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1234,7 +1234,7 @@
     <batik.version>1.17</batik.version>
     <axiom.version>1.4.0</axiom.version>
     <jsonpath.version>2.9.0</jsonpath.version>
-    <jsonsmart.version>2.5.1</jsonsmart.version>
+    <jsonsmart.version>2.5.2</jsonsmart.version>
     <jvm.args>--add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED</jvm.args>
   </properties>
 


### PR DESCRIPTION
PR upgrades json-smart to latest version 2.5.2

Backport: PR for `3.5-main`: #1780 