### PR TITLE
Fixed XMLParsingException in case of empty XML elements

### DIFF
--- a/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/primitive/XMLValueMangler.java
+++ b/deegree-core/deegree-core-commons/src/main/java/org/deegree/commons/tom/primitive/XMLValueMangler.java
@@ -62,66 +62,72 @@ public class XMLValueMangler {
 
 	/**
 	 * Returns the internal representation for the given XML string and {@link BaseType}.
-	 * @param s
+	 * @param s may be null or empty
 	 * @param pt
 	 * @return
 	 * @throws IllegalArgumentException
 	 */
 	public static Object xmlToInternal(String s, BaseType pt) throws IllegalArgumentException {
-		Object value = s;
 		switch (pt) {
 			case BOOLEAN: {
+				if (isNullOrEmpty(s))
+					return null;
 				if (s.equals("true") || s.equals("1")) {
-					value = Boolean.TRUE;
+					return Boolean.TRUE;
 				}
 				else if (s.equals("false") || s.equals("0")) {
-					value = Boolean.FALSE;
+					return Boolean.FALSE;
 				}
 				else {
 					String msg = "Value ('" + s + "') is not valid with respect to the xs:boolean type. "
 							+ "Valid values are 'true', 'false', '1' and '0'.";
 					throw new IllegalArgumentException(msg);
 				}
-				break;
 			}
 			case DATE: {
-				value = parseDate(s);
-				break;
+				if (isNullOrEmpty(s))
+					return null;
+				return parseDate(s);
 			}
 			case DATE_TIME: {
-				value = parseDateTime(s);
-				break;
+				if (isNullOrEmpty(s))
+					return null;
+				return parseDateTime(s);
 			}
 			case DECIMAL: {
-				value = new BigDecimal(s);
-				break;
+				if (isNullOrEmpty(s))
+					return null;
+				return new BigDecimal(s);
 			}
 			case DOUBLE: {
-				value = new Double(s);
-				break;
+				if (isNullOrEmpty(s))
+					return null;
+				return new Double(s);
 			}
 			case INTEGER: {
-				value = new BigInteger(s);
-				break;
+				if (isNullOrEmpty(s))
+					return null;
+				return new BigInteger(s);
 			}
 			case STRING: {
 				break;
 			}
 			case TIME: {
+				if (isNullOrEmpty(s))
+					return null;
 				try {
-					value = parseTime(s);
+					return parseTime(s);
 				}
 				catch (Exception e) {
 					String msg = "Value ('" + s + "') is not valid with respect to the xs:time type.";
 					throw new IllegalArgumentException(msg);
 				}
-				break;
 			}
 			default: {
 				LOG.warn("Unhandled primitive type {} -- treating as string value.", pt);
 			}
 		}
-		return value;
+		return s;
 	}
 
 	static String internalToXML(Object o, BaseType pt) {
@@ -188,6 +194,10 @@ public class XMLValueMangler {
 			}
 		}
 		return xml;
+	}
+
+	private static boolean isNullOrEmpty(String s) {
+		return s == null || s.isEmpty();
 	}
 
 }

--- a/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/tom/primitive/XMLValueManglerTest.java
+++ b/deegree-core/deegree-core-commons/src/test/java/org/deegree/commons/tom/primitive/XMLValueManglerTest.java
@@ -1,0 +1,170 @@
+package org.deegree.commons.tom.primitive;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.deegree.commons.tom.datetime.Date;
+import org.deegree.commons.tom.datetime.DateTime;
+import org.deegree.commons.tom.datetime.Time;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class XMLValueManglerTest {
+
+	@Test
+	public void testXmlToInternal_boolean() {
+		Object o = XMLValueMangler.xmlToInternal("true", BaseType.BOOLEAN);
+		assertTrue(o instanceof Boolean);
+		assertEquals(Boolean.TRUE, o);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyBoolean() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.BOOLEAN);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullBoolean() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.BOOLEAN);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_date() {
+		Object o = XMLValueMangler.xmlToInternal("2026-01-29", BaseType.DATE);
+		assertTrue(o instanceof Date);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyDate() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.DATE);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullDate() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.DATE);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_dateTime() {
+		Object o = XMLValueMangler.xmlToInternal("2026-01-29T00:00:00Z", BaseType.DATE_TIME);
+		assertTrue(o instanceof DateTime);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyDateTime() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.DATE_TIME);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullDateTime() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.DATE_TIME);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_decimal() {
+		Object o = XMLValueMangler.xmlToInternal("5.8", BaseType.DECIMAL);
+		assertTrue(o instanceof BigDecimal);
+		assertEquals(BigDecimal.valueOf(5.8), o);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyDecimal() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.DECIMAL);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullDecimal() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.DECIMAL);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_double() {
+		Object o = XMLValueMangler.xmlToInternal("5.8", BaseType.DOUBLE);
+		assertTrue(o instanceof Double);
+		assertEquals(5.8d, o);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyDouble() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.DOUBLE);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullDouble() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.DOUBLE);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_integer() {
+		Object o = XMLValueMangler.xmlToInternal("5", BaseType.INTEGER);
+		assertTrue(o instanceof BigInteger);
+		assertEquals(BigInteger.valueOf(5), o);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyInteger() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.INTEGER);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullInteger() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.INTEGER);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_string() {
+		Object o = XMLValueMangler.xmlToInternal("text", BaseType.STRING);
+		assertTrue(o instanceof String);
+		assertEquals("text", o);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyString() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.STRING);
+		assertTrue(o instanceof String);
+		assertEquals("", o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullString() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.STRING);
+		assertEquals(null, o);
+	}
+
+	@Test
+	public void testXmlToInternal_time() {
+		Object o = XMLValueMangler.xmlToInternal("00:00:00Z", BaseType.TIME);
+		assertTrue(o instanceof Time);
+	}
+
+	@Test
+	public void testXmlToInternal_emptyTime() {
+		Object o = XMLValueMangler.xmlToInternal("", BaseType.TIME);
+		assertNull(o);
+	}
+
+	@Test
+	public void testXmlToInternal_nullTime() {
+		Object o = XMLValueMangler.xmlToInternal(null, BaseType.TIME);
+		assertNull(o);
+	}
+
+}


### PR DESCRIPTION
Currently an XMLParsingException is thrown if an non-string value element is empty. E.g.:

```
<nummer></nummer>
```

Exception: `org.deegree.commons.xml.XMLParsingException: Error in XML document (line: 106,column: 7, character offset: 5327): Property '{http://www.exampl.org/xplangml/6/0}nummer' is not valid: Zero length BigInteger`

Declaration of the element:
```
<element default="0" name="nummer" type="integer">
```

The GML document is valid according the application schema. 