### PR TITLE
Added support for CQL2 filter IN list, NOT IN list and OR

### DIFF
--- a/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/Cql2FilterVisitor.java
+++ b/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/Cql2FilterVisitor.java
@@ -105,6 +105,13 @@ public class Cql2FilterVisitor extends Cql2ParserBaseVisitor {
 		if (terms == 1) {
 			return ctx.booleanTerm(0).accept(this);
 		}
+		if (Objects.nonNull(ctx.OR())) {
+			List<Operator> operator = ctx.booleanTerm()
+				.stream()
+				.map(booleaTerm -> (Operator) booleaTerm.accept(this))
+				.toList();
+			return new Or(operator.toArray(Operator[]::new));
+		}
 		throw new Cql2UnsupportedExpressionException("More than one booleanTerm are currently not supported.");
 	}
 

--- a/deegree-core/deegree-core-cql2/src/test/java/org/deegree/cql2/Cql2FilterParserTest.java
+++ b/deegree-core/deegree-core-cql2/src/test/java/org/deegree/cql2/Cql2FilterParserTest.java
@@ -678,6 +678,63 @@ public class Cql2FilterParserTest {
 		assertEquals("V_L%", value);
 	}
 
+	@Test
+	public void test_parse_OR() throws UnknownCRSException {
+		String comp = "test1='VALUE1' OR test2 IN ('VALUE1','VALUE2')";
+		Object visit = parseCql2Filter(comp, crs(), PROPS);
+
+		assertTrue(visit instanceof Or);
+		assertEquals(2, ((Or) visit).getSize());
+
+		Operator or1 = ((Or) visit).getParameter(0);
+		Operator or2 = ((Or) visit).getParameter(1);
+
+		assertTrue(or1 instanceof PropertyIsEqualTo);
+
+		Expression param1_1 = ((PropertyIsEqualTo) or1).getParameter1();
+		assertTrue(param1_1 instanceof ValueReference);
+		assertEquals("test1", ((ValueReference) param1_1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1_1).getAsQName().getNamespaceURI());
+
+		Expression param1_2 = ((PropertyIsEqualTo) or1).getParameter2();
+		assertTrue(param1_2 instanceof Literal);
+		TypedObjectNode primitiveValue1 = ((Literal<?>) param1_2).getValue();
+		assertTrue(primitiveValue1 instanceof PrimitiveValue);
+		Object value1 = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(value1 instanceof String);
+		assertEquals("VALUE1", value1);
+
+		assertTrue(or2 instanceof Or);
+		Operator[] or2Params = ((Or) or2).getParams();
+		assertTrue(or2Params[0] instanceof PropertyIsEqualTo);
+		PropertyIsEqualTo or2_param1 = (PropertyIsEqualTo) or2Params[0];
+		Expression or2_param1_1 = or2_param1.getParams()[0];
+		assertTrue(or2_param1_1 instanceof ValueReference);
+		assertEquals("test2", ((ValueReference) or2_param1_1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) or2_param1_1).getAsQName().getNamespaceURI());
+		Expression or2_param1_2 = or2_param1.getParams()[1];
+		assertTrue(or2_param1_2 instanceof Literal<?>);
+		TypedObjectNode or2_param1_2_primitiveValue = ((Literal<?>) param1_2).getValue();
+		assertTrue(or2_param1_2_primitiveValue instanceof PrimitiveValue);
+		Object or2_param1_2_value = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(or2_param1_2_value instanceof String);
+		assertEquals("VALUE1", or2_param1_2_value);
+
+		assertTrue(or2Params[1] instanceof PropertyIsEqualTo);
+		PropertyIsEqualTo or2_param2 = (PropertyIsEqualTo) or2Params[0];
+		Expression or2_param2_1 = or2_param2.getParams()[0];
+		assertTrue(or2_param2_1 instanceof ValueReference);
+		assertEquals("test2", ((ValueReference) or2_param2_1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) or2_param2_1).getAsQName().getNamespaceURI());
+		Expression or2_param2_2 = or2_param2.getParams()[1];
+		assertTrue(or2_param2_2 instanceof Literal<?>);
+		TypedObjectNode or2_param2_2_primitiveValue = ((Literal<?>) param1_2).getValue();
+		assertTrue(or2_param2_2_primitiveValue instanceof PrimitiveValue);
+		Object or2_param2_2_value = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(or2_param2_2_value instanceof String);
+		assertEquals("VALUE1", or2_param2_2_value);
+	}
+
 	@Test(expected = ParseCancellationException.class)
 	public void test_parse_inList_noValues() throws UnknownCRSException {
 		String comp = "test1 IN()";

--- a/deegree-documentation/src/main/asciidoc/webservices.adoc
+++ b/deegree-documentation/src/main/asciidoc/webservices.adoc
@@ -1759,6 +1759,7 @@ Using the vendorspecific parameter CQL2_FILTER a more complex expression can be 
 
 * Logical operators
 ** AND
+** OR
 * Comparison operators
 ** equal to (=), with string, int and double values
 * Advanced Comparison Operators
@@ -1785,6 +1786,8 @@ CQL2_FILTER=index%3D10
 CQL2_FILTER=city%20LIKE%20CASEI%28%27B_N%25%27%29
 # city='Bonn' AND str LIKE 'Erm%'
 CQL2_FILTER=city%3D%27Bonn%27%20AND%20str%20LIKE%20%27Erm%25%27
+# city='Bonn' OR str LIKE 'Erm%'
+CQL2_FILTER=city%3D%27Bonn%27%20OR%20str%20LIKE%20%27Erm%25%27
 # city IN('Bonn','Bremen')
 CQL2_FILTER=city%20IN%28%27Bonn%27%2C%27Bremen%27%29
 # city NOT IN('Bonn','Bremen')


### PR DESCRIPTION
This PR adds the CQL2 Filter IN list, NOT IN list and OR:
* city IN('Bonn','Bremen')
* city NOT IN('Bonn','Bremen')
* city='Bonn' OR str LIKE 'Erm%'