### PR TITLE
Enhanced SldProvider to allow specific implementations retrieving values for SLD parameter

### DIFF
--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/RequestBase.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/RequestBase.java
@@ -37,20 +37,14 @@ package org.deegree.protocol.wms.ops;
 import static org.deegree.commons.utils.CollectionUtils.unzip;
 import static org.deegree.commons.utils.MapUtils.DEFAULT_PIXEL_SIZE;
 import static org.deegree.commons.utils.StringUtils.splitEscaped;
-import static org.deegree.protocol.wms.ops.SLDParser.parse;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.io.StringReader;
-import java.net.URL;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-
-import javax.xml.stream.XMLInputFactory;
 
 import org.deegree.commons.ows.exception.OWSException;
 import org.deegree.commons.utils.StringUtils;
@@ -87,41 +81,8 @@ public abstract class RequestBase {
 	}
 
 	protected void handleSLD(String sld, String sldBody) throws OWSException {
-
-		XMLInputFactory xmlfac = XMLInputFactory.newInstance();
-		Triple<LinkedList<LayerRef>, LinkedList<StyleRef>, LinkedList<OperatorFilter>> triple = null;
-		if (sld != null) {
-			try {
-				triple = parse(xmlfac.createXMLStreamReader(sld, new URL(sld).openStream()), this);
-			}
-			catch (ParseException e) {
-				LOG.trace("Stack trace:", e);
-				throw new OWSException(
-						"The embedded dimension value in the SLD parameter value was invalid: " + e.getMessage(),
-						"InvalidDimensionValue", "sld");
-			}
-			catch (Throwable e) {
-				LOG.trace("Stack trace:", e);
-				throw new OWSException("Error when parsing the SLD parameter: " + e.getMessage(),
-						"InvalidParameterValue", "sld");
-			}
-		}
-		if (sldBody != null) {
-			try {
-				triple = parse(xmlfac.createXMLStreamReader(new StringReader(sldBody)), this);
-			}
-			catch (ParseException e) {
-				LOG.trace("Stack trace:", e);
-				throw new OWSException(
-						"The embedded dimension value in the SLD_BODY parameter value was invalid: " + e.getMessage(),
-						"InvalidDimensionValue", "sld_body");
-			}
-			catch (Throwable e) {
-				LOG.trace("Stack trace:", e);
-				throw new OWSException("Error when parsing the SLD_BODY parameter: " + e.getMessage(),
-						"InvalidParameterValue", "sld_body");
-			}
-		}
+		Triple<LinkedList<LayerRef>, LinkedList<StyleRef>, LinkedList<OperatorFilter>> triple = new SldParamRetriever()
+			.handleSldParam(sld, sldBody, this);
 
 		// if layers are referenced, clear the other layers out, else leave all in
 		if (triple != null && !layers.isEmpty()) {
@@ -158,7 +119,7 @@ public abstract class RequestBase {
 			}
 
 			this.styles.clear();
-			this.filters = new LinkedList<OperatorFilter>();
+			this.filters = new LinkedList<>();
 
 			LinkedList<LayerRef> tmpLayers = new LinkedList<LayerRef>();
 

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/SldParamRetriever.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/SldParamRetriever.java
@@ -1,0 +1,90 @@
+package org.deegree.protocol.wms.ops;
+
+import static org.deegree.protocol.wms.ops.SLDParser.parse;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.xml.stream.XMLInputFactory;
+import java.io.StringReader;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.LinkedList;
+import java.util.ServiceLoader;
+
+import org.deegree.commons.ows.exception.OWSException;
+import org.deegree.commons.utils.Triple;
+import org.deegree.filter.OperatorFilter;
+import org.deegree.layer.LayerRef;
+import org.deegree.style.StyleRef;
+import org.slf4j.Logger;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class SldParamRetriever {
+
+	private static final Logger LOG = getLogger(SldParamRetriever.class);
+
+	private static final ServiceLoader<SldProvider> sldProviderLoader;
+
+	static {
+		sldProviderLoader = ServiceLoader.load(SldProvider.class);
+		for (SldProvider sldProvider : sldProviderLoader) {
+			sldProvider.init();
+		}
+	}
+
+	/**
+	 * @param sld the value of the SLD param, may be <code>null</code>
+	 * @param sldBody the value of the SLD_BODY param, may be <code>null</code>,
+	 * overwrites the sld param value if sld and sldBody are not <code>null</code>
+	 * @param gm the {@link RequestBase} instance, never <code>null</code>
+	 * @return the parsed sld, if sld or sldBody not <code>null</code>, <code>null</code>
+	 * if sld and sldBody are <code>null</code>
+	 * @throws OWSException if sld or sldBody could not be parsed
+	 */
+	Triple<LinkedList<LayerRef>, LinkedList<StyleRef>, LinkedList<OperatorFilter>> handleSldParam(String sld,
+			String sldBody, RequestBase gm) throws OWSException {
+		XMLInputFactory xmlfac = XMLInputFactory.newInstance();
+		Triple<LinkedList<LayerRef>, LinkedList<StyleRef>, LinkedList<OperatorFilter>> triple = null;
+		if (sld != null) {
+			try {
+				for (SldProvider sldProvider : sldProviderLoader) {
+					String sldBodyFromProvider = sldProvider.retrieveSldBody(sld);
+					if (sldBodyFromProvider != null)
+						triple = parse(xmlfac.createXMLStreamReader(new StringReader(sldBodyFromProvider)), gm);
+				}
+				if (triple == null)
+					return parse(xmlfac.createXMLStreamReader(sld, new URL(sld).openStream()), gm);
+			}
+			catch (ParseException e) {
+				LOG.trace("Stack trace:", e);
+				throw new OWSException(
+						"The embedded dimension value in the SLD parameter value was invalid: " + e.getMessage(),
+						"InvalidDimensionValue", "sld");
+			}
+			catch (Throwable e) {
+				LOG.trace("Stack trace:", e);
+				throw new OWSException("Error when parsing the SLD parameter: " + e.getMessage(),
+						"InvalidParameterValue", "sld");
+			}
+		}
+		if (sldBody != null) {
+			try {
+				triple = parse(xmlfac.createXMLStreamReader(new StringReader(sldBody)), gm);
+			}
+			catch (ParseException e) {
+				LOG.trace("Stack trace:", e);
+				throw new OWSException(
+						"The embedded dimension value in the SLD_BODY parameter value was invalid: " + e.getMessage(),
+						"InvalidDimensionValue", "sld_body");
+			}
+			catch (Throwable e) {
+				LOG.trace("Stack trace:", e);
+				throw new OWSException("Error when parsing the SLD_BODY parameter: " + e.getMessage(),
+						"InvalidParameterValue", "sld_body");
+			}
+		}
+		return triple;
+	}
+
+}

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/SldProvider.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/SldProvider.java
@@ -1,0 +1,22 @@
+package org.deegree.protocol.wms.ops;
+
+/**
+ * Implementations of this class provides slds from a passed query sld param.
+ *
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public interface SldProvider {
+
+	/**
+	 * Called once to initialize the SldProvider
+	 */
+	void init();
+
+	/**
+	 * @param sld the value of the sld query param, never <code>null</code>
+	 * @return the content associated to the sld query param, may be <code>null</code> if
+	 * not retrievable or parseable
+	 */
+	String retrieveSldBody(String sld);
+
+}


### PR DESCRIPTION
This PR enhances the parsing of the sld parameter. Currently only parsing from a  http url is supported. This PR adds a SldProvider which can be implemented to allow specific access to SLD files, e.g. from S3 . 