### PR TITLE
Upgraded OWASP maven plugin to v12.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1325,7 +1325,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>10.0.4</version>
+            <version>12.1.0</version>
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
This PR upgrades the OWASP dependency-check-maven plugin to [12.1.0](https://github.com/jeremylong/DependencyCheck/releases/tag/v12.1.0).