### PR TITLE
Improved code quality by removing unnecessary boxing of wrapper types

### DIFF
--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/feature/xpath/GMLObjectXPathTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/feature/xpath/GMLObjectXPathTest.java
@@ -263,7 +263,7 @@ public class GMLObjectXPathTest {
 		assertEquals(1, result.length);
 		PrimitiveValue value = (PrimitiveValue) result[0];
 		assertEquals(DOUBLE, value.getType().getBaseType());
-		assertEquals(new Double(7.0), value.getValue());
+		assertEquals(7.0, value.getValue());
 	}
 
 	@Test

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/feature/GMLFeatureWriterTest.java
@@ -132,7 +132,7 @@ public class GMLFeatureWriterTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
 				SCHEMA_LOCATION_31);
@@ -168,7 +168,7 @@ public class GMLFeatureWriterTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
 				SCHEMA_LOCATION_31);
@@ -199,7 +199,7 @@ public class GMLFeatureWriterTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		XMLStreamWriter writer = memoryWriter.getXMLStreamWriter();
 
@@ -431,7 +431,7 @@ public class GMLFeatureWriterTest {
 	public void testDecimalPropertyEncodedFaithfully() throws Exception {
 		final String formattedInputValue = "0.00000009";
 		final XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		final XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		final XMLStreamWriter writer = memoryWriter.getXMLStreamWriter();
 		final GMLStreamWriter exporter = createGMLStreamWriter(GML_2, writer);
@@ -457,7 +457,7 @@ public class GMLFeatureWriterTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		XMLStreamWriter writer = memoryWriter.getXMLStreamWriter();
 
@@ -495,7 +495,7 @@ public class GMLFeatureWriterTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		XMLStreamWriter writer = memoryWriter.getXMLStreamWriter();
 
@@ -533,7 +533,7 @@ public class GMLFeatureWriterTest {
 		gmlReader.getIdContext().resolveLocalRefs();
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 		XMLStreamWriter writer = memoryWriter.getXMLStreamWriter();
 

--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/geometry/GML2GeometryTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/geometry/GML2GeometryTest.java
@@ -132,7 +132,7 @@ public class GML2GeometryTest extends TestCase {
 				envelope.getCoordinateSystem());
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -179,7 +179,7 @@ public class GML2GeometryTest extends TestCase {
 				point.getCoordinateSystem());
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -210,7 +210,7 @@ public class GML2GeometryTest extends TestCase {
 		Assert.assertEquals(30.0, point.get1(), DELTA);
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -270,7 +270,7 @@ public class GML2GeometryTest extends TestCase {
 				polygon.getCoordinateSystem());
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -314,7 +314,7 @@ public class GML2GeometryTest extends TestCase {
 				lineString.getCoordinateSystem());
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -370,7 +370,7 @@ public class GML2GeometryTest extends TestCase {
 		comparePoint(0.0, 0.0, points.get(3));
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -421,7 +421,7 @@ public class GML2GeometryTest extends TestCase {
 		comparePoint(0.45, 4.56, controlPoints.get(1));
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -461,7 +461,7 @@ public class GML2GeometryTest extends TestCase {
 		comparePoint(0.0, 0.0, secondMember);
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),
@@ -529,7 +529,7 @@ public class GML2GeometryTest extends TestCase {
 				multiPolygon.getCoordinateSystem());
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		XMLMemoryStreamWriter memoryWriter = new XMLMemoryStreamWriter();
 
 		SchemaLocationXMLStreamWriter writer = new SchemaLocationXMLStreamWriter(memoryWriter.getXMLStreamWriter(),

--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/memory/AllocatedHeapMemory.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/utils/memory/AllocatedHeapMemory.java
@@ -90,7 +90,7 @@ public class AllocatedHeapMemory {
 			// set to 32
 			bits = "32";
 		}
-		REF_SIZE = Integer.valueOf(bits) / 8;
+		REF_SIZE = Integer.parseInt(bits) / 8;
 		INSTANCE_SIZE = REF_SIZE * 2;
 	}
 

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/index/RTreeTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/index/RTreeTest.java
@@ -64,35 +64,35 @@ public class RTreeTest {
 	@Before
 	public void loadWikipediaTree() {
 		float[] box = new float[] { 20, 70, 35, 85 };
-		tree.insert(box, new Long(8));
+		tree.insert(box, 8L);
 		box = new float[] { 50, 90, 65, 105 };
-		tree.insert(box, new Long(9));
+		tree.insert(box, 9L);
 		box = new float[] { 50, 75, 65, 85 };
-		tree.insert(box, new Long(10));
+		tree.insert(box, 10L);
 		box = new float[] { 85, 15, 95, 110 };
-		tree.insert(box, new Long(11));
+		tree.insert(box, 11L);
 		box = new float[] { 40, 45, 90, 65 };
-		tree.insert(box, new Long(12));
+		tree.insert(box, 12L);
 		box = new float[] { 125, 40, 135, 95 };
-		tree.insert(box, new Long(13));
+		tree.insert(box, 13L);
 		box = new float[] { 115, 60, 130, 85 };
-		tree.insert(box, new Long(14));
+		tree.insert(box, 14L);
 		box = new float[] { 0, 0, 15, 30 };
-		tree.insert(box, new Long(15));
+		tree.insert(box, 15L);
 		box = new float[] { 20, 0, 80, 40 };
-		tree.insert(box, new Long(16));
+		tree.insert(box, 16L);
 		box = new float[] { 140, 20, 180, 45 };
-		tree.insert(box, new Long(17));
+		tree.insert(box, 17L);
 		box = new float[] { 150, 5, 165, 55 };
-		tree.insert(box, new Long(18));
+		tree.insert(box, 18L);
 		box = new float[] { 155, 10, 175, 25 };
-		tree.insert(box, new Long(19));
+		tree.insert(box, 19L);
 		box = new float[] { 145, 75, 160, 105 };
-		tree.insert(box, new Long(20));
+		tree.insert(box, 20L);
 		box = new float[] { 150, 60, 170, 75 };
-		tree.insert(box, new Long(21));
+		tree.insert(box, 21L);
 		box = new float[] { 155, 85, 180, 95 };
-		tree.insert(box, new Long(22));
+		tree.insert(box, 22L);
 		printOut(tree);
 
 		System.out.println();
@@ -159,7 +159,7 @@ public class RTreeTest {
 
 	@Test
 	public void testRemove() {
-		tree.remove(new Long(11));
+		tree.remove(11L);
 		printOut(tree);
 	}
 

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageBuilder.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/persistence/pyramid/PyramidCoverageBuilder.java
@@ -147,7 +147,7 @@ public class PyramidCoverageBuilder implements ResourceBuilder<Coverage> {
 	private static ICRS getCRS(IIOMetadata metaData) {
 		GeoTiffIIOMetadataAdapter geoTIFFMetaData = new GeoTiffIIOMetadataAdapter(metaData);
 		try {
-			int modelType = Integer.valueOf(geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.GTModelTypeGeoKey));
+			int modelType = Integer.parseInt(geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.GTModelTypeGeoKey));
 			String epsgCode = null;
 			if (modelType == GeoTiffIIOMetadataAdapter.ModelTypeProjected) {
 				epsgCode = geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.ProjectedCSTypeGeoKey);

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/rangeset/Interval.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/rangeset/Interval.java
@@ -246,20 +246,20 @@ public class Interval<T extends Comparable<T>, R extends Comparable<R>> {
 		switch (determined) {
 			case Byte:
 			case Short:
-				short smin = Short.valueOf(min);
-				short smax = Short.valueOf(max);
+				short smin = Short.parseShort(min);
+				short smax = Short.parseShort(max);
 				result = new Interval<Short, RS>(new SingleValue<Short>(determined, smin),
 						new SingleValue<Short>(determined, smax), closure, semantic, atomic, resolution);
 				break;
 			case Integer:
-				int imin = Integer.valueOf(min);
-				int imax = Integer.valueOf(max);
+				int imin = Integer.parseInt(min);
+				int imax = Integer.parseInt(max);
 				result = new Interval<Integer, RS>(new SingleValue<Integer>(determined, imin),
 						new SingleValue<Integer>(determined, imax), closure, semantic, atomic, resolution);
 				break;
 			case Long:
-				long lmin = Long.valueOf(min);
-				long lmax = Long.valueOf(max);
+				long lmin = Long.parseLong(min);
+				long lmax = Long.parseLong(max);
 				result = new Interval<Long, RS>(new SingleValue<Long>(determined, lmin),
 						new SingleValue<Long>(determined, lmax), closure, semantic, atomic, resolution);
 				break;

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/rangeset/SingleValue.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/rangeset/SingleValue.java
@@ -152,23 +152,23 @@ public class SingleValue<T extends Comparable<T>> {
 		switch (determined) {
 			case Byte:
 			case Short:
-				short s = Short.valueOf(value);
+				short s = Short.parseShort(value);
 				result = new SingleValue<Short>(determined, s);
 				break;
 			case Integer:
-				int i = Integer.valueOf(value);
+				int i = Integer.parseInt(value);
 				result = new SingleValue<Integer>(determined, i);
 				break;
 			case Long:
-				long l = Long.valueOf(value);
+				long l = Long.parseLong(value);
 				result = new SingleValue<Long>(determined, l);
 				break;
 			case Double:
-				double d = Double.valueOf(value);
+				double d = Double.parseDouble(value);
 				result = new SingleValue<Double>(determined, d);
 				break;
 			case Float:
-				float f = Float.valueOf(value);
+				float f = Float.parseFloat(value);
 				result = new SingleValue<Float>(determined, f);
 				break;
 			default:

--- a/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/MetaDataReader.java
+++ b/deegree-core/deegree-core-coverage/src/main/java/org/deegree/coverage/raster/io/imageio/MetaDataReader.java
@@ -103,7 +103,7 @@ public class MetaDataReader {
 		GeoTiffIIOMetadataAdapter geoTIFFMetaData = new GeoTiffIIOMetadataAdapter(metaData);
 
 		try {
-			int modelType = Integer.valueOf(geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.GTModelTypeGeoKey));
+			int modelType = Integer.parseInt(geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.GTModelTypeGeoKey));
 			String epsgCode = null;
 			if (modelType == GeoTiffIIOMetadataAdapter.ModelTypeProjected) {
 				epsgCode = geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.ProjectedCSTypeGeoKey);

--- a/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/PROJ4CRSStore.java
+++ b/deegree-core/deegree-core-cs/src/main/java/org/deegree/cs/persistence/proj4/PROJ4CRSStore.java
@@ -1508,7 +1508,7 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 		if (i != -1) {
 			String dd = text.substring(0, i);
 			String mmss = text.substring(i + 1);
-			d = Double.valueOf(dd);
+			d = Double.parseDouble(dd);
 			i = mmss.indexOf('m');
 			if (i == -1) {
 				i = mmss.indexOf('\'');
@@ -1516,14 +1516,14 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 			if (i != -1) {
 				if (i != 0) {
 					String mm = mmss.substring(0, i);
-					m = Double.valueOf(mm);
+					m = Double.parseDouble(mm);
 				}
 				if (mmss.endsWith("s") || mmss.endsWith("\"")) {
 					mmss = mmss.substring(0, mmss.length() - 1);
 				}
 				if (i != mmss.length() - 1) {
 					String ss = mmss.substring(i + 1);
-					s = Double.valueOf(ss);
+					s = Double.parseDouble(ss);
 				}
 				if (m < 0 || m > 59) {
 					throw new NumberFormatException("Minutes must be between 0 and 59");
@@ -1533,7 +1533,7 @@ public class PROJ4CRSStore extends AbstractCRSStore {
 				}
 			}
 			else if (i != 0) {
-				m = Double.valueOf(mmss);
+				m = Double.parseDouble(mmss);
 			}
 			if (toDegrees) {
 				result = dmsToDeg(d, m, s);

--- a/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/other/IDiv.java
+++ b/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/other/IDiv.java
@@ -111,8 +111,8 @@ public class IDiv implements FunctionProvider {
 					pv2 = ((SimpleProperty) vals2[0]).getValue();
 				}
 
-				return new Pair<Integer, Integer>(round(Double.valueOf(pv1.getValue().toString())),
-						round(Double.valueOf(pv2.getValue().toString())));
+				return new Pair<Integer, Integer>(round(Double.parseDouble(pv1.getValue().toString())),
+						round(Double.parseDouble(pv2.getValue().toString())));
 			}
 
 			@Override

--- a/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/other/IMod.java
+++ b/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/other/IMod.java
@@ -126,8 +126,8 @@ public class IMod implements FunctionProvider {
 					pv2 = ((SimpleProperty) vals2[0]).getValue();
 				}
 
-				return new Pair<Integer, Integer>(round(Double.valueOf(pv1.getValue().toString())),
-						round(Double.valueOf(pv2.getValue().toString())));
+				return new Pair<Integer, Integer>(round(Double.parseDouble(pv1.getValue().toString())),
+						round(Double.parseDouble(pv2.getValue().toString())));
 			}
 
 			@Override

--- a/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/styling/HatchingDistance.java
+++ b/deegree-core/deegree-core-filterfunctions/src/main/java/org/deegree/filter/function/styling/HatchingDistance.java
@@ -144,7 +144,7 @@ public class HatchingDistance implements FunctionProvider {
 					distance = ak / Math.cos(Math.toRadians(angle));
 				}
 
-				return new TypedObjectNode[] { new PrimitiveValue(Double.valueOf(distance)) };
+				return new TypedObjectNode[] { new PrimitiveValue(distance) };
 			}
 		};
 	}

--- a/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/pool/LruKeyTracker.java
+++ b/deegree-core/deegree-core-gdal/src/main/java/org/deegree/commons/gdal/pool/LruKeyTracker.java
@@ -53,7 +53,7 @@ class LruKeyTracker {
 	void add(final String key) {
 		Integer num = lruMap.get(key);
 		if (num == null) {
-			num = new Integer(1);
+			num = 1;
 		}
 		else {
 			num++;

--- a/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/dims/Dimension.java
+++ b/deegree-core/deegree-core-layer/src/main/java/org/deegree/layer/dims/Dimension.java
@@ -278,7 +278,7 @@ public class Dimension<T> {
 			try {
 				Double min = Double.valueOf((String) iv.min);
 				Double max = Double.valueOf((String) iv.max);
-				Double res = iv.res instanceof Integer ? (Integer) iv.res : Double.valueOf((String) iv.res);
+				Double res = iv.res instanceof Integer ? (Integer) iv.res : Double.parseDouble((String) iv.res);
 				return new DimensionInterval<Double, Double, Double>(min, max, res);
 			}
 			catch (NumberFormatException e2) {

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleDialectProvider.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleDialectProvider.java
@@ -107,8 +107,8 @@ public class OracleDialectProvider implements SqlDialectProvider {
 				Pattern p = Pattern.compile("^(\\d+)\\.(\\d+)\\.");
 				Matcher m = p.matcher(rs.getString(1));
 				if (m.find()) {
-					major = Integer.valueOf(m.group(1));
-					minor = Integer.valueOf(m.group(2));
+					major = Integer.parseInt(m.group(1));
+					minor = Integer.parseInt(m.group(2));
 				}
 			}
 

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/OracleGeometryConverter.java
@@ -94,7 +94,7 @@ public class OracleGeometryConverter implements GeometryParticleConverter {
 		this.isrid = 0;
 		try {
 			if (srid != null)
-				this.isrid = Integer.valueOf(srid);
+				this.isrid = Integer.parseInt(srid);
 		}
 		catch (NumberFormatException nfe) {
 			// TODO handle it smoother

--- a/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
+++ b/deegree-core/deegree-core-sqldialect/deegree-sqldialect-oracle/src/main/java/org/deegree/sqldialect/oracle/sdo/SDOGeometryConverter.java
@@ -638,7 +638,7 @@ public class SDOGeometryConverter {
 				for (int i = 0, j = orients.length; i < j; i++) {
 					final PropertyType decimalPt = new SimplePropertyType(
 							new QName(ExtraProps.EXTRA_PROP_NS, "orientation" + i), 1, 1, DECIMAL, null, null);
-					final TypedObjectNode value = new PrimitiveValue(Double.valueOf(orients[i]), pt);
+					final TypedObjectNode value = new PrimitiveValue(orients[i], pt);
 					props.add(new GenericProperty(decimalPt, value));
 				}
 				lastGeom.setProperties(props);

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/filter/expression/custom/se/Categorize.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/filter/expression/custom/se/Categorize.java
@@ -223,7 +223,7 @@ public class Categorize extends AbstractCustomExpression {
 	 * @return Category value
 	 */
 	final Color lookup2(final double value) {
-		int pos = Arrays.binarySearch(thresholdsArray, new Float(value));
+		int pos = Arrays.binarySearch(thresholdsArray, (float) value);
 		if (pos >= 0) {
 			// found exact value in the thresholds array
 			if (precedingBelongs == false) {

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/filter/expression/custom/se/Interpolate.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/filter/expression/custom/se/Interpolate.java
@@ -385,7 +385,7 @@ public class Interpolate extends AbstractCustomExpression {
 				String colorS = in.getAttributeValue(null, "color");
 				String opacity = in.getAttributeValue(null, "opacity");
 				String quantity = in.getAttributeValue(null, "quantity");
-				datas.add(quantity != null ? Double.valueOf(quantity) : 0);
+				datas.add(quantity != null ? Double.parseDouble(quantity) : 0);
 				if (opacity != null) {
 					colorS = "#" + toHexString(round(parseDouble(opacity) * 255)) + colorS.substring(1);
 				}

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/test/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTest.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-memory/src/test/java/org/deegree/feature/persistence/memory/MemoryFeatureStoreTest.java
@@ -195,7 +195,7 @@ public class MemoryFeatureStoreTest {
 		Assert.assertTrue(o instanceof Ring);
 
 		XMLOutputFactory outputFactory = XMLOutputFactory.newInstance();
-		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", new Boolean(true));
+		outputFactory.setProperty("javax.xml.stream.isRepairingNamespaces", Boolean.TRUE);
 		OutputStream out = new FileOutputStream(
 				System.getProperty("java.io.tmpdir") + File.separatorChar + "exported_ring.gml");
 		XMLStreamWriter writer = outputFactory.createXMLStreamWriter(out);

--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/DBFReader.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-shape/src/main/java/org/deegree/feature/persistence/shape/DBFReader.java
@@ -380,9 +380,9 @@ public class DBFReader {
 					if (val.isEmpty()) {
 						continue;
 					}
-					int year = Integer.valueOf(val);
-					int month = Integer.valueOf(new String(bs, 4, 2));
-					int day = Integer.valueOf(new String(bs, 6, 2));
+					int year = Integer.parseInt(val);
+					int month = Integer.parseInt(new String(bs, 4, 2));
+					int day = Integer.parseInt(new String(bs, 6, 2));
 					Calendar cal = new GregorianCalendar(year, month, day);
 					PrimitiveType pt = field.propertyType.getPrimitiveType();
 					PrimitiveValue pv = new PrimitiveValue(new Date(cal, true), pt);

--- a/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTiffUtils.java
+++ b/deegree-datastores/deegree-tilestores/deegree-tilestore-geotiff/src/main/java/org/deegree/tile/persistence/geotiff/GeoTiffUtils.java
@@ -69,7 +69,8 @@ public class GeoTiffUtils {
 		GeoTiffIIOMetadataAdapter geoTIFFMetaData = new GeoTiffIIOMetadataAdapter(metaData);
 		try {
 			if (crs == null) {
-				int modelType = Integer.valueOf(geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.GTModelTypeGeoKey));
+				int modelType = Integer
+					.parseInt(geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.GTModelTypeGeoKey));
 				String epsgCode = null;
 				if (modelType == GeoTiffIIOMetadataAdapter.ModelTypeProjected) {
 					epsgCode = geoTIFFMetaData.getGeoKey(GeoTiffIIOMetadataAdapter.ProjectedCSTypeGeoKey);

--- a/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/PolynomialParameterCreator.java
+++ b/deegree-tools/deegree-tools-base/src/main/java/org/deegree/tools/crs/PolynomialParameterCreator.java
@@ -101,7 +101,7 @@ public class PolynomialParameterCreator {
 		// 5.936716E-7, -2.3854978E-12,
 		// 3.0211528E-12, -1.2788576E-12, 1.4953932E-13
 
-		params.add(new Double(1));
+		params.add(1.0);
 		if ("leastsquares".equals(transformationClass.toLowerCase().trim())) {
 			transform = new LeastSquareApproximation(params, params, source, target, 1, 1);
 		}


### PR DESCRIPTION
Remove unnecessary boxing which was detected by IntelliJ IDEA.

Description by IntelliJ IDEA: "Explicit manual boxing is unnecessary as of Java 5 and later, and can safely be removed."

This will also resolve SpotBugs warnings with high criticality like "DM_BOXED_PRIMITIVE_FOR_PARSING".