### PR TITLE
Fixed missing mapping of required attributes if property is nillable

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/AppSchemaMapper.java
@@ -610,7 +610,7 @@ public class AppSchemaMapper {
 			if (attrDecl.getNamespace() != null) {
 				attrName = new QName(attrDecl.getNamespace(), attrDecl.getName());
 			}
-			if (propertyIsNilled && !"nilReason".equals(attrName.getLocalPart())) {
+			if (!attrUse.getRequired() && propertyIsNilled && !"nilReason".equals(attrName.getLocalPart())) {
 				continue;
 			}
 			if (attrDecl.getNamespace() != null) {
@@ -672,7 +672,7 @@ public class AppSchemaMapper {
 				// TODO should all xlink attributes be skipped?
 				continue;
 			}
-			if (propertyIsNilled && !"nilReason".equals(attrName.getLocalPart())) {
+			if (!attrUse.getRequired() && propertyIsNilled && !"nilReason".equals(attrName.getLocalPart())) {
 				continue;
 			}
 			if (attrDecl.getNamespace() != null) {

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/resources/org/deegree/feature/persistence/sql/mapper/schemaWithNilValuesAndRequiredAttributes.xsd
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/test/resources/org/deegree/feature/persistence/sql/mapper/schemaWithNilValuesAndRequiredAttributes.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:te="http://test.de/schema"
+        xmlns:gml="http://www.opengis.net/gml/3.2" elementFormDefault="qualified"
+        targetNamespace="http://test.de/schema" version="4.0">
+
+  <import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd"/>
+
+  <element name="FeatureA" substitutionGroup="gml:AbstractFeature" type="te:FeatureAType"/>
+  <complexType name="FeatureAType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="prop_A1" type="string" maxOccurs="unbounded"/>
+          <element name="prop_A2" type="int"/>
+          <element name="prop_A3" minOccurs="0" maxOccurs="unbounded" nillable="true">
+            <complexType>
+              <simpleContent>
+                <extension base="int">
+                  <attribute name="nilReason" type="gml:NilReasonType"/>
+                </extension>
+              </simpleContent>
+            </complexType>
+          </element>
+          <element name="complex_A4" maxOccurs="unbounded" nillable="true">
+            <complexType>
+              <sequence>
+                <element name="prop_A4_1" type="string" maxOccurs="unbounded" nillable="true"/>
+                <element name="prop_A4_2" type="int" nillable="true"/>
+                <element name="prop_A4_3" type="int" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+              </sequence>
+              <attribute name="nilReason" type="gml:NilReasonType"/>
+              <attribute name="reqAtt" type="string" use="required"/>
+            </complexType>
+          </element>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>
+


### PR DESCRIPTION
Using the Gml Tools SqlFeatureStoreConfigCreator the mapping of required attributes is missing if a property is nilled.

```
deegree-tools-gml.jar SqlFeatureStoreConfigCreator -idtype=uuid -useRefDataProps=true -format=all -deegree.gml.parse.recognize-deprecated-types=false -dbschema=alkis -referenceData=building.gml -schemaUrl=https://inspire.ec.europa.eu/schemas/bu-core2d/4.0/BuildingsCore2D.xsd
```

Example from https://inspire.ec.europa.eu/schemas/bu-core2d/4.0/BuildingsCore2D.xsd:
```
<complexType name="MeasureType">
  <simpleContent>
    <extension base="double">
      <attribute name="uom" type="gml:UomIdentifier" use="required"/>
    </extension>
  </simpleContent>
</complexType>
```

uom is a required attribute but missing in the resulting mapping:;

```
<Complex path="bu-base:horizontalGeometryEstimatedAccuracy">
  <Primitive path="@xsi:nil" mapping="bu_core2d_geometry2d_bu_base_buildinggeometry2d_bu_base_hori_24"/>
  <Primitive path="@nilReason" mapping="bu_core2d_geometry2d_bu_base_buildinggeometry2d_bu_base_hori_25"/>
</Complex>
```

The referenceData contains the property:
```
 <bu-base:horizontalGeometryEstimatedAccuracy uom="m" nilReason="other:unpopulated" xsi:nil="true"></bu-base:horizontalGeometryEstimatedAccuracy>
```

This PR fixes the Gml Tool by writing the mapping of required attributes even if the property is nilled:

```
<Complex path="bu-base:horizontalGeometryEstimatedAccuracy">
  <Primitive path="@xsi:nil" mapping="bu_core2d_geometry2d_bu_base_buildinggeometry2d_bu_base_hori_44"/>
  <Primitive path="@nilReason" mapping="bu_core2d_geometry2d_bu_base_buildinggeometry2d_bu_base_hori_45"/>
  <Primitive path="@uom" mapping="bu_core2d_geometry2d_bu_base_buildinggeometry2d_bu_base_hori_46"/>
</Complex>
```

  