### PR TITLE
Upgraded dependencies commons-dbcp2, weld-servlet-shaded, primefaces-extensions to latest bugfix version

### DIFF
--- a/deegree-client/deegree-jsf-core/pom.xml
+++ b/deegree-client/deegree-jsf-core/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.jboss.weld.servlet</groupId>
       <artifactId>weld-servlet-shaded</artifactId>
-      <version>5.1.5.Final</version>
+      <version>5.1.6.Final</version>
     </dependency>
     <dependency>
       <groupId>jakarta.el</groupId>

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -294,7 +294,7 @@
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>14.0.12</version>
+      <version>14.0.16</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -587,7 +587,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.12.0</version>
+        <version>2.13.0</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
Upgraded dependencies to:
- commons-dbcp2:2.13.0
- weld-servlet-shaded:5.1.5.Final
- primefaces-extensions:14.0.16


