### PR TITLE
Enhanced CQL2 filter by supporting <, <=, > , >=

### DIFF
--- a/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/Cql2FilterVisitor.java
+++ b/deegree-core/deegree-core-cql2/src/main/java/org/deegree/cql2/Cql2FilterVisitor.java
@@ -59,6 +59,10 @@ import org.deegree.filter.Expression;
 import org.deegree.filter.MatchAction;
 import org.deegree.filter.Operator;
 import org.deegree.filter.comparison.PropertyIsEqualTo;
+import org.deegree.filter.comparison.PropertyIsGreaterThan;
+import org.deegree.filter.comparison.PropertyIsGreaterThanOrEqualTo;
+import org.deegree.filter.comparison.PropertyIsLessThan;
+import org.deegree.filter.comparison.PropertyIsLessThanOrEqualTo;
 import org.deegree.filter.comparison.PropertyIsLike;
 import org.deegree.filter.expression.Literal;
 import org.deegree.filter.expression.ValueReference;
@@ -171,14 +175,20 @@ public class Cql2FilterVisitor extends Cql2ParserBaseVisitor {
 	@Override
 	public Object visitBinaryComparisonPredicate(Cql2Parser.BinaryComparisonPredicateContext ctx) {
 		String comparisonOperator = ctx.ComparisonOperator().getText();
-		switch (comparisonOperator) {
-			case "=":
+		Expression param1 = (Expression) ctx.scalarExpression().get(0).accept(this);
+		Expression param2 = (Expression) ctx.scalarExpression().get(1).accept(this);
+		return switch (comparisonOperator) {
+			case "=" -> {
 				boolean matchCase = ctx.getText().contains("CASEI");
-				Expression param1 = (Expression) ctx.scalarExpression().get(0).accept(this);
-				Expression param2 = (Expression) ctx.scalarExpression().get(1).accept(this);
-				return new PropertyIsEqualTo(param1, param2, matchCase, MatchAction.ANY);
-		}
-		throw new Cql2UnsupportedExpressionException("Unsupported comparisonOperator " + comparisonOperator);
+				yield new PropertyIsEqualTo(param1, param2, matchCase, MatchAction.ANY);
+			}
+			case "<" -> new PropertyIsLessThan(param1, param2, false, MatchAction.ANY);
+			case ">" -> new PropertyIsGreaterThan(param1, param2, false, MatchAction.ANY);
+			case "<=" -> new PropertyIsLessThanOrEqualTo(param1, param2, false, MatchAction.ANY);
+			case ">=" -> new PropertyIsGreaterThanOrEqualTo(param1, param2, false, MatchAction.ANY);
+			default ->
+				throw new Cql2UnsupportedExpressionException("Unsupported comparisonOperator " + comparisonOperator);
+		};
 	}
 
 	@Override

--- a/deegree-core/deegree-core-cql2/src/test/java/org/deegree/cql2/Cql2FilterParserTest.java
+++ b/deegree-core/deegree-core-cql2/src/test/java/org/deegree/cql2/Cql2FilterParserTest.java
@@ -45,6 +45,10 @@ import org.deegree.cs.persistence.CRSManager;
 import org.deegree.filter.Expression;
 import org.deegree.filter.Operator;
 import org.deegree.filter.comparison.PropertyIsEqualTo;
+import org.deegree.filter.comparison.PropertyIsGreaterThan;
+import org.deegree.filter.comparison.PropertyIsGreaterThanOrEqualTo;
+import org.deegree.filter.comparison.PropertyIsLessThan;
+import org.deegree.filter.comparison.PropertyIsLessThanOrEqualTo;
 import org.deegree.filter.comparison.PropertyIsLike;
 import org.deegree.filter.expression.Literal;
 import org.deegree.filter.expression.ValueReference;
@@ -974,6 +978,94 @@ public class Cql2FilterParserTest {
 		Object value = ((PrimitiveValue) primitiveValue).getValue();
 		assertTrue(value instanceof String);
 		assertEquals("VALUE2", value);
+	}
+
+	@Test
+	public void test_parse_lessThan() throws UnknownCRSException {
+		String comp = "test1<4";
+		Object visit = parseCql2Filter(comp, crs(), PROPS);
+
+		assertTrue(visit instanceof PropertyIsLessThan);
+		assertEquals(2, ((PropertyIsLessThan) visit).getParams().length);
+		Expression param1 = ((PropertyIsLessThan) visit).getParameter1();
+
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("test1", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression param2 = ((PropertyIsLessThan) visit).getParameter2();
+		assertTrue(param2 instanceof Literal);
+		TypedObjectNode primitiveValue1 = ((Literal<?>) param2).getValue();
+		assertTrue(primitiveValue1 instanceof PrimitiveValue);
+		Object value1 = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(value1 instanceof Integer);
+		assertEquals(4, value1);
+	}
+
+	@Test
+	public void test_parse_lessThanOrEqualTo() throws UnknownCRSException {
+		String comp = "test1<=4";
+		Object visit = parseCql2Filter(comp, crs(), PROPS);
+
+		assertTrue(visit instanceof PropertyIsLessThanOrEqualTo);
+		assertEquals(2, ((PropertyIsLessThanOrEqualTo) visit).getParams().length);
+		Expression param1 = ((PropertyIsLessThanOrEqualTo) visit).getParameter1();
+
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("test1", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression param2 = ((PropertyIsLessThanOrEqualTo) visit).getParameter2();
+		assertTrue(param2 instanceof Literal);
+		TypedObjectNode primitiveValue1 = ((Literal<?>) param2).getValue();
+		assertTrue(primitiveValue1 instanceof PrimitiveValue);
+		Object value1 = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(value1 instanceof Integer);
+		assertEquals(4, value1);
+	}
+
+	@Test
+	public void test_parse_greaterThan() throws UnknownCRSException {
+		String comp = "test1>4";
+		Object visit = parseCql2Filter(comp, crs(), PROPS);
+
+		assertTrue(visit instanceof PropertyIsGreaterThan);
+		assertEquals(2, ((PropertyIsGreaterThan) visit).getParams().length);
+		Expression param1 = ((PropertyIsGreaterThan) visit).getParameter1();
+
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("test1", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression param2 = ((PropertyIsGreaterThan) visit).getParameter2();
+		assertTrue(param2 instanceof Literal);
+		TypedObjectNode primitiveValue1 = ((Literal<?>) param2).getValue();
+		assertTrue(primitiveValue1 instanceof PrimitiveValue);
+		Object value1 = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(value1 instanceof Integer);
+		assertEquals(4, value1);
+	}
+
+	@Test
+	public void test_parse_greaterThanOrEqualTo() throws UnknownCRSException {
+		String comp = "test1>=4";
+		Object visit = parseCql2Filter(comp, crs(), PROPS);
+
+		assertTrue(visit instanceof PropertyIsGreaterThanOrEqualTo);
+		assertEquals(2, ((PropertyIsGreaterThanOrEqualTo) visit).getParams().length);
+		Expression param1 = ((PropertyIsGreaterThanOrEqualTo) visit).getParameter1();
+
+		assertTrue(param1 instanceof ValueReference);
+		assertEquals("test1", ((ValueReference) param1).getAsQName().getLocalPart());
+		assertEquals(NS_URL, ((ValueReference) param1).getAsQName().getNamespaceURI());
+
+		Expression param2 = ((PropertyIsGreaterThanOrEqualTo) visit).getParameter2();
+		assertTrue(param2 instanceof Literal);
+		TypedObjectNode primitiveValue1 = ((Literal<?>) param2).getValue();
+		assertTrue(primitiveValue1 instanceof PrimitiveValue);
+		Object value1 = ((PrimitiveValue) primitiveValue1).getValue();
+		assertTrue(value1 instanceof Integer);
+		assertEquals(4, value1);
 	}
 
 	private static ICRS crs() throws UnknownCRSException {

--- a/deegree-documentation/src/main/asciidoc/webservices.adoc
+++ b/deegree-documentation/src/main/asciidoc/webservices.adoc
@@ -1762,6 +1762,10 @@ Using the vendorspecific parameter CQL2_FILTER a more complex expression can be 
 ** OR
 * Comparison operators
 ** equal to (=), with string, int and double values
+** less than (<), with int and double values
+** less than or equal to (\<=), with int and double values
+** greater than (>), with int and double values
+** greater than or equal to (>=), with int and double values
 * Advanced Comparison Operators
 ** LIKE
 ** IN List
@@ -1780,6 +1784,14 @@ CQL2_FILTER=T_BEFORE(creationDate,TIMESTAMP('2025-04-14T08:59:30Z'))
 CQL2_FILTER=S_INTERSECTS(geometry,BBOX(36.319836,32.288087,37.319836,33.288087))
 # city='Bonn'
 CQL2_FILTER=city%3D%27Bonn%27
+# population<100000
+CQL2_FILTER=population%3C100000
+# population<=100000
+CQL2_FILTER=population%3C%3D100000
+# population>100000
+CQL2_FILTER=population%3E100000
+# population>=100000
+CQL2_FILTER=population%3E%3D100000
 #index=10
 CQL2_FILTER=index%3D10
 # city LIKE CASEI('B_N%')


### PR DESCRIPTION
This PR enhances the support for CQL2 Filter by adding the [Basic CQL2 Comparison operators](https://docs.ogc.org/is/21-065r2/21-065r2.html#_conformance) `<`, `<=`, `>`  and  `>=` .