### PR TITLE
Fixes nil properties in GeoJSON (3.6)

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonWriter.java
@@ -420,7 +420,15 @@ public class GeoJsonWriter extends JsonWriter implements GeoJsonFeatureWriter, G
 			QName key = attributesAndChildren.keySet().iterator().next();
 			List<TypedObjectNode> values = attributesAndChildren.get(key);
 			if (values.size() == 1 && values.get(0) instanceof PrimitiveValue) {
-				exportValue((PrimitiveValue) values.get(0));
+				if (isNilled(key, values.get(0))) {
+					beginObject();
+					name(key.getLocalPart());
+					exportValue((PrimitiveValue) values.get(0));
+					endObject();
+				}
+				else {
+					exportValue((PrimitiveValue) values.get(0));
+				}
 			}
 			else if (values.size() == 1) {
 				beginObject();
@@ -572,6 +580,12 @@ public class GeoJsonWriter extends JsonWriter implements GeoJsonFeatureWriter, G
 				return Boolean.TRUE.equals(((PrimitiveValue) nil).getValue());
 			}
 		}
+		return false;
+	}
+
+	private boolean isNilled(QName key, TypedObjectNode typedObjectNode) {
+		if (XSI_NIL.equals(key) && typedObjectNode instanceof PrimitiveValue)
+			return Boolean.TRUE.equals(((PrimitiveValue) typedObjectNode).getValue());
 		return false;
 	}
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/geojson/GeoJsonFeatureWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/geojson/GeoJsonFeatureWriterTest.java
@@ -261,6 +261,12 @@ public class GeoJsonFeatureWriterTest {
 		assertThat(featureCollection, hasJsonPath("$.features[0].properties.estimatedAccuracy.uom", is("m")));
 		assertThat(featureCollection, hasJsonPath("$.features[0].properties.inspireId.Identifier.localId",
 				is("urn:adv:oid:DEHHALKA10000005")));
+		assertThat(featureCollection,
+				hasJsonPath("$.features[0].properties.name.GeographicalName.sourceOfName.nil", is(true)));
+		assertThat(featureCollection,
+				hasJsonPath("$.features[0].properties.name.GeographicalName.pronunciation.nil", is(true)));
+		assertThat(featureCollection,
+				hasJsonPath("$.features[0].properties.name.GeographicalName.nameStatus.nil", is(true)));
 		assertThat(featureCollection, hasJsonPath(
 				"$.features[0].properties.name.GeographicalName.spelling.SpellingOfName.text", is("Hamburg")));
 		assertThat(featureCollection,


### PR DESCRIPTION
This PRs fixes incomplete nil Properties. Example from the test:

Before (the two first new assertions failed):
```
"name" : {
        "GeographicalName" : {
          "sourceOfName" : true,
            "spelling" : {
             ....
            "pronunciation" : true,
            "nameStatus" : {
              "nil" : true
            },
      ...
```

After: 
```
"name" : {
        "GeographicalName" : {
          "sourceOfName" : {
            "nil" : true
          },
          ....
          "pronunciation" : {
            "nil" : true
          },
          ....
          "nameStatus" : {
            "nil" : true
          },
      ...
```