### PR TITLE
  Upgraded maven dependencies to latest versions

### DIFF
--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -132,13 +132,13 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>15.0.8</version>
+      <version>15.0.10</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>15.0.8</version>
+      <version>15.0.10</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -589,7 +589,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.20.0</version>
+        <version>2.21.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -610,12 +610,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
+        <version>3.20.0</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.19.0</version>
+        <version>1.20.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -694,7 +694,7 @@
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.faces</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
       </dependency>
       <dependency>
         <groupId>jakarta.enterprise</groupId>
@@ -1281,9 +1281,9 @@
     <antlr.version>3.5.3</antlr.version>
     <antlr4.version>4.13.2</antlr4.version>
     <oracle.version>23.4.0.24.05</oracle.version>
-    <logback.version>1.5.19</logback.version>
+    <logback.version>1.5.21</logback.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <spring-boot.version>3.4.10</spring-boot.version>
+    <spring-boot.version>3.4.12</spring-boot.version>
     <batik.version>1.19</batik.version>
     <axiom.version>1.4.0</axiom.version>
     <jsonpath.version>2.9.0</jsonpath.version>


### PR DESCRIPTION
This PR upgrades the following dependencies:
* primefaces
* commons-io
* commons-lang3
* commons-codec
* jakarta.faces
* logback
* spring-boot