### PR TITLE
Fix WKT geometry transformation in GeoJSON for non-default CRS requests (3.6)

### DIFF
--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonGeometryWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonGeometryWriter.java
@@ -9,6 +9,7 @@ import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.cs.persistence.CRSManager;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryTransformer;
+import org.deegree.geometry.io.WKTWriter;
 import org.deegree.geometry.multi.MultiGeometry;
 import org.deegree.geometry.multi.MultiLineString;
 import org.deegree.geometry.multi.MultiPoint;
@@ -55,13 +56,25 @@ public class GeoJsonGeometryWriter {
 	 * Writes the passed geometry as GeoJSON.
 	 * @param geometry geometry to export, never <code>null</code>
 	 * @throws IOException if GeoJSON could no be written
-	 * @throws TransformationException if a geometry to export cannot be transformed to
-	 * CRS:84
+	 * @throws TransformationException if a geometry to export cannot be transformed
 	 * @throws UnknownCRSException if the CRS of the geometry is not supported
 	 */
 	public void writeGeometry(Geometry geometry) throws IOException, TransformationException, UnknownCRSException {
 		Geometry geometryToExport = transformGeometryIfRequired(geometry);
 		exportGeometry(geometryToExport);
+	}
+
+	/**
+	 * Writes the passed geometry as WKT value.
+	 * @param geometry geometry to export as WKT, never <code>null</code>
+	 * @throws IOException if GeoJSON could no be written
+	 * @throws TransformationException if a geometry to export cannot be transformed
+	 * @throws UnknownCRSException if the CRS of the geometry is not supported
+	 */
+	public void writeWktGeometry(Geometry geometry) throws IOException, TransformationException, UnknownCRSException {
+		Geometry geometryToExport = transformGeometryIfRequired(geometry);
+		String wktGeom = WKTWriter.write(geometryToExport);
+		jsonWriter.value(wktGeom);
 	}
 
 	private Geometry transformGeometryIfRequired(Geometry geometry)

--- a/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonWriter.java
+++ b/deegree-core/deegree-core-base/src/main/java/org/deegree/geojson/GeoJsonWriter.java
@@ -20,7 +20,6 @@ import org.deegree.feature.types.property.CustomPropertyType;
 import org.deegree.feature.types.property.FeaturePropertyType;
 import org.deegree.feature.types.property.GeometryPropertyType;
 import org.deegree.geometry.Geometry;
-import org.deegree.geometry.io.WKTWriter;
 import org.deegree.gml.reference.FeatureReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -385,11 +384,11 @@ public class GeoJsonWriter extends JsonWriter implements GeoJsonFeatureWriter, G
 		}
 	}
 
