### PR TITLE
Fixed size of symbols in legends if size is calculated

### DIFF
--- a/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/StandardLegendRenderer.java
+++ b/deegree-core/deegree-core-rendering-2d/src/main/java/org/deegree/rendering/r2d/legends/StandardLegendRenderer.java
@@ -127,14 +127,7 @@ class StandardLegendRenderer {
 		paintLegendText(origin, opts, text, textRenderer);
 
 		// normalize symbol sizes
-		double maxSize = 0;
-		if (isPoint) {
-			for (Styling s : stylings) {
-				if (s instanceof PointStyling) {
-					maxSize = max(((PointStyling) s).graphic.size, maxSize);
-				}
-			}
-		}
+		double maxSize = calculateMaxSize(isPoint);
 
 		if (rule == null) {
 			for (Styling s : stylings) {
@@ -144,6 +137,21 @@ class StandardLegendRenderer {
 		}
 
 		paintRule(isPoint, maxSize, opts, geom);
+	}
+
+	private double calculateMaxSize(boolean isPoint) {
+		double maxSize = 0;
+		if (isPoint) {
+			for (Styling s : stylings) {
+				if (s instanceof PointStyling) {
+					maxSize = max(((PointStyling) s).graphic.size, maxSize);
+				}
+			}
+		}
+		if (maxSize > 0)
+			return maxSize;
+		// fallback to default size 6 to avoid infinite legend size if maxSize is 0
+		return 6;
 	}
 
 	private void paintRule(boolean isPoint, double maxSize, LegendOptions opts, Geometry geom) {
@@ -159,6 +167,10 @@ class StandardLegendRenderer {
 				if (styling instanceof PointStyling && isPoint) {
 					PointStyling ps = ((PointStyling) styling).copy();
 					ps.uom = Metre;
+					// fallback to default size 6 to avoid infinite legend size if maxSize
+					// is 0
+					if (ps.graphic.size <= 0)
+						ps.graphic.size = 6;
 					ps.graphic.size = ps.graphic.size / maxSize * min(opts.baseWidth, opts.baseHeight);
 					styling = ps;
 				}


### PR DESCRIPTION
If the size of a symbol is calculated, e.g.: 
```
<Size>
  <ogc:Function name="idiv">
    <ogc:Literal>50000</ogc:Literal>
    <ogc:Function name="GetCurrentScale" />
  </ogc:Function>
</Size>
```
The legend created by deegree creates not readable legends:

<img width="220" height="243" alt="GetLegendGraphic" src="https://github.com/user-attachments/assets/93b7e86d-164f-496b-93c0-91deb0e68b76" />

This PR fixes this by using a default size of 6 if the size of the symbol is -1.

Created legend after the fix: 
<img width="220" height="243" alt="GetLegendGraphic_fixed" src="https://github.com/user-attachments/assets/e0c8d3ce-bb5c-43c9-9e6d-cb9ca83b9ef3" />
