### PR TITLE
Switched dependency for JSF CDI from weld-shaded to weld-servlet-core

### DIFF
--- a/deegree-client/deegree-jsf-core/pom.xml
+++ b/deegree-client/deegree-jsf-core/pom.xml
@@ -67,17 +67,6 @@
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>jakarta.faces</groupId>
-      <artifactId>jakarta.faces-api</artifactId>
-    </dependency>
-    -->
-    <dependency>
-      <groupId>org.jboss.weld.servlet</groupId>
-      <artifactId>weld-servlet-shaded</artifactId>
-      <version>5.1.6.Final</version>
-    </dependency>
     <dependency>
       <groupId>jakarta.el</groupId>
       <artifactId>jakarta.el-api</artifactId>
@@ -85,6 +74,17 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.faces</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.servlet</groupId>
+      <artifactId>weld-servlet-core</artifactId>
+      <version>5.1.6.Final</version>
+      <exclusions>
+          <exclusion>
+              <groupId>jakarta.el</groupId>
+              <artifactId>jakarta.el-api</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -684,13 +684,6 @@
         <version>5.0.1</version>
         <scope>provided</scope>
       </dependency>
-      <!--
-      <dependency>
-        <groupId>jakarta.faces</groupId>
-        <artifactId>jakarta.faces-api</artifactId>
-        <version>4.0.0</version>
-      </dependency>
-      -->
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.faces</artifactId>
@@ -701,13 +694,6 @@
         <artifactId>jakarta.enterprise.cdi-api</artifactId>
         <version>4.0.1</version>
       </dependency>
-      <!--
-      <dependency>
-        <groupId>com.sun.jersey</groupId>
-        <artifactId>jersey-server</artifactId>
-        <version>1.19.4</version>
-      </dependency>
-      -->
       <!-- logging -->
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This PR switches the dependencies from weld-shaded to weld-servlet-core and removes the obsolet and inactive (commented out) dependencies (this change included here to avoid a merge conflict and changed order on purpose).