### PR TITLE
Add reference to GmlLoader usage information in setup tables section

### DIFF
--- a/deegree-documentation/src/main/asciidoc/cli-utility.adoc
+++ b/deegree-documentation/src/main/asciidoc/cli-utility.adoc
@@ -161,6 +161,7 @@ The option useRefDataProps must be used with the option referenceData and result
  * Mapping of optional properties not in the referenceData is omitted.
  * Mapping of properties with xsi:nil="true" in the referenceData is reduced to the mapping of @xsi:nil and @nilReason.
 
+[[anchor-usage-gmlloader]]
 === Using the GmlLoader CLI GmlLoader
 
 ----

--- a/deegree-documentation/src/main/asciidoc/featurestores.adoc
+++ b/deegree-documentation/src/main/asciidoc/featurestores.adoc
@@ -1849,3 +1849,13 @@ If there are no error messages showing, the execution of the SQL script using *S
 The WFS and WMS now retrieve features directly from your database. However, since the database is currently empty, the
 WMS will not render any data, and the WFS will return no features when queried. In order to access features,
 you need to insert data into the database first. This can be done for example by using the deegree GmlLoader.
+
+The deegree GmlLoader is available as a standalone download at:
+
+* https://www.deegree.org/download/
+
+It is also included in the deegree webservices Docker images at the following path inside the container:
+
+* `/opt/deegree-tools-gml.jar`
+
+See usage information in chapter <<anchor-usage-gmlloader>>.


### PR DESCRIPTION
Closes https://github.com/deegree/deegree3/issues/1764

The PR adds a reference to the usage information of the GmlLoader as well as information where the GmlLoader is available.  