### PR TITLE
Extended API of Cql2FilterParser for use in OGC API features

### DIFF
--- a/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/CQL2FilterParser.java
+++ b/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/CQL2FilterParser.java
@@ -35,6 +35,8 @@
 package org.deegree.cql2;
 
 import javax.xml.namespace.QName;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.antlr.v4.runtime.CharStream;
@@ -51,7 +53,26 @@ public final class CQL2FilterParser {
 	private CQL2FilterParser() {
 	}
 
+	/**
+	 * @param filter the filter to parse, never <code>null</code>
+	 * @param crs never <code>null</code>
+	 * @param availableProperties used to identify properties with namespace bindings, may
+	 * be empty or <code>null</code>
+	 */
 	public static Operator parseCql2Filter(String filter, ICRS crs, Set<QName> availableProperties) {
+		List<FilterProperty> filterProperties = availableProperties != null ? availableProperties.stream()
+			.map(prop -> new FilterProperty(prop, FilterPropertyType.UNKNOWN))
+			.toList() : Collections.emptyList();
+		return parseCql2Filter(filter, crs, filterProperties);
+	}
+
+	/**
+	 * @param filter the filter to parse, never <code>null</code>
+	 * @param crs never <code>null</code>
+	 * @param filterProperties used to identify properties with namespace bindings, may be
+	 * empty or <code>null</code>
+	 */
+	public static Operator parseCql2Filter(String filter, ICRS crs, List<FilterProperty> filterProperties) {
 		CharStream input = CharStreams.fromString(filter);
 		Cql2Lexer lexer = new Cql2Lexer(input);
 		CommonTokenStream cts = new CommonTokenStream(lexer);
@@ -60,7 +81,7 @@ public final class CQL2FilterParser {
 		parser.removeErrorListeners();
 		parser.addErrorListener(new Cql2ErrorListener());
 		Cql2Parser.BooleanExpressionContext cql2 = parser.booleanExpression();
-		Cql2FilterVisitor visitor = new Cql2FilterVisitor(crs, availableProperties);
+		Cql2FilterVisitor visitor = new Cql2FilterVisitor(crs, filterProperties);
 		return (Operator) visitor.visit(cql2);
 	}
 

--- a/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/FilterProperty.java
+++ b/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/FilterProperty.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * deegree-ogcapi-features - OGC API Features (OAF) implementation - Querying and modifying of geospatial data objects
+ * %%
+ * Copyright (C) 2019 - 2020 lat/lon GmbH, info@lat-lon.de, www.lat-lon.de
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package org.deegree.cql2;
+
+import javax.xml.namespace.QName;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a> Required for type safe
+ * filtering.
+ */
+public class FilterProperty {
+
+	private QName name;
+
+	private FilterPropertyType type;
+
+	public FilterProperty(QName name, FilterPropertyType type) {
+		this.name = name;
+		this.type = type;
+	}
+
+	public QName getName() {
+		return name;
+	}
+
+	public FilterPropertyType getType() {
+		return type;
+	}
+
+}

--- a/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/FilterPropertyType.java
+++ b/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/FilterPropertyType.java
@@ -1,0 +1,57 @@
+package org.deegree.cql2;
+
+import org.apache.xerces.xs.XSTypeDefinition;
+import org.deegree.commons.tom.primitive.BaseType;
+
+/**
+ * Enhances {@link BaseType} by GEOMETRY and UNKNOWN (as fallback).
+ *
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public enum FilterPropertyType {
+
+	STRING, BOOLEAN, DECIMAL, DOUBLE, INTEGER, DATE, DATE_TIME, TIME, GEOMETRY, UNKNOWN;
+
+	/**
+	 * @param baseType may be <code>null</code> (returns STRING)
+	 * @return FilterPropertyType derived from BaseType, fallback to STRING
+	 */
+	public static FilterPropertyType fromBaseType(BaseType baseType) {
+		try {
+			return FilterPropertyType.valueOf(baseType.name());
+		}
+		catch (IllegalArgumentException e) {
+			return STRING;
+		}
+	}
+
+	/**
+	 * @param typeDefinition may be <code>null</code> (returns null)
+	 * @return FilterPropertyType derived from XSTypeDefinition, <code>null</code>> of not
+	 * a mappable type
+	 */
+	public static FilterPropertyType fromXsdTypeDefinition(XSTypeDefinition typeDefinition) {
+		if (typeDefinition != null) {
+			String type = typeDefinition.getName();
+			switch (type) {
+				case "string":
+				case "anyURI":
+					return STRING;
+				case "boolean":
+					return BOOLEAN;
+				case "decimal":
+					return DECIMAL;
+				case "integer":
+					return INTEGER;
+				case "dateTime":
+					return DATE_TIME;
+				case "time":
+					return TIME;
+				case "date":
+					return DATE;
+			}
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
This PR prepares the Cql2Parser to be used by the OGC API features. As OGC API features is more strict with unavailable properties or unmatching property times (e.g. if a string property is used in a T_AFTER request), the changes from OGC API https://github.com/deegree/deegree-ogcapi/pull/163 was migrated to deegree3.    