### PR TITLE
Migrate to Apache Commons Lang 3 

### DIFF
--- a/deegree-services/deegree-services-wfs/pom.xml
+++ b/deegree-services/deegree-services-wfs/pom.xml
@@ -47,8 +47,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/WebFeatureService.java
@@ -36,7 +36,7 @@ package org.deegree.services.wfs;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang.StringUtils.trim;
+import static org.apache.commons.lang3.StringUtils.trim;
 import static org.deegree.commons.ows.exception.OWSException.INVALID_PARAMETER_VALUE;
 import static org.deegree.commons.ows.exception.OWSException.LOCK_HAS_EXPIRED;
 import static org.deegree.commons.ows.exception.OWSException.NO_APPLICABLE_CODE;

--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/GmlFormat.java
@@ -35,7 +35,7 @@
 package org.deegree.services.wfs.format.gml;
 
 import static java.lang.Integer.MAX_VALUE;
-import static org.apache.commons.lang.StringUtils.trim;
+import static org.apache.commons.lang3.StringUtils.trim;
 import static org.deegree.protocol.wfs.getfeature.ResultType.RESULTS;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -559,9 +559,9 @@
         <version>4.5.0</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
This PR migrates `commons-lang:commons-lang:2.6` to `org.apache.commons:commons-lang3:3.18.0` using [org.openrewrite.apache.commons.lang.UpgradeApacheCommonsLang_2_3](https://docs.openrewrite.org/recipes/apache/commons/lang/upgradeapachecommonslang_2_3) 
This upgrade fixes CVE-2025-48924.