### PR TITLE
Updated user manual about supported Java and Apache Tomcat versions

### DIFF
--- a/deegree-documentation/src/main/asciidoc/appendix.adoc
+++ b/deegree-documentation/src/main/asciidoc/appendix.adoc
@@ -25,7 +25,7 @@ When using JNDI environment, more complex configurations are possible. For examp
              description="deegree Rendering - Miter Limit Factor"/>
 ----
 More details on the details of configuration can be found inside the documentation of the used Java Servlet container
-like https://tomcat.apache.org/tomcat-9.0-doc/config/context.html#Environment_Entries[Apache Tomcat].
+like https://tomcat.apache.org/tomcat-10.1-doc/config/context.html#Environment_Entries[Apache Tomcat].
 
 .List of current available parameters
 

--- a/deegree-documentation/src/main/asciidoc/basics.adoc
+++ b/deegree-documentation/src/main/asciidoc/basics.adoc
@@ -98,10 +98,10 @@ runs deegree. If you started the Java Servlet container as user
 _/home/kelvin/.deegree_.
 
 TIP: In order to use a different folder for deegree's configuration files,
-you can set the environment variable _DEEGREE_WORKSPACE_ROOT_, for example with `export DEEGREE_WORKSPACE_ROOT=/var/lib/tomcat9/.deegree`. When using Tomcat you can also set the path by defining a Java system property and appending the `JAVA_OPTS` or `CATALINA_OPTS` environment variable with `CATALINA_OPTS=-DDEEGREE_WORKSPACE_ROOT=/var/lib/tomcat9/.deegree`.
+you can set the environment variable _DEEGREE_WORKSPACE_ROOT_, for example with `export DEEGREE_WORKSPACE_ROOT=/var/lib/tomcat/.deegree`. When using Tomcat you can also set the path by defining a Java system property and appending the `JAVA_OPTS` or `CATALINA_OPTS` environment variable with `CATALINA_OPTS=-DDEEGREE_WORKSPACE_ROOT=/var/lib/tomcat/.deegree`.
 
 IMPORTANT: Note that the user running the web application container must have
-read/write access to this directory! Since Debian 11 you have to grant explicitly write access to the default home directory by setting `ReadWritePaths=/var/lib/tomcat9/.deegree` in _/etc/systemd/system/multi-user.target.wants/tomcat9.service_!
+read/write access to this directory! Since Debian 11 you have to grant explicitly write access to the default home directory by setting `ReadWritePaths=/var/lib/tomcat/.deegree` in _/etc/systemd/system/multi-user.target.wants/tomcat.service_!
 
 ==== Windows
 

--- a/deegree-documentation/src/main/asciidoc/featurestores.adoc
+++ b/deegree-documentation/src/main/asciidoc/featurestores.adoc
@@ -208,7 +208,7 @@ The configuration format for the deegree shape feature store is defined
 by schema file
 https://schemas.deegree.org/core/3.6/datasource/feature/shape/shape.xsd. The
 following table lists all available configuration options. When
-specifiying them, their order must be respected.
+specifying them, their order must be respected.
 
 [width="100%",cols="24%,10%,7%,59%",options="header",]
 |===

--- a/deegree-documentation/src/main/asciidoc/gdal.adoc
+++ b/deegree-documentation/src/main/asciidoc/gdal.adoc
@@ -146,7 +146,7 @@ pages in the GDAL documentation.
 The configuration format for the GDAL settings file is defined by schema
 file https://schemas.deegree.org/core/3.6/commons/gdal/gdal.xsd. The
 following table lists the two available configuration options. When
-specifiying them, their order must be respected.
+specifying them, their order must be respected.
 
 [width="100%",cols="16%,14%,10%,60%",options="header",]
 |===

--- a/deegree-documentation/src/main/asciidoc/installation.adoc
+++ b/deegree-documentation/src/main/asciidoc/installation.adoc
@@ -4,20 +4,18 @@
 [[system-requirements]]
 === System requirements
 
