### PR TITLE
Fixed error when resolving CityGML schema and its parts (3.6)

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/xml/schema/RedirectingEntityResolver.java
@@ -55,7 +55,9 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RedirectingEntityResolver.class);
 
-	private static final String SCHEMAS_OPENGIS_NET_URL = "http://schemas.opengis.net/";
+	private static final String OPENGIS_SCHEMAS_URL = "http://schemas.opengis.net/";
+
+	private static final String OASIS_SCHEMAS_URL = "http://docs.oasis-open.org/";
 
 	public static final String INSPIRE_SCHEMAS_URL = "http://inspire.ec.europa.eu/schemas";
 
@@ -81,15 +83,15 @@ public class RedirectingEntityResolver implements XMLEntityResolver {
 	 * <code>null</code>
 	 */
 	public String redirect(String systemId) {
-		if (systemId.startsWith(SCHEMAS_OPENGIS_NET_URL)) {
-			String localPart = systemId.substring(SCHEMAS_OPENGIS_NET_URL.length());
+		if (systemId.startsWith(OPENGIS_SCHEMAS_URL)) {
+			String localPart = systemId.substring(OPENGIS_SCHEMAS_URL.length());
 			URL u = RedirectingEntityResolver.class.getResource(ROOT + localPart);
 			if (u != null) {
 				LOG.debug("Local hit: {}", systemId);
 				return u.toString();
 			}
 		}
-		else if (systemId.startsWith(INSPIRE_SCHEMAS_URL)) {
+		else if (systemId.startsWith(INSPIRE_SCHEMAS_URL) || systemId.startsWith(OASIS_SCHEMAS_URL)) {
 			return HTTP_PATTERN.matcher(systemId).replaceFirst("https://");
 		}
 		else if (systemId.equals("http://www.w3.org/2001/xml.xsd")) {


### PR DESCRIPTION
This PR fixes the unit test error when resolving CityGML schema and its parts due to change from http to https in namespace url.
See issue #1796 for more information which solution is preferred.

Backport for 3.5: #1797 