### PR TITLE
Updated maven owasp and spotbugs plugins to latest versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             }
             steps {
                 echo 'Quality checking'
-                sh 'mvn -B -C -fae -P oracle com.github.spotbugs:spotbugs-maven-plugin:4.9.7.0:spotbugs javadoc:javadoc'
+                sh 'mvn -B -C -fae -P oracle com.github.spotbugs:spotbugs-maven-plugin:4.10.2.0:spotbugs javadoc:javadoc'
             }
             post {
                 always {

--- a/pom.xml
+++ b/pom.xml
@@ -1328,7 +1328,7 @@
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.9.8.3</version>
+            <version>4.10.2.0</version>
             <configuration>
               <xmlOutput>true</xmlOutput>
               <spotbugsXmlOutput>true</spotbugsXmlOutput>
@@ -1384,7 +1384,7 @@
           <plugin>
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
-            <version>12.2.1</version>
+            <version>12.2.2</version>
             <configuration>
               <nvdValidForHours>24</nvdValidForHours>
               <knownExploitedEnabled>false</knownExploitedEnabled>


### PR DESCRIPTION
PR updates the maven plugins:
- com.github.spotbugs:spotbugs-maven-plugin:4.10.2.0
- org.owasp:dependency-check-maven:12.2.2