### PR TITLE
Upgraded maven dependencies and plugins to latest version

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -288,7 +288,7 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>14.0.12</version>
+      <version>14.0.14-LTS</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>

--- a/deegree-tools/deegree-tools-gml/pom.xml
+++ b/deegree-tools/deegree-tools-gml/pom.xml
@@ -133,24 +133,8 @@
     <!-- NOTE: logging is configured by spring boot instead of org.deegree:deegree-core-logging-autoconfigure -->
     <!-- spring -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>${spring-framework.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <version>${spring-framework.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.batch</groupId>
-      <artifactId>spring-batch-core</artifactId>
-      <version>${spring-batch.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-batch</artifactId>
-      <version>${spring-boot.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
@@ -167,15 +151,13 @@
     </dependency>
     <!--  test -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <version>${spring-framework.version}</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.batch</groupId>
       <artifactId>spring-batch-test</artifactId>
-      <version>${spring-batch.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1173,7 +1173,7 @@
       <dependency>
         <groupId>jakarta.mail</groupId>
         <artifactId>jakarta.mail-api</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.11.2</version>
+          <version>3.11.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -254,7 +254,7 @@
         <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>11.0.25</version>
+          <version>11.0.26</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -343,7 +343,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -354,7 +354,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.8.5,)</version>
+                  <version>[3.9,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>${java.version}</version>
@@ -535,7 +535,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.19.0</version>
+        <version>2.20.0</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
@@ -566,7 +566,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.18.0</version>
+        <version>1.19.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1082,7 +1082,7 @@
       <dependency>
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
-        <version>3.10.8</version>
+        <version>3.11.0</version>
         <classifier>jakarta</classifier>
       </dependency>
       <dependency>
@@ -1163,7 +1163,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
-        <version>1.14.0</version>
+        <version>1.14.1</version>
       </dependency>
       <dependency>
         <groupId>org.deegree</groupId>
@@ -1234,13 +1234,11 @@
     <oracle.version>23.4.0.24.05</oracle.version>
     <logback.version>1.5.18</logback.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <spring-boot.version>3.3.13</spring-boot.version>
-    <spring-batch.version>5.1.3</spring-batch.version>
-    <spring-framework.version>6.1.21</spring-framework.version>
+    <spring-boot.version>3.4.9</spring-boot.version>
     <batik.version>1.17</batik.version>
     <axiom.version>1.4.0</axiom.version>
     <jsonpath.version>2.9.0</jsonpath.version>
-    <jsonsmart.version>2.5.2</jsonsmart.version>
+    <jsonsmart.version>2.6.0</jsonsmart.version>
     <jvm.args>--add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED</jvm.args>
   </properties>
 
@@ -1276,7 +1274,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.9.3.2</version>
+            <version>4.9.4.0</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <spotbugsXmlOutput>true</spotbugsXmlOutput>


### PR DESCRIPTION
PR includes

- Upgraded required maven version to 3.9
- Upgraded maven plugins to latest bugfix version
- Cleaned up spring dependencies, using spring-boot dependencies only
- Bumped spring-boot-dependencies to 3.4.9
- Bumped commons-io to 2.20.0
- Bumped commons-codec to 1.19.0
- Bumped commons-csv to 1.14.1
- Bumped ehcache to 3.11.0
- Bumped jsonsmart to 2.6.0
- Bumped primefaces to 14.0.14-LTS
- Bumped jakarta-mail to 2.1.4