### PR TITLE
Enable stale bot to automatically mark stale pr and close them after further inactivity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,8 @@
 name: 'Close stale PRs'
+
+# run on Wednesday mornings or manually
 on:
+  workflow_dispatch:
   schedule:
     - cron: '42 1 * * 3'
 
@@ -12,7 +15,10 @@ jobs:
       - uses: actions/stale@v10
         with:
           # dry-run / no changes
-          debug-only: true
+          #debug-only: true
+          # start with oldest
+          ascending: true
+          #
           enable-statistics: true
           # 
           stale-pr-label: "stuck"
@@ -27,3 +33,5 @@ jobs:
           # disabled for issues
           days-before-issue-stale: -1
           days-before-issue-close: -1
+          #
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After testing the configuration with #1898 this PR removes the dry-run and allows manual execution.

This PR will mark stale PR after 90 days of inactivity and will close marked PRs after an additional 90 days.

Documentation of the bot: https://github.com/actions/stale?tab=readme-ov-file#close-stale-issues-and-prs

Related Issue https://github.com/deegree/deegree3/issues/1874