### PR TITLE
Updated maven plugins used for building the maven site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.21.0</version>
+          <version>3.12.1</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>
@@ -220,7 +220,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.11.3</version>
+          <version>3.12.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -254,6 +254,7 @@
           <detectLinks>false</detectLinks>
           <detectOfflineLinks>false</detectOfflineLinks>
           <excludePackageNames>*.jaxb</excludePackageNames>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>
@@ -426,11 +427,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.12.0</version>
         <configuration>
           <doclint>none</doclint>
           <detectLinks>false</detectLinks>
           <detectOfflineLinks>false</detectOfflineLinks>
+          <excludePackageNames>*.jaxb</excludePackageNames>
+          <release>${java.version}</release>
           <minmemory>512m</minmemory>
           <maxmemory>2g</maxmemory>
           <inherited>false</inherited>
@@ -1299,13 +1302,14 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.2</version>
+            <version>3.12.0</version>
             <configuration>
               <doclint>none</doclint>
               <detectLinks>false</detectLinks>
               <detectOfflineLinks>false</detectOfflineLinks>
               <failOnError>false</failOnError>
               <excludePackageNames>*.jaxb</excludePackageNames>
+              <release>${java.version}</release>
               <minmemory>512m</minmemory>
               <maxmemory>4g</maxmemory>
               <inherited>false</inherited>
@@ -1328,7 +1332,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.1.3</version>
+            <version>12.1.8</version>
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,13 +3,13 @@
 <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.11.2</version>
+    <version>1.12.0</version>
   </skin>
   <body>
 
     <links>
       <item name="Home" href="https://www.deegree.org"/>
-      <item name="User Documentation" href="https://www.deegree.org/documentation/"/>
+      <item name="User Documentation" href="https://www.deegree.org/documentation"/>
       <item name="Source Code Repository" href="https://github.com/deegree/deegree3"/>
     </links>
 


### PR DESCRIPTION
This PR upgrades the maven plugins used to build the maven site:
- maven-javadoc-plugin
- maven-site-plugin
- dependency-check-maven

Tested with:
- `mvn site` -> only JavaDoc 
- `mvn site -P site-all-reports` -> full site with more reports
- `mvn javadoc:javadoc` -> runs the javadoc for reactor build without aggregation