### PR TITLE
Improved configuration of maven site plugins to support maven site and Jenkins reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,6 @@
     </snapshotRepository>
     <site>
       <id>apidoc.deegree.org</id>
-<!--
-      <url>scp://apidoc.deegree.org/var/www/apidoc.deegree.org/${project.version}/</url>
--->
       <url>file:///${site.dir}/${project.version}/</url>
     </site>
   </distributionManagement>
@@ -1276,7 +1273,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <buildTimestamp>${maven.build.timestamp}</buildTimestamp>
-    <site.dir>${user.home}/Sites</site.dir>
     <java.version>17</java.version>
     <antlr.version>3.5.3</antlr.version>
     <antlr4.version>4.13.2</antlr4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@
               --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED</argLine>
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>
-            <skip>${skip.unit.tests}</skip>
             <trimStackTrace>true</trimStackTrace>
           </configuration>
         </plugin>
@@ -484,7 +483,6 @@
           <release>${java.version}</release>
           <minmemory>512m</minmemory>
           <maxmemory>2g</maxmemory>
-          <inherited>false</inherited>
       </configuration>
       </plugin>
     </plugins>
@@ -1355,7 +1353,6 @@
               <release>${java.version}</release>
               <minmemory>512m</minmemory>
               <maxmemory>4g</maxmemory>
-              <inherited>false</inherited>
             </configuration>
           </plugin>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1376,6 +1376,7 @@
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>
+              <formats>JSON,JENKINS</formats>
             </configuration>
             <reportSets>
               <reportSet>


### PR DESCRIPTION
This PR fixes to following minor issues in the Maven POM to support the publishing of the maven site to https://apidoc.deegree.org:
- removed unused (and commented out) section for `site.dir`
- remove wrong default property for `site.dir`
- removed unsupported properties in maven plugins used for `mvn site` 
- added encodings for OWASP maven plugin to be rendered in Jenkins OWASP plugin