### PR TITLE
Set Annotation API to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,7 @@
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>2.1.1</version>
+        <scope>provided</scope>
       </dependency>
       <!-- test dependencies -->
       <dependency>


### PR DESCRIPTION
Annotation API is provided by Tomcat (https://tomcat.apache.org/whichversion.html) and must not be provided by webapp.

Detected during work on https://github.com/deegree/deegree3/issues/1879#issuecomment-3414690898.