### PR TITLE
Updated dependencies for Jaxb, Faces, Jaxen, Postgresql, slf4j, Primefaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -687,7 +687,7 @@
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.faces</artifactId>
-        <version>4.0.15</version>
+        <version>4.0.18</version>
       </dependency>
       <dependency>
         <groupId>jakarta.enterprise</groupId>
@@ -814,7 +814,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.3</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>
@@ -884,7 +884,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.10</version>
+        <version>42.7.11</version>
       </dependency>
       <!-- Oracle (Official provided driver from repo1.maven.org) -->
       <dependency>
@@ -1286,13 +1286,13 @@
     <antlr4.version>4.13.2</antlr4.version>
     <oracle.version>23.4.0.24.05</oracle.version>
     <logback.version>1.5.32</logback.version>
-    <slf4j.version>2.0.17</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <spring-boot.version>3.5.14</spring-boot.version>
     <batik.version>1.19</batik.version>
     <axiom.version>2.0.0</axiom.version>
     <jsonpath.version>2.10.0</jsonpath.version>
     <jsonsmart.version>2.6.0</jsonsmart.version>
-    <primefaces.version>15.0.14</primefaces.version>
+    <primefaces.version>15.0.15</primefaces.version>
     <jvm.args>--add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED</jvm.args>
   </properties>
 


### PR DESCRIPTION
This PR upgrades the dependencies:
* jaxb-runtime 4.0.8
* jakarta.faces 4.0.18
* jaxen  2.0.3
* postgresql 42.7.11
* slf4j 2.0.18
* primefaces 15.0.15