### PR TITLE
Removed unnecessary XML APIs from dependencies

### DIFF
--- a/deegree-tests/pom.xml
+++ b/deegree-tests/pom.xml
@@ -119,10 +119,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -820,14 +820,15 @@
         <version>2.0.0</version>
       </dependency>
       <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
-      </dependency>
-      <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.12.2</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>de.odysseus.staxon</groupId>
@@ -953,6 +954,12 @@
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-dom</artifactId>
         <version>${batik.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
This PR removes  the dependency `xml-api:xml-apis` from deegree POM dependencies as the included APIs are part of most OpenJDKs nowadays, see #1917.

Caution: There might be some very special corner cases where the JDK does not provide thoses APIs or individual extionsions of deegree rely on the implementation of xml-apis.