### PR TITLE
Fix unremoved tmp file (3.6)

### DIFF
--- a/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/BufferableXMLStreamWriter.java
+++ b/deegree-services/deegree-services-wfs/src/main/java/org/deegree/services/wfs/format/gml/BufferableXMLStreamWriter.java
@@ -181,6 +181,7 @@ public class BufferableXMLStreamWriter implements XMLStreamWriter {
 			}
 			inStream.next();
 		}
+		buffer.reset();
 	}
 
 	private void copyAttributes(GMLStreamWriter gmlWriter, XMLStreamReader inStream) throws XMLStreamException {


### PR DESCRIPTION
Before a tmp file of a large WFS GetFeature response was not removed. This PR ensures that the underlying stream is closed and the tmp file removed.