### PR TITLE
Support of FILTER parameters with T_BEFORE

### DIFF
--- a/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/Cql2FilterVisitor.java
+++ b/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/Cql2FilterVisitor.java
@@ -68,6 +68,7 @@ import org.deegree.filter.logical.Or;
 import org.deegree.filter.spatial.Intersects;
 import org.deegree.filter.spatial.SpatialOperator;
 import org.deegree.filter.temporal.After;
+import org.deegree.filter.temporal.Before;
 import org.deegree.filter.temporal.TemporalOperator;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.GeometryFactory;
@@ -440,10 +441,15 @@ public class Cql2FilterVisitor extends Cql2ParserBaseVisitor {
 		TemporalOperator.SubType type = TemporalOperator.SubType.valueOf(temporalFunctionType);
 		switch (type) {
 			case AFTER:
-				Expression propName = checkExpressionType(
+				Expression propNameAfter = checkExpressionType(
 						(Expression) ctx.temporalExpression(0).propertyName().accept(this), DATE, DATE_TIME, TIME);
-				Expression dateValue = (Expression) ctx.temporalExpression(1).temporalInstance().accept(this);
-				return new After(propName, dateValue);
+				Expression dateValueAfter = (Expression) ctx.temporalExpression(1).temporalInstance().accept(this);
+				return new After(propNameAfter, dateValueAfter);
+			case BEFORE:
+				Expression propNameBefore = checkExpressionType(
+						(Expression) ctx.temporalExpression(0).propertyName().accept(this), DATE, DATE_TIME, TIME);
+				Expression dateValueBefore = (Expression) ctx.temporalExpression(1).temporalInstance().accept(this);
+				return new Before(propNameBefore, dateValueBefore);
 		}
 		throw new Cql2UnsupportedExpressionException("Unsupported geometry type " + type);
 	}

--- a/deegree-core/deegree-core-cql2/src/test/java/org/deegree/cql2/Cql2FilterParserTest.java
+++ b/deegree-core/deegree-core-cql2/src/test/java/org/deegree/cql2/Cql2FilterParserTest.java
@@ -53,6 +53,7 @@ import org.deegree.filter.logical.Not;
 import org.deegree.filter.logical.Or;
 import org.deegree.filter.spatial.Intersects;
 import org.deegree.filter.temporal.After;
+import org.deegree.filter.temporal.Before;
 import org.deegree.geometry.Envelope;
 import org.deegree.geometry.Geometry;
 import org.deegree.geometry.multi.MultiGeometry;
@@ -484,9 +485,111 @@ public class Cql2FilterParserTest {
 	}
 
 	@Test
-	public void parse_t_after_non_date_property() throws Exception {
+	public void parse_t_after_non_date_property() {
 		String after = "T_AFTER(testString,TIMESTAMP('2025-04-14T08:59:30Z'))";
 		assertThrows(IllegalArgumentException.class, () -> parseCql2Filter(after, crs(), PROPS));
+	}
+
+	@Test
+	public void test_parse_T_BEFORE_date() throws UnknownCRSException {
+		String Before = "T_BEFORE(testDate,DATE('2025-04-14'))";
+		Object visit = parseCql2Filter(Before, crs(), PROPS);
+
+		assertTrue(visit instanceof Before);
+
+		Expression param1 = ((Before) visit).getParameter1();
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("testDate", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression date = ((Before) visit).getParameter2();
+		assertTrue(date instanceof Literal);
+		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
+		assertTrue(primitiveValue instanceof PrimitiveValue);
+		Object value = ((PrimitiveValue) primitiveValue).getValue();
+		assertTrue(value instanceof Date);
+		Calendar calendar = ((Date) value).getCalendar();
+		assertEquals(2025, calendar.get(Calendar.YEAR));
+		assertEquals(APRIL, calendar.get(Calendar.MONTH));
+		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
+	}
+
+	@Test
+	public void parse_t_Before_date() throws Exception {
+		String Before = "T_BEFORE(testDate,DATE('2025-04-14'))";
+		Object visit = parseCql2Filter(Before, crs(), FILTERPROPS);
+
+		assertTrue(visit instanceof Before);
+
+		Expression param1 = ((Before) visit).getParameter1();
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("testDate", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression date = ((Before) visit).getParameter2();
+		assertTrue(date instanceof Literal);
+		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
+		assertTrue(primitiveValue instanceof PrimitiveValue);
+		Object value = ((PrimitiveValue) primitiveValue).getValue();
+		assertTrue(value instanceof Date);
+		Calendar calendar = ((Date) value).getCalendar();
+		assertEquals(2025, calendar.get(Calendar.YEAR));
+		assertEquals(APRIL, calendar.get(Calendar.MONTH));
+		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
+	}
+
+	@Test
+	public void test_parse_T_BEFORE_timestamp() throws UnknownCRSException {
+		String Before = "T_BEFORE(testDate,TIMESTAMP('2025-04-14T08:59:30Z'))";
+		Object visit = parseCql2Filter(Before, crs(), PROPS);
+
+		assertTrue(visit instanceof Before);
+
+		Expression param1 = ((Before) visit).getParameter1();
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("testDate", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression date = ((Before) visit).getParameter2();
+		assertTrue(date instanceof Literal);
+		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
+		assertTrue(primitiveValue instanceof PrimitiveValue);
+		Object value = ((PrimitiveValue) primitiveValue).getValue();
+		assertTrue(value instanceof DateTime);
+		Calendar calendar = ((DateTime) value).getCalendar();
+		assertEquals(2025, calendar.get(Calendar.YEAR));
+		assertEquals(APRIL, calendar.get(Calendar.MONTH));
+		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
+	}
+
+	@Test
+	public void parse_t_Before_timestamp() throws Exception {
+		String Before = "T_BEFORE(testDate,TIMESTAMP('2025-04-14T08:59:30Z'))";
+		Object visit = parseCql2Filter(Before, crs(), FILTERPROPS);
+
+		assertTrue(visit instanceof Before);
+
+		Expression param1 = ((Before) visit).getParameter1();
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("testDate", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals("", ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression date = ((Before) visit).getParameter2();
+		assertTrue(date instanceof Literal);
+		TypedObjectNode primitiveValue = ((Literal<?>) date).getValue();
+		assertTrue(primitiveValue instanceof PrimitiveValue);
+		Object value = ((PrimitiveValue) primitiveValue).getValue();
+		assertTrue(value instanceof DateTime);
+		Calendar calendar = ((DateTime) value).getCalendar();
+		assertEquals(2025, calendar.get(Calendar.YEAR));
+		assertEquals(APRIL, calendar.get(Calendar.MONTH));
+		assertEquals(14, calendar.get(Calendar.DAY_OF_MONTH));
+	}
+
+	@Test
+	public void parse_t_Before_non_date_property() {
+		String Before = "T_BEFORE(testString,TIMESTAMP('2025-04-14T08:59:30Z'))";
+		assertThrows(IllegalArgumentException.class, () -> parseCql2Filter(Before, crs(), PROPS));
 	}
 
 	@Test

--- a/deegree-documentation/src/main/asciidoc/webservices.adoc
+++ b/deegree-documentation/src/main/asciidoc/webservices.adoc
@@ -1772,11 +1772,11 @@ Using the vendorspecific parameter CQL2_FILTER a more complex expression can be 
 ** S_INTERSECTS
 * Temporal Functions
 ** T_AFTER
-* Temporal Functions
-** T_AFTER
+** T_BEFORE
 
 ----
 CQL2_FILTER=T_AFTER(creationDate,TIMESTAMP('2025-04-14T08:59:30Z'))
+CQL2_FILTER=T_BEFORE(creationDate,TIMESTAMP('2025-04-14T08:59:30Z'))
 CQL2_FILTER=S_INTERSECTS(geometry,BBOX(36.319836,32.288087,37.319836,33.288087))
 # city='Bonn'
 CQL2_FILTER=city%3D%27Bonn%27


### PR DESCRIPTION
This PR enhances the support for [OGC API - Features - Part 3](https://docs.ogc.org/is/19-079r2/19-079r2.html) by adding the [temporal CQL2 function](https://docs.ogc.org/is/21-065r2/21-065r2.html#_temporal_functions) T_BEFORE({propertyName},{temporalInstance}) with {temporalInstance} = {instantInstance} and {instantInstance} = {dateInstant} | {timestampInstant}.

It builds upon the implementation of [T_AFTER](https://github.com/deegree/deegree-ogcapi/pull/150).