### PR TITLE
Fixed requesting of legend graphics each time the capabilities are requested

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/LegendBuilder.java
@@ -53,10 +53,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
-import javax.imageio.ImageIO;
-
 import org.deegree.commons.utils.Pair;
-import org.deegree.commons.utils.net.HttpUtils;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.GeometryFactory;
 import org.deegree.rendering.r2d.Java2DRasterRenderer;
@@ -92,6 +89,9 @@ class LegendBuilder {
 	}
 
 	Pair<Integer, Integer> getLegendSize(Style style) {
+		if (style.getLegendSize() != null) {
+			return style.getLegendSize();
+		}
 		URL url = style.getLegendURL();
 		File file = style.getLegendFile();
 		if (url == null) {
@@ -108,7 +108,7 @@ class LegendBuilder {
 			try {
 				BufferedImage legend = get(IMAGE, url.toExternalForm(), null);
 				if (legend != null) {
-					return new Pair<Integer, Integer>(legend.getWidth(), legend.getHeight());
+					style.setLegendSize(new Pair<>(legend.getWidth(), legend.getHeight()));
 				}
 				else {
 					LOG.warn("Legend file {} could not be read, using dynamic legend.", url);
@@ -131,7 +131,8 @@ class LegendBuilder {
 			res.second = 2 * opts.spacing + opts.baseWidth;
 		}
 
-		return res;
+		style.setLegendSize(res);
+		return style.getLegendSize();
 	}
 
 }

--- a/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/unevaluated/Style.java
+++ b/deegree-core/deegree-core-style/src/main/java/org/deegree/style/se/unevaluated/Style.java
@@ -120,6 +120,8 @@ public class Style implements Copyable<Style> {
 
 	private boolean prefersGetLegendGraphicUrl;
 
+	private Pair<Integer, Integer> legendSize;
+
 	/**
 	 * @param rules
 	 * @param labels
@@ -449,6 +451,14 @@ public class Style implements Copyable<Style> {
 
 	public URL getLegendURL() {
 		return legendUrl;
+	}
+
+	public Pair<Integer, Integer> getLegendSize() {
+		return legendSize;
+	}
+
+	public void setLegendSize(Pair<Integer, Integer> legendSize) {
+		this.legendSize = legendSize;
 	}
 
 	public void setPrefersGetLegendGraphicUrl(boolean prefers) {


### PR DESCRIPTION
Before this PR the configured legend is requested each time the capabilities are requested to determine the size of the legend:

```
<l:StyleRef>		
  <l:StyleStoreId>styles</l:StyleStoreId>		
    <l:Style>
      <l:StyleName>test</l:StyleName>
      <l:LayerNameRef>test_layer</l:LayerNameRef>
      <l:StyleNameRef>test</l:StyleNameRef>
      <l:LegendGraphic outputGetLegendGraphicUrl="false">https://deegree.org/legends/legend.png</l:LegendGraphic>
    </l:Style>
</l:StyleRef>
```

This PRs fixes this by storing the legend size in the styles instance.