### PR TITLE
Upgraded maven dependencies and plugins to latest version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -408,7 +408,7 @@
       <plugin>
         <groupId>io.spring.javaformat</groupId>
         <artifactId>spring-javaformat-maven-plugin</artifactId>
-        <version>0.0.46</version>
+        <version>0.0.47</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.4</version>
+        <version>4.5.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
@@ -566,7 +566,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.17.2</version>
+        <version>1.18.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1158,12 +1158,12 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.11.0</version>
+        <version>2.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
-        <version>1.7</version>
+        <version>1.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.deegree</groupId>
@@ -1209,7 +1209,7 @@
       <dependency>
         <groupId>net.gcardone.junidecode</groupId>
         <artifactId>junidecode</artifactId>
-        <version>0.4.1</version>
+        <version>0.5.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -1276,7 +1276,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.9.3.0</version>
+            <version>4.9.3.2</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <spotbugsXmlOutput>true</spotbugsXmlOutput>
@@ -1285,7 +1285,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-pmd-plugin</artifactId>
-            <version>3.26.0</version>
+            <version>3.27.0</version>
             <configuration>
               <linkXref>true</linkXref>
               <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>


### PR DESCRIPTION
PR includes
* Upgraded maven plugins
* Bump commons-collections4 to 4.5.0
* Bump commons-codec to 1.18.0
* Bump commons-csv to 1.14.0
* Bump gson to 2.13.1
* Bump junidecode to 0.5.2