-	private void exportGeometryPropertyTypeAsWkt(Property property) throws IOException {
+	private void exportGeometryPropertyTypeAsWkt(Property property)
+			throws IOException, TransformationException, UnknownCRSException {
 		TypedObjectNode value = property.getValue();
 		if (value instanceof Geometry) {
-			String wkt = WKTWriter.write((Geometry) value);
-			value(wkt);
+			geoJsonGeometryWriter.writeWktGeometry((Geometry) value);
 		}
 	}
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/geojson/GeoJsonFeatureWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/geojson/GeoJsonFeatureWriterTest.java
@@ -355,7 +355,7 @@ public class GeoJsonFeatureWriterTest {
 	}
 
 	@Test(expected = IOException.class)
-	public void testWrite_multipleGeometries_noTunables() throws Exception {
+	public void testWrite_multipleGeometries_noSkipExportAsWkt() throws Exception {
 		StringWriter featureAsJson = new StringWriter();
 		GeoJsonWriter geoJsonFeatureWriter = new GeoJsonWriter(featureAsJson, null);
 		Feature cadastralZoning = parseFeature("zuwanderung_multipleGeometries.gml");
@@ -366,7 +366,7 @@ public class GeoJsonFeatureWriterTest {
 	}
 
 	@Test
-	public void testWrite_multipleGeometries_tunableGeom() throws Exception {
+	public void testWrite_multipleGeometries_skipExportAsWktFalse() throws Exception {
 		StringWriter featureAsJson = new StringWriter();
 		GeoJsonWriter geoJsonFeatureWriter = new GeoJsonWriter(featureAsJson, null,
 				new QName("http://www.deegree.org/datasource/feature/sql", "test_geom2"), false);
@@ -389,7 +389,7 @@ public class GeoJsonFeatureWriterTest {
 	}
 
 	@Test
-	public void testWrite_multipleGeometries_tunableGeomSkipWkt() throws Exception {
+	public void testWrite_multipleGeometries_skipExportAsWktTrue() throws Exception {
 		StringWriter featureAsJson = new StringWriter();
 		GeoJsonWriter geoJsonFeatureWriter = new GeoJsonWriter(featureAsJson, null,
 				new QName("http://www.deegree.org/datasource/feature/sql", "test_geom2"), true);
@@ -407,6 +407,30 @@ public class GeoJsonFeatureWriterTest {
 		assertThat(featureCollection, not(hasJsonPath("$.features[0].properties.test_geom1")));
 		assertThat(featureCollection, not(hasJsonPath("$.features[0].properties.test_geom2")));
 		assertThat(featureCollection, not(hasJsonPath("$.features[0].properties.test_geom3")));
+	}
+
+	@Test
+	public void testWrite_multipleGeometries_skipExportAsWktFalse_EPSG25832() throws Exception {
+		ICRS targetCrs = CRSManager.lookup("EPSG:25832");
+		StringWriter featureAsJson = new StringWriter();
+		GeoJsonWriter geoJsonFeatureWriter = new GeoJsonWriter(featureAsJson, targetCrs,
+				new QName("http://www.deegree.org/datasource/feature/sql", "test_geom2"), false);
+		Feature cadastralZoning = parseFeature("zuwanderung_multipleGeometries.gml");
+
+		geoJsonFeatureWriter.startFeatureCollection();
+		geoJsonFeatureWriter.write(cadastralZoning);
+		geoJsonFeatureWriter.endFeatureCollection();
+
+		String featureCollection = featureAsJson.toString();
+		assertThat(featureCollection, hasJsonPath("$.features[0].geometry.type", is("Point")));
+		assertThat(featureCollection, hasJsonPath("$.features[0].geometry.coordinates[0]", is(705075.4151535835)));
+		assertThat(featureCollection, hasJsonPath("$.features[0].geometry.coordinates[1]", is(5818715.751191899)));
+
+		assertThat(featureCollection,
+				hasJsonPath("$.features[0].properties.test_geom1", is("POINT (640268.604138 5705139.824517)")));
+		assertThat(featureCollection, not(hasJsonPath("$.features[0].properties.test_geom2")));
+		assertThat(featureCollection,
+				hasJsonPath("$.features[0].properties.test_geom3", is("POINT (766718.335245 5933193.592495)")));
 	}
 
 	@Test


### PR DESCRIPTION
This PR follows up on #1830 and resolves an issue with transforming the additional WKT geometry (when enabled) if a different CRS is requested.

PR with backport for 3.5: #1853

GeoJSON output with of an WKT geometry under `EPSG:5555`:
```
"boreholePath": "LINESTRING (476589.310000 5970112.160000 6.020000,476589.310000 5970112.160000 -10.480000)"
```
### Example of behavior **before** the fix
GeoJSON output of the same WKT geometry under `EPSG:5554`:
```
"boreholePath": "LINESTRING (476589.310000 5970112.160000 6.020000,476589.310000 5970112.160000 -10.480000)"
```
* The WKT geometry is not transformed :x: 
### Example of behavior **after** the fix
GeoJSON output of the same  WKT geometry under `EPSG:5554`:
```
"boreholePath": "LINESTRING (870843.268878 5984827.566754 6.025525,870843.268878 5984827.566755 -10.474475)"
```
* The WKT geometry is successfully transformed :heavy_check_mark: 