### PR TITLE
Added vendor specific parameter GFI_TEMPLATE and GfiTemplateProvider to allow specific implementations retrieving values for GFI_TEMPLATE parameter

### DIFF
--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/FeatureInfoParams.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/FeatureInfoParams.java
@@ -52,34 +52,13 @@ import org.deegree.feature.types.FeatureType;
  *
  * @author <a href="mailto:schmitz@occamlabs.de">Andreas Schmitz</a>
  */
-public class FeatureInfoParams {
-
-	private Map<String, String> nsBindings;
-
-	private FeatureCollection featureCollection;
-
-	private String format;
-
-	private boolean withGeometries;
-
-	private String schemaLocation;
-
-	private FeatureType featureType;
-
-	private ICRS crs;
-
-	private final ICRS infoCrs;
+public record FeatureInfoParams(Map<String, String> nsBindings, FeatureCollection featureCollection, String format,
+		boolean withGeometries, String schemaLocation, FeatureType featureType, ICRS crs, ICRS infoCrs,
+		String gfiTemplate) {
 
 	public FeatureInfoParams(Map<String, String> nsBindings, FeatureCollection col, String format,
 			boolean withGeometries, String schemaLocation, FeatureType type, ICRS crs, ICRS infoCrs) {
-		this.nsBindings = nsBindings;
-		this.featureCollection = col;
-		this.format = format;
-		this.withGeometries = withGeometries;
-		this.schemaLocation = schemaLocation;
-		this.featureType = type;
-		this.crs = crs;
-		this.infoCrs = infoCrs;
+		this(nsBindings, col, format, withGeometries, schemaLocation, type, crs, infoCrs, null);
 	}
 
 	/**

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/serializing/TemplateFeatureInfoSerializer.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/serializing/TemplateFeatureInfoSerializer.java
@@ -62,8 +62,8 @@ public class TemplateFeatureInfoSerializer implements FeatureInfoSerializer {
 
 	@Override
 	public void serialize(FeatureInfoParams params, FeatureInfoContext context) throws IOException, XMLStreamException {
-
-		runTemplate(context.getOutputStream(), fiFile, params.getFeatureCollection(), params.isWithGeometries());
+		runTemplate(context.getOutputStream(), fiFile, params.getFeatureCollection(), params.isWithGeometries(),
+				params.gfiTemplate());
 	}
 
 }

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/GfiRetriever.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/GfiRetriever.java
@@ -1,0 +1,47 @@
+package org.deegree.featureinfo.templating;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ServiceLoader;
+
+import org.deegree.featureinfo.FeatureInfoManager;
+
+/**
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public class GfiRetriever {
+
+	private static final ServiceLoader<GfiTemplateProvider> gfiTemplateProviderLoader;
+
+	static {
+		gfiTemplateProviderLoader = ServiceLoader.load(GfiTemplateProvider.class);
+		for (GfiTemplateProvider gfiTemplateProvider : gfiTemplateProviderLoader) {
+			gfiTemplateProvider.init();
+		}
+	}
+
+	/**
+	 * @param gfiFile to retrieve the template from, may be <code>null</code>
+	 * @param gfiTemplateParam the value of the gfiTemplate parameter, may be
+	 * <code>null</code>
+	 * @return the template from the gfiTemplateParam, if available or from the gfiFile if
+	 * not <code>null</code>, if both are <code>null</code> or not available the default
+	 * 'html.gfi' is returned
+	 * @throws FileNotFoundException if the gfiFile could not be found
+	 */
+	InputStream retrieveTemplate(String gfiFile, String gfiTemplateParam) throws FileNotFoundException {
+		if (gfiTemplateParam != null && !gfiTemplateParam.isEmpty()) {
+			for (GfiTemplateProvider gfiTemplateProvider : gfiTemplateProviderLoader) {
+				InputStream gfiTemplateFromProvider = gfiTemplateProvider.retrieveTemplate(gfiTemplateParam);
+				if (gfiTemplateFromProvider != null)
+					return gfiTemplateFromProvider;
+			}
+		}
+		if (gfiFile == null) {
+			return FeatureInfoManager.class.getResourceAsStream("html.gfi");
+		}
+		return new FileInputStream(gfiFile);
+	}
+
+}

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/GfiTemplateProvider.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/GfiTemplateProvider.java
@@ -1,0 +1,24 @@
+package org.deegree.featureinfo.templating;
+
+import java.io.InputStream;
+
+/**
+ * Implementations of this class provides gfi templates from a passed query param.
+ *
+ * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
+ */
+public interface GfiTemplateProvider {
+
+	/**
+	 * Called once to initialize the GfiTemplateProvider
+	 */
+	void init();
+
+	/**
+	 * @param gfiTemplateParam the value of the query param, never <code>null</code>
+	 * @return the content associated to the query param, may be <code>null</code> if not
+	 * retrievable or parseable
+	 */
+	InputStream retrieveTemplate(String gfiTemplateParam);
+
+}

--- a/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/TemplatingUtils.java
+++ b/deegree-core/deegree-core-featureinfo/src/main/java/org/deegree/featureinfo/templating/TemplatingUtils.java
@@ -43,19 +43,17 @@ package org.deegree.featureinfo.templating;
 import static java.util.Collections.singletonList;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import org.antlr.runtime.ANTLRInputStream;
 import org.antlr.runtime.CharStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.deegree.feature.FeatureCollection;
-import org.deegree.featureinfo.FeatureInfoManager;
 import org.deegree.featureinfo.templating.lang.PropertyTemplateCall;
 import org.slf4j.Logger;
 
@@ -68,18 +66,12 @@ public class TemplatingUtils {
 
 	private static final Logger LOG = getLogger(TemplatingUtils.class);
 
-	public static void runTemplate(OutputStream response, String fiFile, FeatureCollection col, boolean geometries)
-			throws IOException {
-		PrintWriter out = new PrintWriter(new OutputStreamWriter(response, "UTF-8"));
+	public static void runTemplate(OutputStream response, String fiFile, FeatureCollection col, boolean geometries,
+			String gfiTemplateParam) {
+		PrintWriter out = new PrintWriter(new OutputStreamWriter(response, StandardCharsets.UTF_8));
 
 		try {
-			InputStream in;
-			if (fiFile == null) {
-				in = FeatureInfoManager.class.getResourceAsStream("html.gfi");
-			}
-			else {
-				in = new FileInputStream(fiFile);
-			}
+			InputStream in = new GfiRetriever().retrieveTemplate(fiFile, gfiTemplateParam);
 
 			CharStream input = new ANTLRInputStream(in);
 			Templating2Lexer lexer = new Templating2Lexer(input);
@@ -90,7 +82,7 @@ public class TemplatingUtils {
 
 			StringBuilder sb = new StringBuilder();
 			new PropertyTemplateCall("start", singletonList("*"), false).eval(sb, defs, col, geometries);
-			out.println(sb.toString());
+			out.println(sb);
 		}
 		catch (Throwable e) {
 			if (fiFile == null) {

--- a/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetFeatureInfo.java
+++ b/deegree-core/deegree-core-protocol/deegree-protocol-wms/src/main/java/org/deegree/protocol/wms/ops/GetFeatureInfo.java
@@ -105,6 +105,8 @@ public class GetFeatureInfo extends RequestBase {
 
 	private double scale;
 
+	private String gfiTemplate;
+
 	/**
 	 * @param map
 	 * @param version
@@ -332,6 +334,7 @@ public class GetFeatureInfo extends RequestBase {
 
 		returnGeometries = map.get("GEOMETRIES") != null && map.get("GEOMETRIES").equalsIgnoreCase("true");
 		infoCrs = map.get("INFO_CRS") != null ? CRSManager.getCRSRef(map.get("INFO_CRS")) : null;
+		gfiTemplate = map.get("GFI_TEMPLATE");
 
 		return vals;
 	}
@@ -440,6 +443,14 @@ public class GetFeatureInfo extends RequestBase {
 	 */
 	public int getY() {
 		return y;
+	}
+
+	/**
+	 * @return the gfi template (vendor specific parameter GFI_TEMPLATE), may be
+	 * <code>null</code>
+	 */
+	public String getGfiTemplate() {
+		return gfiTemplate;
 	}
 
 	/**

--- a/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
+++ b/deegree-services/deegree-services-wms/src/main/java/org/deegree/services/wms/controller/WMSController.java
@@ -957,7 +957,7 @@ public class WMSController extends AbstractOWS {
 
 		try {
 			FeatureInfoParams params = new FeatureInfoParams(nsBindings, col, format, geometries, loc, type, crs,
-					infoCrs);
+					infoCrs, fi.getGfiTemplate());
 			featureInfoManager.serializeFeatureInfo(params, new StandardFeatureInfoContext(response));
 			response.flushBuffer();
 		}


### PR DESCRIPTION
This PR adds an new vendor specific parameter `GFI_TEMPLATE` and adds a GfiTemplateProvider which can be implemented to allow specific access to gfi files, e.g. from S3 .