### PR TITLE
Upgraded maven dependencies and plugins to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,13 +510,13 @@
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-core</artifactId>
-        <version>2.10.2</version>
+        <version>2.10.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-matchers</artifactId>
-        <version>2.10.2</version>
+        <version>2.10.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
PR includes
- Upgraded maven plugins to latest bugfix version
- Bumped commons-beanutils to 1.11.0 which resolves https://github.com/advisories/GHSA-wxr5-93ph-8wr9
- Bumped springframework to 6.1.21 and spring-boot to 3.3.13
- Bumped commons-fileupload2-jakarta-servlet6 to 2.0.0-M4
- Bumped mssql-jdbc to 12.10.1
- Bumped xmlunit-core to 12.10.3