### PR TITLE
Fix SOAP WMS namespace (3.6)

### DIFF
--- a/deegree-documentation/src/main/asciidoc/webservices.adoc
+++ b/deegree-documentation/src/main/asciidoc/webservices.adoc
@@ -2011,9 +2011,9 @@ The ExtendedCapabilities are compliant to following schema:
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="https://schemas.deegree.org/extensions/services/wms/1.3.0" xmlns:wms="http://www.opengis.net/wms"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soapwms="https://schemas.deegree.org/extensions/services/wms/1.3.0"
-  targetNamespace="https://schemas.deegree.org/extensions/services/wms/1.3.0">
+<xs:schema xmlns="http://schemas.deegree.org/extensions/services/wms/1.3.0" xmlns:wms="http://www.opengis.net/wms"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soapwms="http://schemas.deegree.org/extensions/services/wms/1.3.0"
+  targetNamespace="http://schemas.deegree.org/extensions/services/wms/1.3.0">
 
   <xs:import namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd" />
 

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Wms130SoapExtendedCapabilitesWriter.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/capabilities/Wms130SoapExtendedCapabilitesWriter.java
@@ -61,7 +61,7 @@ public class Wms130SoapExtendedCapabilitesWriter {
 
 	private static final String SOAPWMS_XSD_LOCATION = "https://schemas.deegree.org/extensions/services/wms/1.3.0/soapwms.xsd";
 
-	public static final String SOAPWMS_NS = "https://schemas.deegree.org/extensions/services/wms/1.3.0";
+	public static final String SOAPWMS_NS = "http://schemas.deegree.org/extensions/services/wms/1.3.0";
 
 	public static final String SOAPWMS_PREFIX = "soapwms";
 

--- a/deegree-services/deegree-services-wms/src/test/resources/org/deegree/services/wms/controller/capabilities/soapwms.xsd
+++ b/deegree-services/deegree-services-wms/src/test/resources/org/deegree/services/wms/controller/capabilities/soapwms.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="https://schemas.deegree.org/extensions/services/wms/1.3.0" xmlns:wms="http://www.opengis.net/wms"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soapwms="https://schemas.deegree.org/extensions/services/wms/1.3.0"
-  targetNamespace="https://schemas.deegree.org/extensions/services/wms/1.3.0">
+<xs:schema xmlns="http://schemas.deegree.org/extensions/services/wms/1.3.0" xmlns:wms="http://www.opengis.net/wms"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soapwms="http://schemas.deegree.org/extensions/services/wms/1.3.0"
+  targetNamespace="http://schemas.deegree.org/extensions/services/wms/1.3.0">
 
   <xs:import namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd" />
 


### PR DESCRIPTION
deegree is using a wrong namespace for SOAP WMS. It starts with http**s** instead of http.

This was fixed and, now, the namespace aligns to the one used in the uploaded schema: https://schemas.deegree.org/extensions/services/wms/1.3.0/soapwms.xsd

Backport for 3.5: #1860 