-deegree webservices work on any platform with a compatible Java SE 11
-installation, including:
+deegree webservices work on any platform with a compatible Java SE 17 installation, including:
 
 * Microsoft Windows
 * Linux
 * macOS
 
-Supported Java SE 11 versions are
-https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK 11]
-footnote:[Oracle JDK 8 and later requires a subscription from Oracle for use in production environments. Read further in https://www.oracle.com/java/java-se-subscription/[Oracle Java SE subscription].] and https://openjdk.org/projects/jdk/11/[OpenJDK 11]
-footnote:[OpenJDK binaries are provided by https://www.azul.com/downloads/#zulu[Azul Systems]
-or https://adoptium.net/[Eclipse Temurin].].
+Supported Java SE 17 versions are
+https://www.oracle.com/java/technologies/downloads/#java17[Oracle JDK 17]
+footnote:[Oracle JDK requires a subscription from Oracle for use in production environments. Read further in https://www.oracle.com/java/java-se-subscription/[Oracle Java SE subscription].] and https://adoptium.net/en-GB/temurin/releases?version=17&os=any&arch=any[Eclipse Temurin JDK 17]
+footnote:[OpenJDK binaries are also provided by https://www.azul.com/downloads/#zulu[Azul Systems] or https://aws.amazon.com/de/corretto[Amazon Corretto 17].].
 
-NOTE: Newer Java SE versions such as the LTS versions 17 are currently not supported by deegree 3.5. Please check out our wiki page https://github.com/deegree/deegree3/wiki/End-of-Life-and-Support-Matrix[End of Life and Support Matrix] for further information.
+NOTE: Newer Java SE versions such as the LTS versions 21 may work but are not tested by the community. Please check out our wiki page https://github.com/deegree/deegree3/wiki/End-of-Life-and-Support-Matrix[End of Life and Support Matrix] for further information.
 
 === Downloading
 
@@ -29,9 +27,9 @@ Tomcat footnote:[Requires an installation of Docker Community or
 Enterprise Edition, download Docker from
 https://www.docker.com/[www.docker.com].]
 * _WAR_: Generic Java Web Archive for deployment in an existing Java
-Servlet container footnote:[A Java Servlet 3.1 compliant container is
+Servlet container footnote:[A Java Servlet 6.0 compliant container is
 required. We recommend using the latest https://tomcat.apache.org/[Apache
-Tomcat 9] release.]
+Tomcat 10.1] release.]
 
 TIP: If you are confused by the options and unsure which version to pick,
 use the WAR. All variants contain exactly the same deegree webservices webapp,
@@ -72,8 +70,8 @@ To shut deegree webservices down, switch back to the terminal window and
 press _CTRL+c_ or simply close it.
 
 TIP: If you want to run deegree webservices on system startup automatically,
-consider installing https://tomcat.apache.org[Apache Tomcat 9] as a
-system service. Consult the https://tomcat.apache.org/tomcat-9.0-doc/index.html[Tomcat documentation]
+consider installing https://tomcat.apache.org[Apache Tomcat] as a
+system service. Consult the https://tomcat.apache.org/tomcat-10.1-doc/index.html[Tomcat documentation]
 for more information and options.
 
 === Securing deegree
@@ -98,7 +96,7 @@ releases of software:
 
 TIP: If you are running Apache Tomcat we recommend that you read and apply
 all recommendations as documented in
-https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html[Apache Tomcat Security Considerations].
+https://tomcat.apache.org/tomcat-10.1-doc/security-howto.html[Apache Tomcat Security Considerations].
 
 ==== Encryption
 
@@ -107,7 +105,7 @@ or TLS. Either enable HTTPS on your Java Servlet Container or operate it
 behind a web server such as Apache httpd oder NGINX.
 
 TIP: If you are running Apache Tomcat read the
-https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html[SSL HowTo].
+https://tomcat.apache.org/tomcat-10.1-doc/ssl-howto.html[SSL configuration HowTo].
 
 ==== Securing the deegree webservices administration console and REST API
 
@@ -128,5 +126,5 @@ you must not operate the Java Servlet container as root user!
 Furthermore, you should consider to enable the Java Security Manager and
 define restrictive file permissions.footnote:[How to run securely Java
 applications we recommend to follow the
-https://docs.oracle.com/en/java/javase/11/security/index.html[Java Security Guidelines] and for
-https://tomcat.apache.org/tomcat-9.0-doc/security-manager-howto.html[Apache Tomcat the Security Manager HowTo].]
+https://docs.oracle.com/en/java/javase/17/security/index.html[Java Security Guidelines] and for
+https://tomcat.apache.org/tomcat-10.1-doc/security-manager-howto.html[Apache Tomcat the Security Manager HowTo].]

--- a/deegree-documentation/src/main/asciidoc/intro.adoc
+++ b/deegree-documentation/src/main/asciidoc/intro.adoc
@@ -3,7 +3,7 @@
 deegree webservices are implementations of the geospatial webservice
 specifications of the https://www.ogc.org/[Open Geospatial
 Consortium (OGC)] and the https://inspire.jrc.ec.europa.eu[INSPIRE
-Network Services]. deegree webservices 3.5 includes the following
+Network Services]. deegree webservices 3.6 includes the following
 services:
 
 * https://www.ogc.org/standard/wfs/[Web Feature Service

--- a/deegree-documentation/src/main/asciidoc/javamodules.adoc
+++ b/deegree-documentation/src/main/asciidoc/javamodules.adoc
@@ -105,7 +105,7 @@ The following deegree resources support Oracle Spatial databases:
 
 In order to enable Oracle connectivity for these resources, you need to
 add a compatible Oracle JDBC driver (e.g.
-_ojdbc11.jar_)footnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
+_ojdbc17.jar_)footnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
 (see <<anchor-adding-jars>>).
 
 ==== Adding Oracle GeoRaster support
