### PR TITLE
Included all database drivers available through maven central into webservices and its variants

### DIFF
--- a/deegree-client/deegree-jsf-core/pom.xml
+++ b/deegree-client/deegree-jsf-core/pom.xml
@@ -78,7 +78,6 @@
     <dependency>
       <groupId>org.jboss.weld.servlet</groupId>
       <artifactId>weld-servlet-core</artifactId>
-      <version>5.1.7.Final</version>
       <exclusions>
           <exclusion>
               <groupId>jakarta.el</groupId>

--- a/deegree-services/deegree-webservices-basic/pom.xml
+++ b/deegree-services/deegree-webservices-basic/pom.xml
@@ -3,13 +3,39 @@
     <artifactId>deegree-webservices-basic</artifactId>
     <packaging>war</packaging>
     <name>deegree-webservices-basic</name>
-    <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules</description>
+    <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules and the REST API</description>
     <parent>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-services</artifactId>
         <version>3.6.7-SNAPSHOT</version>
     </parent>
-
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <configuration>
+            <archiveClasses>true</archiveClasses>
+            <attachClasses>true</attachClasses>
+            <archive>
+              <manifest>
+                <addDefaultEntries>true</addDefaultEntries>
+              </manifest>
+              <manifestEntries>
+                <Implementation-Title>${project.name}</Implementation-Title>
+                <Implementation-Version>${project.version}</Implementation-Version>
+                <Implementation-Vendor>${project.groupId}:${project.artifactId}:${buildNumber}:${buildTimestamp} ${user.name}</Implementation-Vendor>
+                <deegree-build-groupId>${project.groupId}</deegree-build-groupId>
+                <deegree-build-artifactId>${project.artifactId}</deegree-build-artifactId>
+                <deegree-build-by>${user.name}</deegree-build-by>
+                <deegree-build-date>${buildTimestamp}</deegree-build-date>
+                <deegree-build-rev>${buildNumber}</deegree-build-rev>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-services/deegree-webservices-commons/pom.xml
+++ b/deegree-services/deegree-webservices-commons/pom.xml
@@ -66,23 +66,11 @@
             <groupId>org.deegree</groupId>
             <artifactId>deegree-sqldialect-oracle</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.oracle.database.jdbc</groupId>
-                    <artifactId>ojdbc11</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deegree</groupId>
             <artifactId>deegree-sqldialect-mssql</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.microsoft.sqlserver</groupId>
-                    <artifactId>mssql-jdbc</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-services/deegree-webservices-minimal/pom.xml
+++ b/deegree-services/deegree-webservices-minimal/pom.xml
@@ -3,13 +3,39 @@
     <artifactId>deegree-webservices-minimal</artifactId>
     <packaging>war</packaging>
     <name>deegree-webservices-minimal</name>
-    <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules and REST services</description>
+    <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules</description>
     <parent>
         <groupId>org.deegree</groupId>
         <artifactId>deegree-services</artifactId>
         <version>3.6.7-SNAPSHOT</version>
     </parent>
-
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <configuration>
+            <archiveClasses>true</archiveClasses>
+            <attachClasses>true</attachClasses>
+            <archive>
+              <manifest>
+                <addDefaultEntries>true</addDefaultEntries>
+              </manifest>
+              <manifestEntries>
+                <Implementation-Title>${project.name}</Implementation-Title>
+                <Implementation-Version>${project.version}</Implementation-Version>
+                <Implementation-Vendor>${project.groupId}:${project.artifactId}:${buildNumber}:${buildTimestamp} ${user.name}</Implementation-Vendor>
+                <deegree-build-groupId>${project.groupId}</deegree-build-groupId>
+                <deegree-build-artifactId>${project.artifactId}</deegree-build-artifactId>
+                <deegree-build-by>${user.name}</deegree-build-by>
+                <deegree-build-date>${buildTimestamp}</deegree-build-date>
+                <deegree-build-rev>${buildNumber}</deegree-build-rev>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.deegree</groupId>

--- a/deegree-services/deegree-webservices/pom.xml
+++ b/deegree-services/deegree-webservices/pom.xml
@@ -3,7 +3,7 @@
   <artifactId>deegree-webservices</artifactId>
   <packaging>war</packaging>
   <name>deegree-webservices</name>
-  <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules and service administration console</description>
+  <description>Webapp that includes deegree WMS, WFS, CSW, WPS, common datastore modules, REST API and service administration console</description>
   <parent>
     <groupId>org.deegree</groupId>
     <artifactId>deegree-services</artifactId>
@@ -33,30 +33,6 @@
             </manifestEntries>
           </archive>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/WEB-INF/classes</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/resources</directory>
-                  <includes>
-                    <include>**/log4j2.properties</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
@@ -119,13 +95,11 @@
     <dependency>
       <groupId>org.primefaces</groupId>
       <artifactId>primefaces</artifactId>
-      <version>15.0.13</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>org.primefaces.extensions</groupId>
       <artifactId>primefaces-extensions</artifactId>
-      <version>15.0.13</version>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -694,6 +694,23 @@
         <artifactId>jakarta.enterprise.cdi-api</artifactId>
         <version>4.0.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.primefaces</groupId>
+        <artifactId>primefaces</artifactId>
+        <version>${primefaces.version}</version>
+        <classifier>jakarta</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.primefaces.extensions</groupId>
+        <artifactId>primefaces-extensions</artifactId>
+        <version>${primefaces.version}</version>
+        <classifier>jakarta</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld.servlet</groupId>
+        <artifactId>weld-servlet-core</artifactId>
+        <version>5.1.7.Final</version>
+      </dependency>
       <!-- logging -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
@@ -1275,6 +1292,7 @@
     <axiom.version>2.0.0</axiom.version>
     <jsonpath.version>2.10.0</jsonpath.version>
     <jsonsmart.version>2.6.0</jsonsmart.version>
+    <primefaces.version>15.0.13</primefaces.version>
     <jvm.args>--add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED</jvm.args>
   </properties>
 


### PR DESCRIPTION
Related Issue https://github.com/deegree/deegree3/issues/1450

This is a variation of https://github.com/deegree/deegree3/pull/1938 without the additional `-nodriver` variants.

This PR contains the following fixes:

* Align and/or fix metadata and description in variants
* Include jdbc drivers in regular variants (no-suffix, basic, minimal)
* The postgis dependency was not excluded in the -nodriver variants

closes https://github.com/deegree/deegree3/pull/1938