### PR TITLE
Upgraded spotbugs-maven-plugin to 4.9.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1265,7 +1265,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.8.6.3</version>
+            <version>4.9.3.0</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <spotbugsXmlOutput>true</spotbugsXmlOutput>


### PR DESCRIPTION
This PR fixes issue #1800 by setting the spotbugs-maven-plugin to version 4.9.3.0 to resolve the build issue during pipeline step "Quality Checks".