### PR TITLE
Upgraded Axiom to version 2.0.0

### DIFF
--- a/deegree-core/deegree-core-commons/pom.xml
+++ b/deegree-core/deegree-core-commons/pom.xml
@@ -57,11 +57,6 @@
       <groupId>org.apache.ws.commons.axiom</groupId>
       <artifactId>axiom-impl</artifactId>
     </dependency>
-    <!-- javax.activation for axiom only (until migrated to jakarta) -->
-    <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.ws.commons.axiom</groupId>
       <artifactId>axiom-api</artifactId>

--- a/deegree-services/deegree-services-commons/pom.xml
+++ b/deegree-services/deegree-services-commons/pom.xml
@@ -83,11 +83,6 @@
       <groupId>org.apache.ws.commons.axiom</groupId>
       <artifactId>axiom-impl</artifactId>
     </dependency>
-    <!-- javax.activation for axiom only (until migrated to jakarta) -->
-    <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -797,12 +797,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- javax.activation for axiom only (until migrated to jakarta) -->
-      <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>jakarta.activation</artifactId>
-        <version>1.2.2</version>
-      </dependency>
       <dependency>
         <groupId>com.sun.xml.fastinfoset</groupId>
         <artifactId>FastInfoset</artifactId>
@@ -1285,7 +1279,7 @@
     <slf4j.version>2.0.17</slf4j.version>
     <spring-boot.version>3.4.12</spring-boot.version>
     <batik.version>1.19</batik.version>
-    <axiom.version>1.4.0</axiom.version>
+    <axiom.version>2.0.0</axiom.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.6.0</jsonsmart.version>
     <jvm.args>--add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED</jvm.args>


### PR DESCRIPTION
This PR upgrades Axiom to version 2.0.0 which supports Jakarta API (https://ws.apache.org/axiom/release-notes/2.0.0.html)