### PR TITLE
Fixed empty GFI response on a FeatureType with multiple geometry columns

### DIFF
--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FeatureLayer.java
@@ -150,13 +150,14 @@ public class FeatureLayer extends AbstractLayer {
 			layerRadius = getMetadata().getMapOptions().getFeatureInfoRadius();
 		}
 		final Envelope clickBox = query.calcClickBox(layerRadius > -1 ? layerRadius : query.getLayerRadius());
+		final ValueReference geomProp = findGeometryProperty(style);
 
-		filter = (OperatorFilter) addBBoxConstraint(clickBox, filter, null, false);
+		filter = (OperatorFilter) addBBoxConstraint(clickBox, filter, geomProp, false);
 		filter = Filters.repair(filter, AppSchemas.collectProperyNames(featureStore.getSchema(), featureType));
 
 		LOG.debug("Querying the feature store(s)...");
 
-		QueryBuilder builder = new QueryBuilder(featureStore, filter, featureType, clickBox, query, null,
+		QueryBuilder builder = new QueryBuilder(featureStore, filter, featureType, clickBox, query, geomProp,
 				sortByFeatureInfo, getMetadata().getName());
 		List<Query> queries = builder.buildInfoQueries();
 

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FilterBuilder.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/FilterBuilder.java
@@ -93,7 +93,7 @@ class FilterBuilder {
 		return filter;
 	}
 
-	static OperatorFilter buildFilter(Operator operator, FeatureType ft, Envelope clickBox) {
+	static OperatorFilter buildFilter(Operator operator, FeatureType ft, Envelope clickBox, ValueReference geomProp) {
 		if (ft == null) {
 			if (operator == null) {
 				return null;
@@ -112,9 +112,9 @@ class FilterBuilder {
 			// obnoxious case where feature has no geometry properties (but features may
 			// have extra geometry props)
 			if (operator == null) {
-				return new OperatorFilter(new Intersects(null, clickBox));
+				return new OperatorFilter(new Intersects(geomProp, clickBox));
 			}
-			return new OperatorFilter(new And(operator, new Intersects(null, clickBox)));
+			return new OperatorFilter(new And(operator, new Intersects(geomProp, clickBox)));
 		}
 		if (operator == null) {
 			return new OperatorFilter(list.get(0));

--- a/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/QueryBuilder.java
+++ b/deegree-layers/deegree-layers-feature/src/main/java/org/deegree/layer/persistence/feature/QueryBuilder.java
@@ -132,10 +132,10 @@ class QueryBuilder {
 						public Query apply(FeatureType u) {
 							Filter f;
 							if (filter == null) {
-								f = buildFilter(null, u, bbox);
+								f = buildFilter(null, u, bbox, geomProp);
 							}
 							else {
-								f = buildFilter(((OperatorFilter) filter).getOperator(), u, bbox);
+								f = buildFilter((filter).getOperator(), u, bbox, geomProp);
 							}
 							return createQuery(u.getName(), f, -1, query.getFeatureCount(), -1, sortBy);
 						}
@@ -145,11 +145,11 @@ class QueryBuilder {
 		else {
 			Filter f;
 			if (filter == null) {
-				f = buildFilter(null, featureStore.getSchema().getFeatureType(ftName), bbox);
+				f = buildFilter(null, featureStore.getSchema().getFeatureType(ftName), bbox, geomProp);
 			}
 			else {
-				f = buildFilter(((OperatorFilter) filter).getOperator(),
-						featureStore.getSchema().getFeatureType(ftName), bbox);
+				f = buildFilter((filter).getOperator(), featureStore.getSchema().getFeatureType(ftName), bbox,
+						geomProp);
 			}
 			queries.add(createQuery(ftName, f, -1, query.getFeatureCount(), -1, sortBy));
 		}


### PR DESCRIPTION
Currently a GetFetureInfo requests based on FeatureLayer uses the first geometry column, to match the requested click point. This geometry may differ from the geometry used to render the GetMap request or may be empty,  

This PR fixes this by using the same geometry property for GetFeatureInfo requests from the style as the GetMap request. 

Fixes #1640.