### PR TITLE
Changed dependencies for imageio-ext with JAXB 4.0 support to custom deegree build

### DIFF
--- a/deegree-core/deegree-core-coverage/pom.xml
+++ b/deegree-core/deegree-core-coverage/pom.xml
@@ -50,7 +50,7 @@
       <artifactId>h2</artifactId>
     </dependency>
     <dependency>
-      <groupId>it.geosolutions.imageio-ext</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>imageio-ext-tiff</artifactId>
     </dependency>
     <dependency>

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/pom.xml
@@ -40,7 +40,7 @@
       <artifactId>jai_imageio</artifactId>
     </dependency>
     <dependency>
-      <groupId>it.geosolutions.imageio-ext</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>imageio-ext-tiff</artifactId>
     </dependency>
     <dependency>

--- a/deegree-tests/deegree-wmts-tests/pom.xml
+++ b/deegree-tests/deegree-wmts-tests/pom.xml
@@ -110,11 +110,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>it.geosolutions.imageio-ext</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>imageio-ext-tiff</artifactId>
     </dependency>
     <dependency>
-      <groupId>it.geosolutions.imageio-ext</groupId>
+      <groupId>org.deegree</groupId>
       <artifactId>imageio-ext-utilities</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1096,9 +1096,9 @@
         <version>2.3.232</version>
       </dependency>
       <dependency>
-        <groupId>it.geosolutions.imageio-ext</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>imageio-ext-utilities</artifactId>
-        <version>1.4.15</version>
+        <version>1.4.16-M1</version>
         <exclusions>
           <exclusion>
             <groupId>javax.media</groupId>
@@ -1123,9 +1123,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>it.geosolutions.imageio-ext</groupId>
+        <groupId>org.deegree</groupId>
         <artifactId>imageio-ext-tiff</artifactId>
-        <version>1.4.15</version>
+        <version>1.4.16-M1</version>
         <exclusions>
           <exclusion>
             <groupId>javax.media</groupId>


### PR DESCRIPTION
This PR changes the groupId for all it.geosolutions.imageio-ext dependencies to org.deegree with version 1.4.16-M1. This patched version of imageio-ext (forked here: https://github.com/deegree/imageio-ext) supports Jakarta API/JAXB 4.0 and fixes the issues reported in #1681. 
As soon as the [imageio project](https://github.com/geosolutions-it/imageio-ext) is publishing a version with Jakarta API support we will switch back to the upstream original artifacts.