### PR TITLE
Introduce stale bot to automatically mark stale pr and close them after further inactivity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '42 1 * * 3'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # dry-run / no changes
+          debug-only: true
+          enable-statistics: true
+          # 
+          stale-pr-label: "stuck"
+          close-pr-label: "auto-closed"
+          remove-pr-stale-when-updated: true
+          #
+          stale-pr-message: 'Thank you for your contribution. Unfortunately, this PR has been inactive for 90 days (see [PR stuck workflow](https://github.com/deegree/deegree3/wiki/Working-with-pull-requests#pull-requests-stuck-workflow)). Of course this is not the final word. The PR can become unstuck, for example, by reengaging in the discussion, answering open questions, rebasing, or adding new commits to this PR.'
+          close-pr-message: 'Thank you for your contribution. Unfortunately, this PR got stuck (see [PR stuck workflow](https://github.com/deegree/deegree3/wiki/Working-with-pull-requests#pull-requests-stuck-workflow)). Of course this is not the final word. If you think that we did wrong, then reopening this pull request, continuing the conversation, and/or finishing any outstanding tasks will help to restart the decision-making process. Perhaps we can then, with additional information, merge the pull request. Anyhow, we do appreciate your commitment to open source and to deegree in particular.'
+          #
+          days-before-pr-stale: 90
+          days-before-pr-close: 90
+          # disabled for issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
NOTE: Currently configured in dry-run mode.

This PR will mark stale PR after 90 days of inactivity and will close marked PRs after additionl 90 days.

Documentation of the bot: https://github.com/actions/stale?tab=readme-ov-file#close-stale-issues-and-prs

Related Issue https://github.com/deegree/deegree3/issues/1874