### PR TITLE
Add support of nillable primitives

### DIFF
--- a/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/XPathSchemaWalker.java
+++ b/deegree-datastores/deegree-featurestores/deegree-featurestore-sql/src/main/java/org/deegree/feature/persistence/sql/mapper/XPathSchemaWalker.java
@@ -167,17 +167,18 @@ public class XPathSchemaWalker {
 				}
 				else if (step.getAxis() == Axis.ATTRIBUTE) {
 					QName qName = getQName(step);
-					XSTypeDefinition typeDef = currentEl.first.getTypeDefinition();
-					if (!(typeDef instanceof XSComplexTypeDefinition)) {
-						throw new IllegalArgumentException("Unable to match XPath '" + propName
-								+ "' to application schema. Referenced attribute does not exist.");
-					}
+					XSElementDeclaration elementDeclaration = currentEl.first;
 					if (new QName(XSINS, "nil").equals(qName)) {
-						if (!currentEl.first.getNillable()) {
+						if (!elementDeclaration.getNillable()) {
 							throw new IllegalArgumentException("Unable to match XPath '" + propName
 									+ "' to application schema. Referenced element is not nillable.");
 						}
 						return new Pair<PrimitiveType, Boolean>(new PrimitiveType(BOOLEAN), TRUE);
+					}
+					XSTypeDefinition typeDef = elementDeclaration.getTypeDefinition();
+					if (!(typeDef instanceof XSComplexTypeDefinition)) {
+						throw new IllegalArgumentException("Unable to match XPath '" + propName
+								+ "' to application schema. Referenced attribute does not exist.");
 					}
 					XSComplexTypeDefinition complexTypeDef = (XSComplexTypeDefinition) typeDef;
 					XSObjectList attrUses = complexTypeDef.getAttributeUses();


### PR DESCRIPTION
If a simple element is declared in the application schema
```
<element name="measurementID" type="string" nillable="true">
</element>
```
an exception is thrown
```
ERROR o.d.w.s.DefaultWorkspace [main] Unable to build resource FeatureStoreProvider:BoreholeML: Error in mapping of table 'measurement': java.lang.IllegalArgumentException: Unable to match XPath '-PropertyName ('@xsi:nil')
[2026-04-30 12:20:38] [info] ' to application schema. Referenced attribute does not exist.
```
with the following mapping:
```
<Complex path="bml:measurementID">
	<Primitive path="@xsi:nil" mapping="CASE WHEN measurement_id IS NULL THEN TRUE ELSE FALSE END"/>
	<Primitive path="text()" mapping="measurement_id"/>
</Complex>
```
This PR fixes the exception,  the configuration can be parsed and the GML output contains the xml element with nil-attribute:
```
<bml:measurementID xsi:nil="true"/>
```
