### PR TITLE
Fix rendering of Multipoints (3.6)

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/Java2DRenderer.java
@@ -148,7 +148,11 @@ public class Java2DRenderer implements Renderer {
 		if (clippedGeometry == null) {
 			return;
 		}
-		if (clippedGeometry instanceof Surface) {
+		if (clippedGeometry instanceof Point) {
+			rendererContext.pointRenderer.render(styling, ((Point) clippedGeometry).get0(),
+					((Point) clippedGeometry).get1());
+		}
+		else if (clippedGeometry instanceof Surface) {
 			rendererContext.polygonRenderer.render(styling, (Surface) clippedGeometry);
 		}
 		else if (clippedGeometry instanceof Curve) {


### PR DESCRIPTION
This PR fixes the rendering of Multipoint  geometries. 

Before: A Multipoint  geometry with multiple points was only rendered if the BBOX of the GetMap requests contained all geometries of the Multipoint geometry. If the BBOX contained only parts of the Multipoint geometry **none** of the points was rendered. 

After: If the BBOX of the GetMap request contains only parts of the Multipoint geometry the visible points are rendered. 