### PR TITLE
Enhance build pipeline with SBOM comparsion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,11 @@ pipeline {
         maven 'maven-3.9'
         jdk 'temurin-jdk17'
         git 'git-default'
+        generic 'cyclonedx'
     }
     environment {
         MAVEN_OPTS='-Djava.awt.headless=true -Xmx4096m'
+        CYCLONEDX_HOME = tool name: 'cyclonedx', type: 'io.jenkins.plugins.generic_tool.GenericToolInstallation'
     }
     parameters {
           string name: 'REL_VERSION', defaultValue: "3.6.x", description: 'Next release version'
@@ -26,6 +28,7 @@ pipeline {
                 sh 'mvn -version'
                 sh 'java -version'
                 sh 'git --version'
+                sh 'DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 ${CYCLONEDX_HOME}/cyclonedx --version'
             }
         }
         stage ('Build') {
@@ -57,6 +60,28 @@ pipeline {
                 always {
                     recordIssues enabledForFailure: true, tools: [mavenConsole(), java(), javaDoc(), spotBugs()]
                 }
+            }
+        }
+        stage ('SBOM Comparsion') {
+            environment {
+                SBOM_LOCATION='target/bom.json'
+                DOTNET_SYSTEM_GLOBALIZATION_INVARIANT='1'
+                POM_VERSION="""${sh(
+                    returnStdout: true,
+                    script: 'mvn org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=project.version -q -DforceStdout'
+                ).trim()}"""
+                TAG_VERSION="""${sh(
+                    returnStdout: true,
+                    script: '((git fetch origin "refs/tags/deegree-3.6*:refs/tags/deegree-3.6*" >/dev/null 2>/dev/null) && git describe --abbrev=0 --tags --match "deegree-*.*" 2>/dev/null || echo "deegree-0.0.0") | cut -d"-" -f 2-'
+                ).trim()}"""
+            }
+            steps {
+                sh 'mvn -U dependency:copy -Dmdep.stripVersion=true -DoutputDirectory=target/sbom-snapshot -Dartifact=org.deegree:deegree:${POM_VERSION}:json:cyclonedx || true'
+                sh 'mvn -U dependency:copy -Dmdep.stripVersion=true -DoutputDirectory=target/sbom-last-tag -Dartifact=org.deegree:deegree:${TAG_VERSION}:json:cyclonedx || true'
+                echo 'Compare last repository snapshot bom with current build'
+                sh '${CYCLONEDX_HOME}/cyclonedx diff --output-format text --component-versions target/sbom-snapshot/deegree-cyclonedx.json ${SBOM_LOCATION} || true'
+                echo 'Compare last repository tag bom with current build'
+                sh '${CYCLONEDX_HOME}/cyclonedx diff --output-format text --component-versions target/sbom-last-tag/deegree-cyclonedx.json ${SBOM_LOCATION} || true'
             }
         }
         stage ('Release') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,9 +14,9 @@ pipeline {
         CYCLONEDX_HOME = tool name: 'cyclonedx', type: 'io.jenkins.plugins.generic_tool.GenericToolInstallation'
     }
     parameters {
-          string name: 'REL_VERSION', defaultValue: "3.6.x", description: 'Next release version'
-          string name: 'DEV_VERSION', defaultValue: "3.6.x-SNAPSHOT", description: 'Next snapshot version'
-          booleanParam name: 'PERFORM_RELEASE', defaultValue: false, description: 'Perform release build (on main branch only)'
+        string name: 'REL_VERSION', defaultValue: "3.6.x", description: 'Next release version'
+        string name: 'DEV_VERSION', defaultValue: "3.6.x-SNAPSHOT", description: 'Next snapshot version'
+        booleanParam name: 'PERFORM_RELEASE', defaultValue: false, description: 'Perform release build (on main branch only)'
     }
     stages {
         stage ('Initialize') {
@@ -33,8 +33,8 @@ pipeline {
         }
         stage ('Build') {
             steps {
-               echo 'Building'
-               sh 'mvn -B -C -P oracle clean test-compile'
+                echo 'Building'
+                sh 'mvn -B -C -P oracle clean test-compile'
             }
         }
         stage ('Test') {


### PR DESCRIPTION
This extends the pipeline by adding an `SBOM Comparsion` step to the pipeline.
In short, this adds the following to the execution:
  * Download SBOM from previous SNAPSHOT version.
  * Download SBOM from previous tag version.
  * Compare current SBOM with previous SNAPSHOT.
  * Compare current SBOM with previous tag version.
 
If one of the above steps fails, this will be ignored with `|| true` in the execution.

On the Jenkins side, the plugin https://plugins.jenkins.io/generic-tool/ was installed, and a tool was defined that gets automatically installed from the release binary from https://github.com/CycloneDX/cyclonedx-cli/releases .

An actual output can be seen on the testing branch #1936 built output [here PR-1936/13](https://buildserver.deegree.org/blue/organizations/jenkins/pull-request/detail/PR-1936/13/pipeline/69).

PS: This merge request also cleans up some indentation inconsistencies.

closes #1936