### PR TITLE
Migrated and upgraded of commons-collections4 to version 4.5.0 and of commons-beanutils2 to version 2.0.0-M2

### DIFF
--- a/deegree-core/deegree-connectionprovider-datasource/pom.xml
+++ b/deegree-core/deegree-connectionprovider-datasource/pom.xml
@@ -33,8 +33,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-beanutils2</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceInitializer.java
+++ b/deegree-core/deegree-connectionprovider-datasource/src/main/java/org/deegree/db/datasource/DataSourceInitializer.java
@@ -47,10 +47,10 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.beanutils.ConstructorUtils;
-import org.apache.commons.beanutils.ConvertUtils;
-import org.apache.commons.beanutils.MethodUtils;
+import org.apache.commons.beanutils2.BeanUtils;
+import org.apache.commons.beanutils2.ConstructorUtils;
+import org.apache.commons.beanutils2.ConvertUtils;
+import org.apache.commons.beanutils2.MethodUtils;
 import org.deegree.db.datasource.jaxb.DataSourceConnectionProvider;
 import org.deegree.db.datasource.jaxb.DataSourceConnectionProvider.DataSource.Argument;
 import org.slf4j.Logger;

--- a/deegree-core/deegree-core-gdal/pom.xml
+++ b/deegree-core/deegree-core-gdal/pom.xml
@@ -31,8 +31,8 @@
       <artifactId>gdal</artifactId>
     </dependency>
 	<dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
 	</dependency>    
   </dependencies>
 </project>

--- a/deegree-services/deegree-services-wms/pom.xml
+++ b/deegree-services/deegree-services-wms/pom.xml
@@ -92,8 +92,8 @@
     </dependency>
     -->
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-beanutils2</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -90,7 +90,7 @@ import javax.xml.transform.dom.DOMSource;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.soap.SOAP11Version;
 import org.apache.axiom.soap.SOAPVersion;
-import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils2.BeanUtils;
 import org.apache.commons.fileupload2.core.FileItem;
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.ows.metadata.ServiceIdentification;

--- a/pom.xml
+++ b/pom.xml
@@ -537,9 +537,9 @@
         <version>2.20.0</version>
       </dependency>
       <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.11.0</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-beanutils2</artifactId>
+        <version>2.0.0-M2</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -548,9 +548,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>3.2.2</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Following dependencies were migrated to a more recent version:
* commons-collections:commons-collections:3.2.2 -> org.apache.commons:commons-collections4:4.5.0
* commons-beanutils:commons-beanutils:1.11.0 -> org.apache.commons:commons-beanutils2:2.0.0-M2

Afterwards, `commons-collections:commons-collections` is not used by deegree3 anymore. Instead, `org.apache.commons:commons-collections4:4.5.0` is used.

Closes #1891