### PR TITLE
Fix MS SQL Statements using paging (3.6)

### DIFF
--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-commons/src/main/java/org/deegree/sqldialect/SQLDialect.java
@@ -214,4 +214,6 @@ public interface SQLDialect {
 	 */
 	boolean isRowLimitingCapable();
 
+	String getOffsetAndFetchClause(int maxFeatures, int startIndex);
+
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-mssql/src/main/java/org/deegree/sqldialect/mssql/MSSQLDialect.java
@@ -55,6 +55,7 @@ import org.deegree.filter.sort.SortProperty;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.utils.GeometryParticleConverter;
+import org.deegree.sqldialect.AbstractSQLDialect;
 import org.deegree.sqldialect.SQLDialect;
 import org.deegree.sqldialect.SortCriterion;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
@@ -62,7 +63,6 @@ import org.deegree.sqldialect.filter.PropertyNameMapper;
 import org.deegree.sqldialect.filter.UnmappableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.deegree.sqldialect.AbstractSQLDialect;
 
 /**
  * {@link SQLDialect} for Microsoft SQL Server databases.
@@ -192,6 +192,19 @@ public class MSSQLDialect extends AbstractSQLDialect implements SQLDialect {
 	public String getSelectSequenceNextVal(String sequence) {
 		throw new UnsupportedOperationException(
 				"Using DB sequences for FIDs is currently not supported on Microsoft SQL Server.");
+	}
+
+	@Override
+	public String getOffsetAndFetchClause(int maxFeatures, int startIndex) {
+		StringBuilder sql = new StringBuilder();
+		if (maxFeatures < 0)
+			return null;
+		if (startIndex > 0)
+			sql.append(" OFFSET ").append(startIndex).append(" ROWS");
+		else
+			sql.append(" OFFSET 0 ROWS");
+		sql.append(" FETCH NEXT ").append(maxFeatures).append(" ROWS ONLY ");
+		return sql.toString();
 	}
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleDialect.java
@@ -64,13 +64,13 @@ import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.geometry.utils.GeometryParticleConverter;
+import org.deegree.sqldialect.AbstractSQLDialect;
 import org.deegree.sqldialect.SQLDialect;
 import org.deegree.sqldialect.SortCriterion;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
 import org.deegree.sqldialect.filter.PropertyNameMapper;
 import org.deegree.sqldialect.filter.UnmappableException;
 import org.slf4j.Logger;
-import org.deegree.sqldialect.AbstractSQLDialect;
 
 /**
  * {@link SQLDialect} for Oracle Spatial databases.
@@ -282,6 +282,16 @@ public class OracleDialect extends AbstractSQLDialect implements SQLDialect {
 	@Override
 	public boolean isRowLimitingCapable() {
 		return versionMajor < 12 ? false : true;
+	}
+
+	@Override
+	public String getOffsetAndFetchClause(int maxFeatures, int startIndex) {
+		StringBuilder sql = new StringBuilder();
+		if (startIndex > 0)
+			sql.append(" OFFSET ").append(startIndex).append(" ROWS");
+		if (maxFeatures > -1)
+			sql.append(" FETCH NEXT ").append(maxFeatures).append(" ROWS ONLY ");
+		return sql.toString();
 	}
 
 }

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISDialect.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-postgis/src/main/java/org/deegree/sqldialect/postgis/PostGISDialect.java
@@ -41,6 +41,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import net.postgis.jdbc.PGboxbase;
 import org.deegree.commons.jdbc.SQLIdentifier;
 import org.deegree.commons.jdbc.TableName;
 import org.deegree.commons.tom.primitive.PrimitiveType;
@@ -61,7 +62,6 @@ import org.deegree.sqldialect.SortCriterion;
 import org.deegree.sqldialect.filter.AbstractWhereBuilder;
 import org.deegree.sqldialect.filter.PropertyNameMapper;
 import org.deegree.sqldialect.filter.UnmappableException;
-import net.postgis.jdbc.PGboxbase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -292,6 +292,16 @@ public class PostGISDialect extends AbstractSQLDialect implements SQLDialect {
 	@Override
 	public char getTailingEscapeChar() {
 		return escapeChar;
+	}
+
+	@Override
+	public String getOffsetAndFetchClause(int maxFeatures, int startIndex) {
+		StringBuilder sql = new StringBuilder();
+		if (startIndex > 0)
+			sql.append(" OFFSET ").append(startIndex).append(" ROWS");
+		if (maxFeatures > -1)
+			sql.append(" FETCH NEXT ").append(maxFeatures).append(" ROWS ONLY ");
+		return sql.toString();
 	}
 
 }

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/SQLFeatureStore.java
@@ -39,6 +39,7 @@ import static org.deegree.commons.xml.CommonNamespaces.XLNNS;
 import static org.deegree.commons.xml.CommonNamespaces.XSINS;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import javax.xml.namespace.QName;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.sql.Connection;
@@ -56,8 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-
-import javax.xml.namespace.QName;
 
 import org.deegree.commons.jdbc.ResultSetIterator;
 import org.deegree.commons.jdbc.SQLIdentifier;
@@ -1844,10 +1843,9 @@ public class SQLFeatureStore implements FeatureStore {
 	}
 
 	private void appendOffsetAndFetch(StringBuilder sql, int maxFeatures, int startIndex) {
-		if (startIndex > 0)
-			sql.append(" OFFSET ").append(startIndex).append(" ROWS");
-		if (maxFeatures > -1)
-			sql.append(" FETCH NEXT ").append(maxFeatures).append(" ROWS ONLY ");
+		String offsetAndFetchClause = dialect.getOffsetAndFetchClause(maxFeatures, startIndex);
+		if (offsetAndFetchClause != null)
+			sql.append(offsetAndFetchClause);
 	}
 
 }


### PR DESCRIPTION
Currently a GetFeature requesting a WFS with an SQLFeatureStore and MS SQL backend fails with:
```
com.microsoft.sqlserver.jdbc.SQLServerException: Invalid usage of the option NEXT in the FETCH statement.
````
MS SQL requires ORDER BY, OFFSET **and** FETCH. This PR ensures that OFFSET and FETCH are always part of the created SQL Statement. The ORDER BY clause must be added by configuration (in the SQLFeatureStore), otherwise the statement still fails. Other FeatureStores, as well as the SQLFeatureStore with Blob mode, are not tested yet.  


