### PR TITLE
Set testParsingCityGML to ignore

### DIFF
--- a/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/schema/GMLAppSchemaReaderTest.java
+++ b/deegree-core/deegree-core-base/src/test/java/org/deegree/gml/schema/GMLAppSchemaReaderTest.java
@@ -60,6 +60,7 @@ import org.deegree.feature.types.FeatureType;
 import org.deegree.feature.types.property.GeometryPropertyType;
 import org.deegree.gml.GMLVersion;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -92,6 +93,7 @@ public class GMLAppSchemaReaderTest {
 		Assert.assertEquals(4, fts.size());
 	}
 
+	@Ignore
 	@Test
 	public void testParsingCityGML()
 			throws ClassCastException, ClassNotFoundException, InstantiationException, IllegalAccessException {


### PR DESCRIPTION
Fixes #1953

This PR sets testParsingCityGML to ignore as retrieving an external schema used by the test is blocked on some systems.