### PR TITLE
Fixed non-transparant WMS output for remote WMS and GDAL layers

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/ImageRenderContext.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/context/ImageRenderContext.java
@@ -79,7 +79,11 @@ public class ImageRenderContext extends Java2DRenderContext {
 		this.info = info;
 	}
 
-	public static RenderContext createInstance(RenderingInfo info, BufferedImage image, OutputStream outputStream) {
+	public static RenderContext createInstance(RenderingInfo info, BufferedImage existingImage,
+			OutputStream outputStream) {
+		BufferedImage image = ImageUtils.prepareImage(existingImage, info.getFormat(), info.getWidth(),
+				info.getHeight(), info.getTransparent(), info.getBgColor());
+
 		return new ImageRenderContext(info, image, image.createGraphics(), outputStream);
 	}
 
@@ -87,7 +91,7 @@ public class ImageRenderContext extends Java2DRenderContext {
 		BufferedImage image = ImageUtils.prepareImage(info.getFormat(), info.getWidth(), info.getHeight(),
 				info.getTransparent(), info.getBgColor());
 
-		return createInstance(info, image, outputStream);
+		return new ImageRenderContext(info, image, image.createGraphics(), outputStream);
 	}
 
 	@Override
@@ -101,9 +105,9 @@ public class ImageRenderContext extends Java2DRenderContext {
 				if (format.equals("x-ms-bmp")) {
 					format = "bmp";
 				}
-				if (format.equals("png; subtype=8bit") || format.equals("png; mode=8bit")) {
+				if (format.equals("png; subtype=8bit") || format.equals("png; mode=8bit") || format.equals("gif")) {
 					image = ColorQuantizer.quantizeImage(image, 256, false, false);
-					format = "png";
+					format = format.substring(0, 3);
 				}
 
 				if (info.getSerializer() != null) {

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/ImageUtils.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/utils/ImageUtils.java
@@ -59,22 +59,38 @@ import javax.media.jai.operator.ColorQuantizerDescriptor;
 public class ImageUtils {
 
 	private static int getType(boolean transparent, String format) {
-		if (!isTransparentAndTransparencySupported(format, transparent)) {
+		if (isTransparentAndTransparencySupported(format, transparent)) {
+			return TYPE_INT_ARGB;
+		}
+		else {
 			return TYPE_INT_RGB;
 		}
-		return transparent ? TYPE_INT_ARGB : TYPE_INT_RGB;
+	}
+
+	/**
+	 * @return an image conforming to the request parameters
+	 */
+	public static BufferedImage prepareImage(BufferedImage existingImage, String format, int width, int height,
+			boolean transparent, Color bgColor) {
+		int requiredType = getType(transparent, format);
+		int existingType = existingImage.getType();
+		if (existingType != requiredType) {
+			BufferedImage newImage = prepareImage(format, width, height, transparent, bgColor);
+
+			Graphics2D g = newImage.createGraphics();
+			g.drawImage(existingImage, 0, 0, null);
+			g.dispose();
+
+			return newImage;
+		}
+
+		return existingImage;
 	}
 
 	/**
 	 * @return an empty image conforming to the request parameters
 	 */
 	public static BufferedImage prepareImage(String format, int width, int height, boolean transparent, Color bgColor) {
-		if (format.equals("image/png; mode=8bit") || format.equals("image/png; subtype=8bit")
-				|| format.equals("image/gif")) {
-			ColorModel cm = PlanarImage.getDefaultColorModel(TYPE_BYTE, 4);
-			return new BufferedImage(cm, createBandedRaster(TYPE_BYTE, width, height, 4, null), false, null);
-		}
-
 		BufferedImage img = new BufferedImage(width, height, getType(transparent, format));
 		if (!isTransparentAndTransparencySupported(format, transparent)) {
 			Graphics2D g = img.createGraphics();


### PR DESCRIPTION
This fix re-enables JPEG output and correct handling of the `transparent` and `bgcolor` WMS parameters for remote WMS and GDAL layers.

For both layer types deegree tries to reuse an existing `BufferedImage` (provided by the WMS client or by GDAL) and this fails when this image has an alpha layer and JPEG output is requested or transparency is not enabled in the request.