@@ -117,7 +117,7 @@ In order to enable Oracle connectivity for these resources, you need to
 add the following JAR files (see <<anchor-adding-jars>>):
 
 * A compatible Oracle JDBC-driverfootnote:[https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html]
-** ojdbc11.jar
+** ojdbc17.jar
 * The Oracle Spatial and GeoRaster libraries and their dependencies
 ** sdoapi.jar
 ** sdogr.jar
@@ -144,5 +144,5 @@ The following deegree resources support Microsoft SQL Server:
 
 In order to enable Microsoft SQL Server connectivity for these
 resources, you need to add a compatible Microsoft JDBC driver (e.g.
-_mssql-jdbc-12.6.1.jre11.jar_)footnote:[https://learn.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server]
+_mssql-jdbc-13.2.0.jre11.jar_)footnote:[https://learn.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server]
 (see <<anchor-adding-jars>>).

--- a/deegree-documentation/src/main/asciidoc/metadatastores.adoc
+++ b/deegree-documentation/src/main/asciidoc/metadatastores.adoc
@@ -39,8 +39,7 @@ https://schemas.deegree.org/core/3.6/datasource/metadata/iso19139/memory/memory.
 </ISOMemoryMetadataStore>
 ----
 
-The root element has to be _ISOMemoryMetadataStore_ and the optional
-attribute `config` can be set to _3.5.0_. The only mandatory element is:
+The root element has to be _ISOMemoryMetadataStore_ and the only mandatory element is:
 
 * _ISORecordDirectory_: A list of directories containing records
 loaded in the store during start of the store.
@@ -95,8 +94,7 @@ https://schemas.deegree.org/core/3.6/datasource/metadata/iso19115/iso19115.xsd
 </ISOMetadataStore>
 ----
 
-The root element has to be _ISOMetadataStore_ and the optional
-attribute `config` can be set to _3.5.0_. The only mandatory element is:
+The root element has to be _ISOMetadataStore_ and the only mandatory element is:
 
 * _JDBCConnId_: Id of the JDBC connection to use (see ...)
 

--- a/deegree-documentation/src/main/asciidoc/serverconnections.adoc
+++ b/deegree-documentation/src/main/asciidoc/serverconnections.adoc
@@ -234,8 +234,7 @@ creating an Oracle UCP connection pool.
 
 The database connection config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/connectionprovider/datasource/datasource.xsd. The
-root element is _DataSourceConnectionProvider_ and the optional
-attribute `config` can be set to _3.5.0_. The following table lists the available
+root element is _DataSourceConnectionProvider_. The following table lists the available
 configuration options. When specifying them, their order must be
 respected.
 
@@ -455,8 +454,7 @@ is called 'inspire', the database user is 'postgres' and password is
 
 The legacy connection config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/jdbc/jdbc.xsd. The root element is
-_JDBCConnection_. The
-following table lists the available configuration options. When
+_JDBCConnection_. The following table lists the available configuration options. When
 specifying them, their order must be respected.
 
 [width="100%",cols="16%,18%,12%,54%",options="header",]

--- a/deegree-documentation/src/main/asciidoc/tilestores.adoc
+++ b/deegree-documentation/src/main/asciidoc/tilestores.adoc
@@ -134,7 +134,7 @@ _-co BIGTIFF=YES_ option)
 * it must be created as a tiled tiff (eg. with GDAL using the
 _-co TILED=YES_ option)
 * it can contain overviews (it is best to use a recent GDAL version >=
-1.8.0, where you can use _GDAL_TIFF_OVR_BLOCKSIZE_ to specify the
+3.0, where you can use _GDAL_TIFF_OVR_BLOCKSIZE_ to specify the
 overview tile size)
 * it is recommended that the overviews contain the same tile size as the
 main level

