### PR TITLE
Added http notation to EPSG:5554,5555,5556 (3.6)

### DIFF
--- a/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
+++ b/deegree-core/deegree-core-cs/src/main/resources/org/deegree/cs/persistence/deegree/d3/config/crs-definitions.xml
@@ -71360,6 +71360,7 @@
         <crs:CompoundCRS>
                 <crs:Id>epsg:5554</crs:Id>        
                 <crs:Id>urn:ogc:def:crs:epsg::5554</crs:Id>
+                <crs:Id>http://www.opengis.net/def/crs/EPSG/0/5554</crs:Id>
                 <crs:Name>ETRS89 / UTM zone 31N + DHHN92 height</crs:Name>
                 <crs:Version>2011-07-21</crs:Version>
                 <crs:Description>Inserted by hand.</crs:Description>
@@ -71376,6 +71377,7 @@
         <crs:CompoundCRS>
                 <crs:Id>epsg:5555</crs:Id>        
                 <crs:Id>urn:ogc:def:crs:epsg::5555</crs:Id>
+                <crs:Id>http://www.opengis.net/def/crs/EPSG/0/5555</crs:Id>
                 <crs:Name>ETRS89 / UTM zone 32N + DHHN92 height</crs:Name>
                 <crs:Version>2011-07-21</crs:Version>
                 <crs:Description>Inserted by hand.</crs:Description>
@@ -71392,6 +71394,7 @@
         <crs:CompoundCRS>
                 <crs:Id>epsg:5556</crs:Id>        
                 <crs:Id>urn:ogc:def:crs:epsg::5556</crs:Id>
+                <crs:Id>http://www.opengis.net/def/crs/EPSG/0/5556</crs:Id>
                 <crs:Name>ETRS89 / UTM zone 33N + DHHN92 height</crs:Name>
                 <crs:Version>2011-07-21</crs:Version>
                 <crs:Description>Inserted by hand.</crs:Description>


### PR DESCRIPTION
This PR adds http://www.opengis.net/def/crs/EPSG/0/XXX notation to EPSG:5554, EPSG:5555 and EPSG:5556
Required for OGC API for Features.

Backport #1806 