### PR TITLE
00felix: upgrade org.apache.james:apache-mime4j-core to 0.8.10

### DIFF
--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>axiom-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.james</groupId>
+      <artifactId>apache-mime4j-core</artifactId>
+      <version>0.8.10</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.fastinfoset</groupId>
       <artifactId>FastInfoset</artifactId>
     </dependency>

--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.apache.ws.commons.axiom</groupId>
       <artifactId>axiom-impl</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <!-- javax.activation for axiom only (until migrated to jakarta) -->
     <dependency>
@@ -65,6 +66,7 @@
     <dependency>
       <groupId>org.apache.ws.commons.axiom</groupId>
       <artifactId>axiom-api</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.fastinfoset</groupId>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -82,6 +82,12 @@
     <dependency>
       <groupId>org.apache.ws.commons.axiom</groupId>
       <artifactId>axiom-impl</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ws.commons.axiom</groupId>
+      <artifactId>axiom-api</artifactId>
+      <version>2.0.0</version>
     </dependency>
     <!-- javax.activation for axiom only (until migrated to jakarta) -->
     <dependency>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -120,6 +120,11 @@
       <groupId>jakarta.xml.soap</groupId>
       <artifactId>jakarta.xml.soap-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.james</groupId>
+      <artifactId>apache-mime4j-core</artifactId>
+      <version>0.8.10</version>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
**Upgrade `org.apache.james:apache-mime4j-core` from `0.8.6` to `0.8.10`**
**Upgrade `org.apache.ws.commons.axiom:axiom-api` from `1.4.0` to `2.0.0`**
**Upgrade `org.apache.ws.commons.axiom:axiom-impl` from `1.4.0` to `2.0.0`**

This pull request upgrades `org.apache.james:apache-mime4j-core` from version `0.8.6` to `0.8.10`, `org.apache.ws.commons.axiom:axiom-api` from version `1.4.0` to `2.0.0`, and `org.apache.ws.commons.axiom:axiom-impl` from version `1.4.0` to `2.0.0` to address multiple security vulnerabilities and ensure compliance with security best practices. The upgrade has been tested locally to confirm compatibility with existing functionality.



Vulnerabilities Addressed

| Vulnerability | Description |
| --- | --- |
| GHSA-jw7r-rxff-gv24 | Apache James MIME4J improper input validation vulnerability |


This upgrade enhances the security and stability of the `org.apache.james:apache-mime4j-core`, `org.apache.ws.commons.axiom:axiom-api`, and `org.apache.ws.commons.axiom:axiom-impl` dependencies.