### PR TITLE
Removed references to 3rd party repositories from Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,6 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>geotools-releases</id>
-      <url>https://repo.osgeo.org/repository/geotools-releases/</url>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-    </repository>
   </repositories>
 
   <distributionManagement>


### PR DESCRIPTION
This pull request removes two external remote repositories from Maven pom as the only required dependency is now also available via https://repo.deegree.org/#browse/browse:public.

Background and workflow of creating this PR are described in #1876.

Closes #1876