### PR TITLE
Fixed lost decimal places in geometries stored in BLOB Store

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/BlobCodec.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/blob/BlobCodec.java
@@ -65,6 +65,7 @@ import org.deegree.cs.exceptions.UnknownCRSException;
 import org.deegree.feature.Feature;
 import org.deegree.feature.persistence.FeatureStoreException;
 import org.deegree.feature.types.AppSchema;
+import org.deegree.geometry.io.DoubleCoordinateFormatter;
 import org.deegree.gml.GMLInputFactory;
 import org.deegree.gml.GMLOutputFactory;
 import org.deegree.gml.GMLStreamReader;
@@ -139,6 +140,7 @@ public class BlobCodec {
 		GMLStreamWriter gmlWriter = GMLOutputFactory.createGMLStreamWriter(gmlVersion, xmlWriter);
 		Map<String, String> bindings = new HashMap<String, String>(nsContext);
 		gmlWriter.setNamespaceBindings(bindings);
+		gmlWriter.setCoordinateFormatter(new DoubleCoordinateFormatter());
 		gmlWriter.setOutputCrs(crs);
 		gmlWriter.setExportExtraProps(true);
 		gmlWriter.write(object);


### PR DESCRIPTION
This PR fixed decimal places of geometries in  BLOB Store, before the geometries was rounded using the default values. of the DecimalCoordinateFormatter (six places respectively  three places for metric coordinates) . 
With this PR the decimal places of the coordinates are kept.