--- a/deegree-documentation/src/main/asciidoc/webservices.adoc
+++ b/deegree-documentation/src/main/asciidoc/webservices.adoc
@@ -127,8 +127,7 @@ A more complex configuration example looks like this:
 
 The deegree WFS config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/services/wfs/wfs_configuration.xsd. The
-root element is <deegreeWFS> and the optional
-attribute `config` can be set to _3.5.0_. The following table lists all available configuration options
+root element is _deegreeWFS_. The following table lists all available configuration options
 (complex ones contain nested options themselves). When specifying them,
 their order must be respected.
 
@@ -2147,7 +2146,7 @@ like this:
 
 The deegree WMTS config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/services/wmts/wmts.xsd. The root
-element is _deegreeWMTS_ and the optional attribute `config` can be set to _3.5.0_.
+element is _deegreeWMTS_.
 
 The following table lists all available configuration options. When
 specifying them, their order must be respected.
@@ -2361,7 +2360,7 @@ example looks like this:
 
 The deegree CSW config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/services/csw/csw_configuration.xsd. The
-root element is _deegreeCSW_ and the optional attribute `config` can be set to _3.5.0_.
+root element is _deegreeCSW_.
 
 The following table lists all available configuration options. When
 specifying them, their order must be respected.
@@ -2492,9 +2491,8 @@ storage directory.
 
 The deegree WPS config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/services/wps/wps_configuration.xsd. The
-root element is _deegreeWPS_ and the config attribute must be
-_3.1.0_. The following table lists all available configuration options
-(complex ones contain nested options themselves). When specifiying them,
+root element is _deegreeWPS_. The following table lists all available configuration options
+(complex ones contain nested options themselves). When specifying them,
 their order must be respected.
 
 [width="100%",cols="28%,14%,10%,48%",options="header",]
@@ -2622,8 +2620,7 @@ configuration works for all types of service alike.
 
 The metadata config file format is defined by schema file
 https://schemas.deegree.org/core/3.6/services/metadata/metadata.xsd. The
-root element is _deegreeServicesMetadata_ and the optional
-attribute `config` can be set to _3.5.0_. The following table lists all available configuration
+root element is _deegreeServicesMetadata_. The following table lists all available configuration
 options (complex ones contain nested options themselves). When
 specifying them, their order must be respected.
 


### PR DESCRIPTION
This PR sets the supported Java/JDK  and Apache Tomcat version and documentation links to the versions supported by deegree webservices 3.6. The supported JDK is 17 and the supported Servlet API Version 6.0 which is provided by Apache Tomcat version 10.1. 

Reference is https://github.com/deegree/deegree3/wiki/End-of-Life-and-Support-Matrix#support-matrix