### PR TITLE
Improved exception if other than the currently active workspace is validated

### DIFF
--- a/deegree-services/deegree-services-config/src/main/java/org/deegree/services/config/actions/Validate.java
+++ b/deegree-services/deegree-services-config/src/main/java/org/deegree/services/config/actions/Validate.java
@@ -2,6 +2,7 @@ package org.deegree.services.config.actions;
 
 import static org.apache.commons.io.IOUtils.write;
 import static org.deegree.services.config.actions.Utils.getWorkspaceAndPath;
+import static org.deegree.services.controller.OGCFrontController.getServiceWorkspace;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
@@ -16,7 +17,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.deegree.commons.config.DeegreeWorkspace;
 import org.deegree.commons.config.ResourceInitException;
 import org.deegree.commons.utils.Pair;
@@ -44,6 +44,13 @@ public class Validate {
 	 */
 	public static void validate(String path, HttpServletResponse resp) throws IOException {
 		Pair<DeegreeWorkspace, String> p = getWorkspaceAndPath(path);
+		DeegreeWorkspace currentWorkspace = getServiceWorkspace();
+		if (!currentWorkspace.getName().equals(p.getFirst().getName())) {
+			setStatusCodeAndContentType(400, resp);
+			write("Validating the requested workspace is not allowed: " + p.getFirst().getName()
+					+ " is not the currently active workspace.", resp.getOutputStream());
+			return;
+		}
 
 		try {
 			DeegreeWorkspace workspace = p.getFirst();

--- a/deegree-services/deegree-services-config/src/main/java/org/deegree/services/config/servlet/ConfigServlet.java
+++ b/deegree-services/deegree-services-config/src/main/java/org/deegree/services/config/servlet/ConfigServlet.java
@@ -44,8 +44,8 @@ import static org.deegree.services.config.actions.List.list;
 import static org.deegree.services.config.actions.ListFonts.listFonts;
 import static org.deegree.services.config.actions.ListWorkspaces.listWorkspaces;
 import static org.deegree.services.config.actions.Restart.restart;
-import static org.deegree.services.config.actions.UpdateBboxCache.updateBboxCache;
 import static org.deegree.services.config.actions.Update.update;
+import static org.deegree.services.config.actions.UpdateBboxCache.updateBboxCache;
 import static org.deegree.services.config.actions.Upload.upload;
 import static org.deegree.services.config.actions.Validate.validate;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -56,7 +56,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.IOUtils;
 import org.deegree.services.config.ApiKey;
 import org.slf4j.Logger;
@@ -111,7 +110,7 @@ public class ConfigServlet extends HttpServlet {
 			data.append(
 					"GET /config/validate[/path]                                  - validate currently running workspace or file in workspace\n");
 			data.append(
-					"GET /config/validate/wsname[/path]                           - validate workspace with name <wsname> or file in workspace\n");
+					"GET /config/validate/wsname[/path]                           - validate workspace with name <wsname> or file in workspace. Only the active workspace can be validated.\n");
 			data.append(
 					"GET /config/update/bboxcache[?featureStoreId=]               - recalculates the bounding boxes of all feature stores of the currently running workspace, with the parameter 'featureStoreId' a comma separated list of feature stores to update can be passed\n");
 			data.append(


### PR DESCRIPTION
Fixes #1875 

If REST API  `/config/validate/notCrurrentWs' is validated instead of a 500 Internal server  status code 400 Bad Request is returned with the following reason

```
Validating the requested workspace is not allowed: notCrurrentWs is not the currently active workspace.
``