### PR TITLE
Fixed version for spotbugs maven plugin in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
             }
             steps {
                 echo 'Quality checking'
-                sh 'mvn -B -C -fae -P oracle com.github.spotbugs:spotbugs-maven-plugin:spotbugs javadoc:javadoc'
+                sh 'mvn -B -C -fae -P oracle com.github.spotbugs:spotbugs-maven-plugin:4.8.6.0:spotbugs javadoc:javadoc'
             }
             post {
                 always {


### PR DESCRIPTION
This PR fixes #1800 by setting the fixed version 4.8.6.0 for the spotbugs maven plugin to avoid in incompatibility with doxia when executing quality goal in Jenkins pipeline. PR #1801 set the plugin version for maven profile "site-all-reports" only.