### PR TITLE
Upgrade Maven wrapper

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 wrapperVersion=3.3.1
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip


### PR DESCRIPTION
Upgrade Maven wrapper after #1857 changed the minimal required version.

Command used to create this PR:
`./mvnw wrapper:wrapper -Dmaven=3.9.11`