### PR TITLE
Update SECURITY.md with supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ The following versions of deegree are currently being supported with security up
 | Version | Supported          |
 |---------|--------------------|
 | 3.6.x   | :white_check_mark: |
-| 3.5.x   | :white_check_mark: |
+| 3.5.x   | :x:                |
 | 3.4.x   | :x:                |
 | <= 3.3  | :x:                |
 


### PR DESCRIPTION
With general availability of deegree release version 3.6 the community support for version line 3.5 ends.